### PR TITLE
docs: rebrand examples and docs to rivet

### DIFF
--- a/examples/ai-agent/README.md
+++ b/examples/ai-agent/README.md
@@ -1,10 +1,10 @@
-# AI Agent Chat for RivetKit
+# AI Agent Chat for Rivet
 
-Example project demonstrating AI agent integration with [RivetKit](https://rivetkit.org).
+Example project demonstrating AI agent integration with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -16,8 +16,8 @@ Example project demonstrating AI agent integration with [RivetKit](https://rivet
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/ai-agent
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/ai-agent
 npm install
 ```
 

--- a/examples/background-jobs/README.md
+++ b/examples/background-jobs/README.md
@@ -1,10 +1,10 @@
-# Daily Email Campaign for RivetKit
+# Daily Email Campaign for Rivet
 
-Example project demonstrating scheduled background emails with [RivetKit](https://rivetkit.org).
+Example project demonstrating scheduled background emails with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -16,8 +16,8 @@ Example project demonstrating scheduled background emails with [RivetKit](https:
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/background-jobs
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/background-jobs
 npm install
 ```
 

--- a/examples/better-auth-external-db/README.md
+++ b/examples/better-auth-external-db/README.md
@@ -1,10 +1,10 @@
-# Better Auth with External Database for RivetKit
+# Better Auth with External Database for Rivet
 
-Example project demonstrating authentication integration with [RivetKit](https://rivetkit.org) using Better Auth and SQLite database.
+Example project demonstrating authentication integration with [Rivet](https://www.rivet.dev/) using Better Auth and SQLite database.
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -16,8 +16,8 @@ Example project demonstrating authentication integration with [RivetKit](https:/
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/better-auth-external-db
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/better-auth-external-db
 npm install
 ```
 

--- a/examples/bots/README.md
+++ b/examples/bots/README.md
@@ -1,10 +1,10 @@
-# Discord Bot Gateway for RivetKit
+# Discord Bot Gateway for Rivet
 
-Example project demonstrating Discord Gateway lifecycle management with [RivetKit](https://rivetkit.org).
+Example project demonstrating Discord Gateway lifecycle management with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -16,8 +16,8 @@ Example project demonstrating Discord Gateway lifecycle management with [RivetKi
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/bots
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/bots
 npm install
 ```
 

--- a/examples/chat-room/README.md
+++ b/examples/chat-room/README.md
@@ -1,10 +1,10 @@
-# Chat Room for RivetKit
+# Chat Room for Rivet
 
-Example project demonstrating real-time messaging and actor state management with [RivetKit](https://rivetkit.org).
+Example project demonstrating real-time messaging and actor state management with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating real-time messaging and actor state management wit
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/chat-room
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/chat-room
 npm install
 ```
 
@@ -44,7 +44,7 @@ npm run dev:cli
 - Real-time messaging with automatic persistence
 - Multiple chat rooms support
 - Both web and CLI interfaces
-- Event-driven architecture with RivetKit actors
+- Event-driven architecture with Rivet actors
 - TypeScript support throughout
 
 ## License

--- a/examples/cloudflare-workers-hono/README.md
+++ b/examples/cloudflare-workers-hono/README.md
@@ -1,10 +1,10 @@
-# Cloudflare Workers with Hono for RivetKit
+# Cloudflare Workers with Hono for Rivet
 
-Example project demonstrating Cloudflare Workers deployment with Hono router using [RivetKit](https://rivetkit.org).
+Example project demonstrating Cloudflare Workers deployment with Hono router using [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -17,8 +17,8 @@ Example project demonstrating Cloudflare Workers deployment with Hono router usi
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/cloudflare-workers-hono
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/cloudflare-workers-hono
 npm install
 ```
 

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -1,10 +1,10 @@
-# Cloudflare Workers for RivetKit
+# Cloudflare Workers for Rivet
 
-Example project demonstrating Cloudflare Workers deployment with [RivetKit](https://rivetkit.org).
+Example project demonstrating Cloudflare Workers deployment with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -17,8 +17,8 @@ Example project demonstrating Cloudflare Workers deployment with [RivetKit](http
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/cloudflare-workers
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/cloudflare-workers
 npm install
 ```
 

--- a/examples/counter-serverless/README.md
+++ b/examples/counter-serverless/README.md
@@ -1,10 +1,10 @@
-# Counter (Serverless) for RivetKit
+# Counter (Serverless) for Rivet
 
-Example project demonstrating serverless actor deployment with automatic engine configuration using [RivetKit](https://rivetkit.org).
+Example project demonstrating serverless actor deployment with automatic engine configuration using [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -16,8 +16,8 @@ Example project demonstrating serverless actor deployment with automatic engine 
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/counter-serverless
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/counter-serverless
 npm install
 ```
 

--- a/examples/counter/README.md
+++ b/examples/counter/README.md
@@ -1,10 +1,10 @@
-# Counter for RivetKit
+# Counter for Rivet
 
-Example project demonstrating basic actor state management and RPC calls with [RivetKit](https://rivetkit.org).
+Example project demonstrating basic actor state management and RPC calls with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating basic actor state management and RPC calls with [R
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/counter
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/counter
 npm install
 ```
 

--- a/examples/crdt/README.md
+++ b/examples/crdt/README.md
@@ -1,10 +1,10 @@
-# CRDT Collaborative Editor for RivetKit
+# CRDT Collaborative Editor for Rivet
 
-Example project demonstrating real-time collaborative editing using Conflict-free Replicated Data Types (CRDTs) with [RivetKit](https://rivetkit.org).
+Example project demonstrating real-time collaborative editing using Conflict-free Replicated Data Types (CRDTs) with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating real-time collaborative editing using Conflict-fre
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/crdt
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/crdt
 npm install
 ```
 
@@ -41,8 +41,8 @@ Open your browser to `http://localhost:3000`
 This example demonstrates how to build a collaborative editor using:
 
 1. **Yjs**: A high-performance CRDT implementation for building collaborative applications
-2. **RivetKit Actors**: Manage document state and synchronize changes between clients
-3. **Real-time Updates**: Use RivetKit's event system for instant synchronization
+2. **Rivet Actors**: Manage document state and synchronize changes between clients
+3. **Real-time Updates**: Use Rivet's event system for instant synchronization
 4. **Conflict-free Merging**: Yjs automatically handles concurrent edits without conflicts
 
 ## Usage
@@ -55,7 +55,7 @@ This example demonstrates how to build a collaborative editor using:
 
 ## Architecture
 
-- **Backend**: RivetKit actor that manages Yjs document state and broadcasts updates
+- **Backend**: Rivet actor that manages Yjs document state and broadcasts updates
 - **Frontend**: React application with Yjs integration for local document management
 - **Synchronization**: Binary diffs are sent between clients for efficient updates
 

--- a/examples/cursors-raw-websocket/README.md
+++ b/examples/cursors-raw-websocket/README.md
@@ -1,10 +1,10 @@
-# Real-time Collaborative Cursors for RivetKit
+# Real-time Collaborative Cursors for Rivet
 
-Example project demonstrating real-time cursor tracking and collaborative canvas with [RivetKit](https://rivetkit.org).
+Example project demonstrating real-time cursor tracking and collaborative canvas with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating real-time cursor tracking and collaborative canvas
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/cursors
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/cursors
 npm install
 ```
 
@@ -35,7 +35,7 @@ Open your browser to `http://localhost:5173`. Open multiple tabs or windows to s
 - Click-to-place text on canvas
 - Multiple room support for different collaborative spaces
 - Persistent text labels across sessions
-- Event-driven architecture with RivetKit actors
+- Event-driven architecture with Rivet actors
 - TypeScript support throughout
 
 ## License

--- a/examples/cursors/README.md
+++ b/examples/cursors/README.md
@@ -1,10 +1,10 @@
-# Real-time Collaborative Cursors for RivetKit
+# Real-time Collaborative Cursors for Rivet
 
-Example project demonstrating real-time cursor tracking and collaborative canvas with [RivetKit](https://rivetkit.org).
+Example project demonstrating real-time cursor tracking and collaborative canvas with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating real-time cursor tracking and collaborative canvas
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/cursors
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/cursors
 npm install
 ```
 
@@ -35,7 +35,7 @@ Open your browser to `http://localhost:5173`. Open multiple tabs or windows to s
 - Click-to-place text on canvas
 - Multiple room support for different collaborative spaces
 - Persistent text labels across sessions
-- Event-driven architecture with RivetKit actors
+- Event-driven architecture with Rivet actors
 - TypeScript support throughout
 
 ## License

--- a/examples/database/README.md
+++ b/examples/database/README.md
@@ -1,10 +1,10 @@
-# Database Notes for RivetKit
+# Database Notes for Rivet
 
-Example project demonstrating persistent data storage and real-time updates with [RivetKit](https://rivetkit.org).
+Example project demonstrating persistent data storage and real-time updates with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating persistent data storage and real-time updates with
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/database
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/database
 npm install
 ```
 
@@ -42,7 +42,7 @@ Open your browser to `http://localhost:3000`
 
 This example demonstrates:
 
-1. **Actor State Management**: Using RivetKit actors to manage persistent application state
+1. **Actor State Management**: Using Rivet actors to manage persistent application state
 2. **Authentication**: Basic token-based authentication for user identification
 3. **Real-time Events**: Broadcasting changes to all connected clients using actor events
 4. **State Persistence**: Actor state is automatically persisted between sessions
@@ -50,8 +50,8 @@ This example demonstrates:
 
 ## Architecture
 
-- **Backend**: RivetKit actor that manages note storage and user authentication
-- **Frontend**: React application with real-time updates via RivetKit hooks
+- **Backend**: Rivet actor that manages note storage and user authentication
+- **Frontend**: React application with real-time updates via Rivet hooks
 - **State Management**: Each user gets their own actor instance for data isolation
 - **Authentication**: Mock token-based auth (replace with real auth in production)
 

--- a/examples/deno/README.md
+++ b/examples/deno/README.md
@@ -1,10 +1,10 @@
-# Deno Example for RivetKit
+# Deno Example for Rivet
 
-Example project demonstrating basic actor state management and RPC calls with [RivetKit](https://rivetkit.org) using Deno runtime.
+Example project demonstrating basic actor state management and RPC calls with [Rivet](https://www.rivet.dev/) using Deno runtime.
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating basic actor state management and RPC calls with [R
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/deno
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/deno
 pnpm install
 ```
 

--- a/examples/drizzle/README.md
+++ b/examples/drizzle/README.md
@@ -1,10 +1,10 @@
-# Hono Integration for RivetKit
+# Hono Integration for Rivet
 
-Example project demonstrating Hono web framework integration with [RivetKit](https://rivetkit.org).
+Example project demonstrating Hono web framework integration with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating Hono web framework integration with [RivetKit](htt
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/hono
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/hono
 npm install
 ```
 
@@ -26,7 +26,7 @@ npm install
 npm run dev
 ```
 
-Open your browser to http://localhost:3000 to see the Hono server with RivetKit integration.
+Open your browser to http://localhost:3000 to see the Hono server with Rivet integration.
 
 ## License
 

--- a/examples/elysia/README.md
+++ b/examples/elysia/README.md
@@ -1,10 +1,10 @@
-# Elysia Integration for RivetKit
+# Elysia Integration for Rivet
 
-Example project demonstrating Elysia web framework integration with [RivetKit](https://rivetkit.org).
+Example project demonstrating Elysia web framework integration with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating Elysia web framework integration with [RivetKit](h
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/elysia
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/elysia
 npm install
 ```
 
@@ -26,7 +26,7 @@ npm install
 npm run dev
 ```
 
-Open your browser to http://localhost:3000 to see the Elysia server with RivetKit integration.
+Open your browser to http://localhost:3000 to see the Elysia server with Rivet integration.
 
 ## License
 

--- a/examples/express/README.md
+++ b/examples/express/README.md
@@ -1,10 +1,10 @@
-# Express Integration for RivetKit
+# Express Integration for Rivet
 
-Example project demonstrating Express web framework integration with [RivetKit](https://rivetkit.org).
+Example project demonstrating Express web framework integration with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating Express web framework integration with [RivetKit](
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/express
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/express
 npm install
 ```
 
@@ -26,7 +26,7 @@ npm install
 npm run dev
 ```
 
-Open your browser to http://localhost:3000 to see the Express server with RivetKit integration.
+Open your browser to http://localhost:3000 to see the Express server with Rivet integration.
 
 ## License
 

--- a/examples/freestyle/README.md
+++ b/examples/freestyle/README.md
@@ -1,10 +1,10 @@
-# Freestyle Deployment for RivetKit
+# Freestyle Deployment for Rivet
 
-Example project demonstrating serverless deployment of RivetKit actors to [Freestyle](https://freestyle.sh) with [RivetKit](https://rivetkit.org).
+Example project demonstrating serverless deployment of Rivet actors to [Freestyle](https://freestyle.sh) with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 
 ## What is this?
@@ -23,8 +23,8 @@ Freestyle is unique from other providers since it is built to deploy untrusted A
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/freestyle
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/freestyle
 pnpm install
 ```
 

--- a/examples/game/README.md
+++ b/examples/game/README.md
@@ -1,10 +1,10 @@
-# Multiplayer Game for RivetKit
+# Multiplayer Game for Rivet
 
-Example project demonstrating real-time multiplayer game mechanics with [RivetKit](https://rivetkit.org).
+Example project demonstrating real-time multiplayer game mechanics with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating real-time multiplayer game mechanics with [RivetKi
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/game
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/game
 npm install
 ```
 
@@ -50,7 +50,7 @@ This multiplayer game demonstrates:
 
 ## Architecture
 
-- **Backend**: RivetKit actor managing game state and player positions
+- **Backend**: Rivet actor managing game state and player positions
 - **Frontend**: React canvas-based game with real-time input handling
 - **State Management**: Server-authoritative with client-side prediction
 - **Networking**: WebSocket-based real-time communication

--- a/examples/hono-bun/README.md
+++ b/examples/hono-bun/README.md
@@ -1,10 +1,10 @@
-# Hono + Bun Integration for RivetKit
+# Hono + Bun Integration for Rivet
 
-Example project demonstrating Hono web framework with Bun runtime and React frontend integration with [RivetKit](https://rivetkit.org).
+Example project demonstrating Hono web framework with Bun runtime and React frontend integration with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating Hono web framework with Bun runtime and React fron
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/hono-bun
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/hono-bun
 npm install
 ```
 

--- a/examples/hono-react/README.md
+++ b/examples/hono-react/README.md
@@ -1,10 +1,10 @@
-# Hono React Integration for RivetKit
+# Hono React Integration for Rivet
 
-Example project demonstrating full-stack Hono backend with React frontend integration with [RivetKit](https://rivetkit.org).
+Example project demonstrating full-stack Hono backend with React frontend integration with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating full-stack Hono backend with React frontend integr
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/hono-react
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/hono-react
 npm install
 ```
 

--- a/examples/hono/README.md
+++ b/examples/hono/README.md
@@ -1,10 +1,10 @@
-# Hono Integration for RivetKit
+# Hono Integration for Rivet
 
-Example project demonstrating Hono web framework integration with [RivetKit](https://rivetkit.org).
+Example project demonstrating Hono web framework integration with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating Hono web framework integration with [RivetKit](htt
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/hono
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/hono
 npm install
 ```
 
@@ -26,7 +26,7 @@ npm install
 npm run dev
 ```
 
-Open your browser to http://localhost:3000 to see the Hono server with RivetKit integration.
+Open your browser to http://localhost:3000 to see the Hono server with Rivet integration.
 
 ## License
 

--- a/examples/kitchen-sink/README.md
+++ b/examples/kitchen-sink/README.md
@@ -1,23 +1,23 @@
-# Kitchen Sink Example for RivetKit
+# Kitchen Sink Example for Rivet
 
-Example project demonstrating all RivetKit features with [RivetKit](https://rivetkit.org).
+Example project demonstrating all Rivet features with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
 ### Prerequisites
 
 - Node.js 18+ or Bun
-- RivetKit development environment
+- Rivet development environment
 
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/kitchen-sink
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/kitchen-sink
 npm install
 ```
 

--- a/examples/rate/README.md
+++ b/examples/rate/README.md
@@ -1,10 +1,10 @@
-# Rate Limiter for RivetKit
+# Rate Limiter for Rivet
 
-Example project demonstrating API rate limiting with [RivetKit](https://rivetkit.org).
+Example project demonstrating API rate limiting with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating API rate limiting with [RivetKit](https://rivetkit
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/rate
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/rate
 npm install
 ```
 
@@ -49,7 +49,7 @@ This rate limiter demonstrates:
 
 ## Architecture
 
-- **Backend**: RivetKit actor that maintains rate limit state per user
+- **Backend**: Rivet actor that maintains rate limit state per user
 - **Frontend**: React application with real-time rate limit status
 - **State Management**: Persistent rate limit counters with automatic window resets
 - **User Isolation**: Each user/API client gets independent rate limiting

--- a/examples/raw-fetch-handler/README.md
+++ b/examples/raw-fetch-handler/README.md
@@ -1,10 +1,10 @@
-# Raw Fetch Handler Example for RivetKit
+# Raw Fetch Handler Example for Rivet
 
-Example project demonstrating raw HTTP fetch handling with Hono integration in [RivetKit](https://rivetkit.org).
+Example project demonstrating raw HTTP fetch handling with Hono integration in [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Overview
 
@@ -13,7 +13,7 @@ This example demonstrates:
 - Creating named counter actors that maintain independent state
 - Making fetch requests to actors through the frontend client
 - Forwarding requests from custom Hono endpoints to actor fetch handlers
-- Building a React frontend that interacts with RivetKit actors
+- Building a React frontend that interacts with Rivet actors
 - Testing actors with fetch handlers
 
 ## Project Structure
@@ -21,7 +21,7 @@ This example demonstrates:
 ```
 raw-fetch-handler/
 ├── src/
-│   ├── backend/     # RivetKit server with counter actors
+│   ├── backend/     # Rivet server with counter actors
 │   └── frontend/    # React app demonstrating client interactions
 └── tests/           # Vitest test suite
 ```
@@ -35,8 +35,8 @@ raw-fetch-handler/
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/raw-fetch-handler
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/raw-fetch-handler
 pnpm install
 ```
 
@@ -88,7 +88,7 @@ A React app demonstrating:
 1. The backend defines a counter actor with a Hono router
 2. Each counter is identified by a unique name
 3. The frontend can interact with counters in two ways:
-   - Direct actor fetch calls using the RivetKit client
+   - Direct actor fetch calls using the Rivet client
    - HTTP requests through the forward endpoint
 4. Multiple counters maintain independent state
 

--- a/examples/raw-websocket-handler-proxy/README.md
+++ b/examples/raw-websocket-handler-proxy/README.md
@@ -1,10 +1,10 @@
-# Raw WebSocket Handler Proxy for RivetKit
+# Raw WebSocket Handler Proxy for Rivet
 
-Example project demonstrating raw WebSocket handling with [RivetKit](https://rivetkit.org).
+Example project demonstrating raw WebSocket handling with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -16,8 +16,8 @@ Example project demonstrating raw WebSocket handling with [RivetKit](https://riv
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/raw-websocket-handler-proxy
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/raw-websocket-handler-proxy
 npm install
 ```
 

--- a/examples/raw-websocket-handler/README.md
+++ b/examples/raw-websocket-handler/README.md
@@ -1,10 +1,10 @@
-# Raw WebSocket Handler Proxy for RivetKit
+# Raw WebSocket Handler Proxy for Rivet
 
-Example project demonstrating raw WebSocket handling with [RivetKit](https://rivetkit.org).
+Example project demonstrating raw WebSocket handling with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -16,8 +16,8 @@ Example project demonstrating raw WebSocket handling with [RivetKit](https://riv
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/raw-websocket-handler-proxy
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/raw-websocket-handler-proxy
 npm install
 ```
 

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -1,10 +1,10 @@
-# Hono React Integration for RivetKit
+# Hono React Integration for Rivet
 
-Example project demonstrating full-stack Hono backend with React frontend integration with [RivetKit](https://rivetkit.org).
+Example project demonstrating full-stack Hono backend with React frontend integration with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating full-stack Hono backend with React frontend integr
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/hono-react
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/hono-react
 npm install
 ```
 

--- a/examples/starter/README.md
+++ b/examples/starter/README.md
@@ -1,10 +1,10 @@
-# Rivet Platform for RivetKit
+# Rivet Platform for Rivet
 
-Example project demonstrating Rivet cloud platform deployment with [RivetKit](https://rivetkit.org).
+Example project demonstrating Rivet cloud platform deployment with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -17,8 +17,8 @@ Example project demonstrating Rivet cloud platform deployment with [RivetKit](ht
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/rivet
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/rivet
 npm install
 ```
 
@@ -39,7 +39,7 @@ export RIVET_ENVIRONMENT=your_environment
 npm run dev
 ```
 
-This will start the RivetKit server locally at http://localhost:8080.
+This will start the Rivet server locally at http://localhost:8080.
 
 ### Testing the Client
 

--- a/examples/stream/README.md
+++ b/examples/stream/README.md
@@ -1,10 +1,10 @@
-# Stream Processor for RivetKit
+# Stream Processor for Rivet
 
-Example project demonstrating real-time top-K stream processing with [RivetKit](https://rivetkit.org).
+Example project demonstrating real-time top-K stream processing with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating real-time top-K stream processing with [RivetKit](
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/stream
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/stream
 npm install
 ```
 
@@ -49,7 +49,7 @@ This stream processor demonstrates:
 
 ## Architecture
 
-- **Backend**: RivetKit actor managing stream state and top-K algorithm
+- **Backend**: Rivet actor managing stream state and top-K algorithm
 - **Frontend**: React application with real-time stream visualization
 - **State Management**: Server-side state with client-side event subscriptions
 - **Algorithm**: Insertion-based top-K maintenance with O(k) complexity

--- a/examples/sync/README.md
+++ b/examples/sync/README.md
@@ -1,10 +1,10 @@
-# Sync Contacts for RivetKit
+# Sync Contacts for Rivet
 
-Example project demonstrating offline-first contact synchronization with conflict resolution using [RivetKit](https://rivetkit.org).
+Example project demonstrating offline-first contact synchronization with conflict resolution using [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating offline-first contact synchronization with conflic
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/sync
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/sync
 npm install
 ```
 
@@ -52,7 +52,7 @@ This contact sync system demonstrates:
 
 ## Architecture
 
-- **Backend**: RivetKit actor managing contact state and synchronization logic
+- **Backend**: Rivet actor managing contact state and synchronization logic
 - **Frontend**: React application with offline-first contact management
 - **Sync Strategy**: Timestamp-based conflict resolution with periodic reconciliation
 - **State Management**: Server-side persistence with client-side optimistic updates

--- a/examples/tenant/README.md
+++ b/examples/tenant/README.md
@@ -1,10 +1,10 @@
-# Tenant Dashboard for RivetKit
+# Tenant Dashboard for Rivet
 
-Example project demonstrating multi-tenant organization management with role-based access control using [RivetKit](https://rivetkit.org).
+Example project demonstrating multi-tenant organization management with role-based access control using [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating multi-tenant organization management with role-bas
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/tenant
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/tenant
 npm install
 ```
 
@@ -51,7 +51,7 @@ This tenant system demonstrates:
 
 ## Architecture
 
-- **Backend**: RivetKit actor with authentication and role-based permissions
+- **Backend**: Rivet actor with authentication and role-based permissions
 - **Frontend**: React application with conditional rendering based on user roles
 - **Authentication**: Token-based with connection state for user context
 - **Authorization**: Server-side permission checks for all sensitive operations

--- a/examples/trpc/README.md
+++ b/examples/trpc/README.md
@@ -1,10 +1,10 @@
-# tRPC Integration for RivetKit
+# tRPC Integration for Rivet
 
-Example project demonstrating tRPC integration with [RivetKit](https://rivetkit.org).
+Example project demonstrating tRPC integration with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating tRPC integration with [RivetKit](https://rivetkit.
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/trpc
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/trpc
 npm install
 ```
 

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -1,10 +1,10 @@
-# Order Fulfillment State Machine for RivetKit
+# Order Fulfillment State Machine for Rivet
 
-Example project demonstrating a basic order state machine with [RivetKit](https://rivetkit.org).
+Example project demonstrating a basic order state machine with [Rivet](https://www.rivet.dev/).
 
-[Learn More →](https://github.com/rivet-dev/rivetkit)
+[Learn More →](https://github.com/rivet-dev/rivet)
 
-[Discord](https://rivet.dev/discord) — [Documentation](https://rivetkit.org) — [Issues](https://github.com/rivet-dev/rivetkit/issues)
+[Discord](https://rivet.dev/discord) — [Documentation](https://www.rivet.dev/) — [Issues](https://github.com/rivet-dev/rivet/issues)
 
 ## Getting Started
 
@@ -15,8 +15,8 @@ Example project demonstrating a basic order state machine with [RivetKit](https:
 ### Installation
 
 ```sh
-git clone https://github.com/rivet-dev/rivetkit
-cd rivetkit/examples/workflows
+git clone https://github.com/rivet-dev/rivet
+cd rivet/examples/workflows
 npm install
 ```
 

--- a/website/src/content/docs/actors/fetch-and-websocket-handler.mdx
+++ b/website/src/content/docs/actors/fetch-and-websocket-handler.mdx
@@ -93,7 +93,7 @@ export const honoActor = actor({
 </Tab>
 </Tabs>
 
-Also see the [raw fetch handler example project](https://github.com/rivet-dev/rivetkit/tree/main/examples/raw-fetch-handler).
+Also see the [raw fetch handler example project](https://github.com/rivet-dev/rivet/tree/main/examples/raw-fetch-handler).
 
 <Tip>
 	`onFetch` can be used to expose Server-Sent Events from Rivet Actors.
@@ -123,7 +123,7 @@ export const websocketActor = actor({
 });
 ```
 
-Also see the [raw WebSocket handler with proxy example project](https://github.com/rivet-dev/rivetkit/tree/main/examples/raw-websocket-handler-proxy).
+Also see the [raw WebSocket handler with proxy example project](https://github.com/rivet-dev/rivet/tree/main/examples/raw-websocket-handler-proxy).
 
 <Note>
 	Connection lifecycle hooks like `onConnect` and `onDisconnect` do not get called when opening WebSockets for `onWebSocket`. This is because `onWebSocket` provides a low-level connection. Use `ws.addEventListener("open")` and `ws.addEventListener("close")` instead.

--- a/website/src/content/docs/actors/schedule.mdx
+++ b/website/src/content/docs/actors/schedule.mdx
@@ -5,7 +5,7 @@ Scheduling is used to trigger events in the future. The actor scheduler is like 
 <Warning>
 	Scheduling is supported on the Rivet Cloud, Cloudflare Workers, file system, and memory drivers.
 
-	Follow [this issue](https://github.com/rivet-dev/rivetkit/issues/1095) for Redis support.
+	Follow [this issue](https://github.com/rivet-dev/rivet/issues/1095) for Redis support.
 </Warning>
 
 ## Use Cases

--- a/website/src/content/docs/clients/next-js.mdx
+++ b/website/src/content/docs/clients/next-js.mdx
@@ -6,7 +6,7 @@ import { InstallPackage } from "@/components/docs/InstallPackage";
 The Rivet Next.js client allows you to connect to and interact with actors in Next.js applications.
 
 <CardGroup>
-<Card title="View Example on GitHub" icon="github" href="https://github.com/rivet-dev/rivetkit/tree/main/examples/next-js">
+<Card title="View Example on GitHub" icon="github" href="https://github.com/rivet-dev/rivet/tree/main/examples/next-js">
 	Check out the complete example
 </Card>
 <Card title="View the backend integration" icon="github" href="https://rivet.dev/docs/integrations/next-js/">

--- a/website/src/content/docs/clients/openapi.mdx
+++ b/website/src/content/docs/clients/openapi.mdx
@@ -1,6 +1,6 @@
 # OpenAPI
 
-The Rivet OpenAPI spec is available [here](https://github.com/rivet-dev/rivetkit/blob/main/clients/openapi/openapi.json)
+The Rivet OpenAPI spec is available [here](https://github.com/rivet-dev/rivet/blob/main/clients/openapi/openapi.json)
 
-<Note>The OpenAPI spec currently only exposes creating & managing actors. It does not expose how to communicate with actors. See the [HTTP client implementation](https://github.com/rivet-dev/rivetkit/blob/b5072fdac18d90a27bb6cd36e9ee73b00d36d42c/packages/rivetkit/src/client/actor-handle.ts) for reference.</Note>
+<Note>The OpenAPI spec currently only exposes creating & managing actors. It does not expose how to communicate with actors. See the [HTTP client implementation](https://github.com/rivet-dev/rivet/blob/b5072fdac18d90a27bb6cd36e9ee73b00d36d42c/packages/rivetkit/src/client/actor-handle.ts) for reference.</Note>
 

--- a/website/src/content/docs/clients/rust.mdx
+++ b/website/src/content/docs/clients/rust.mdx
@@ -79,4 +79,4 @@ The Rivet Rust client provides a way to connect to and interact with actors from
 
 ## API Reference
 
-For detailed API documentation, please refer to the [RivetKit Rust client implementation](https://github.com/rivet-dev/rivetkit/blob/main/clients/rust).
+For detailed API documentation, please refer to the [RivetKit Rust client implementation](https://github.com/rivet-dev/rivet/blob/main/clients/rust).

--- a/website/src/content/docs/deploy/cloudflare-workers.mdx
+++ b/website/src/content/docs/deploy/cloudflare-workers.mdx
@@ -5,7 +5,7 @@ import { faGithub } from "@rivet-gg/icons";
 Deploy your Cloudflare Workers + RivetKit app to [Cloudflare Workers](https://workers.cloudflare.com/).
 
 <CardGroup>
-<Card title="View Example on GitHub" href="https://github.com/rivet-dev/rivetkit/tree/main/examples/cloudflare-workers" target="_blank" icon={faGithub}>
+<Card title="View Example on GitHub" href="https://github.com/rivet-dev/rivet/tree/main/examples/cloudflare-workers" target="_blank" icon={faGithub}>
 Complete example Cloudflare Workers + RivetKit app.
 </Card>
 </CardGroup>
@@ -19,7 +19,7 @@ Complete example Cloudflare Workers + RivetKit app.
 - [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/) v3
 - Access to the [Rivet Cloud](https://dashboard.rivet.dev/) or a self-hosted [Rivet Engine](/docs/general/self-hosting)
 - A Cloudflare Worker app integrated with RivetKit
-  - See the [Cloudflare Workers quickstart](/docs/actors/quickstart/cloudflare-workers/) or [Cloudflare Workers example](https://github.com/rivet-dev/rivetkit/tree/main/examples/cloudflare-workers) to get started
+  - See the [Cloudflare Workers quickstart](/docs/actors/quickstart/cloudflare-workers/) or [Cloudflare Workers example](https://github.com/rivet-dev/rivet/tree/main/examples/cloudflare-workers) to get started
 
 </Step>
 <Step title="Verify RivetKit integration with Cloudflare Workers">
@@ -29,7 +29,7 @@ Your project should have the following files:
 - `src/registry.ts` (or similar actor registry file)
 - `wrangler.json` with proper Durable Objects and KV namespace configuration
 
-If your project is not integrated with RivetKit yet, follow the [Cloudflare Workers quickstart guide](/docs/actors/quickstart/cloudflare-workers/) or see the [Cloudflare Workers example](https://github.com/rivet-dev/rivetkit/tree/main/examples/cloudflare-workers).
+If your project is not integrated with RivetKit yet, follow the [Cloudflare Workers quickstart guide](/docs/actors/quickstart/cloudflare-workers/) or see the [Cloudflare Workers example](https://github.com/rivet-dev/rivet/tree/main/examples/cloudflare-workers).
 </Step>
 <Step title="Deploy to Cloudflare Workers">
 

--- a/website/src/content/docs/deploy/freestyle.mdx
+++ b/website/src/content/docs/deploy/freestyle.mdx
@@ -5,7 +5,7 @@ Deploy RivetKit app to [Freestyle.sh](https://freestyle.sh/), a cloud platform f
 Freestyle provides built-in security for running untrusted AI-generated code, making it ideal for AI agent applications. Using Rivet, it is easy to deploy your vibe-coded or user-provided RivetKit backends straight to Freestyle.
 
 <CardGroup>
-<Card title="Freestyle + Rivet" href="https://github.com/rivet-dev/rivetkit/tree/main/examples/freestyle" target="_blank">
+<Card title="Freestyle + Rivet" href="https://github.com/rivet-dev/rivet/tree/main/examples/freestyle" target="_blank">
 Complete example of deploying RivetKit app to Freestyle.sh.
 </Card>
 </CardGroup>

--- a/website/src/content/docs/deploy/railway.mdx
+++ b/website/src/content/docs/deploy/railway.mdx
@@ -13,7 +13,7 @@ If you're starting from scratch, go to the Connect tab on the Rivet dashboard an
 
 - [Railway account](https://railway.app)
 - Your RivetKit app
-  - If you don't have one, see the [Quickstart](/docs/actors/quickstart) page or our [Examples](https://github.com/rivet-dev/rivetkit/tree/main/examples)
+  - If you don't have one, see the [Quickstart](/docs/actors/quickstart) page or our [Examples](https://github.com/rivet-dev/rivet/tree/main/examples)
 - Access to the [Rivet Cloud](https://dashboard.rivet.dev/) or a [self-hosted Rivet Engine](/docs/general/self-hosting)
 
 </Step>

--- a/website/src/content/docs/deploy/vercel.mdx
+++ b/website/src/content/docs/deploy/vercel.mdx
@@ -6,7 +6,7 @@ import { faGithub } from "@rivet-gg/icons";
 Deploy your Next.js + RivetKit app to [Vercel](https://vercel.com/).
 
 <CardGroup>
-<Card title="View Example on GitHub" href="https://github.com/rivet-dev/rivetkit/tree/main/examples/next-js" target="_blank" icon={faGithub}>
+<Card title="View Example on GitHub" href="https://github.com/rivet-dev/rivet/tree/main/examples/next-js" target="_blank" icon={faGithub}>
 Complete example Next.js + RivetKit app.
 </Card>
 </CardGroup>
@@ -19,7 +19,7 @@ Complete example Next.js + RivetKit app.
 - [Vercel account](https://vercel.com/)
 - Access to the [Rivet Cloud](https://dashboard.rivet.dev/) or a self-hosted [Rivet Engine](/docs/general/self-hosting)
 - A Next.js app integrated with RivetKit
-  - See the [Next.js quickstart](/docs/actors/quickstart/next-js/) or [Next.js example](https://github.com/rivet-dev/rivetkit/tree/main/examples/next-js) to get started
+  - See the [Next.js quickstart](/docs/actors/quickstart/next-js/) or [Next.js example](https://github.com/rivet-dev/rivet/tree/main/examples/next-js) to get started
   - Your project should have the following files:
     - `src/app/api/rivet/[...all]/route.ts`
     - `src/rivet/registry.ts`

--- a/website/src/content/docs/drivers/build-your-own.mdx
+++ b/website/src/content/docs/drivers/build-your-own.mdx
@@ -10,8 +10,8 @@ Each driver implements common interfaces defined by RivetKit, including:
 Get started by looking at source code for the driver interfaces and existing drivers:
 
 - **Driver Interfaces**
-  - **ActorDriver*** [Source Code](https://github.com/rivet-dev/rivetkit/blob/main/packages/core/src/actor/driver.ts)
-  - **ManagerDriver*** [Source Code](https://github.com/rivet-dev/rivetkit/blob/main/packages/core/src/manager/driver.ts)
-- **Driver Implementations**: [Source Code](https://github.com/rivet-dev/rivetkit/tree/main/packages/core/src/drivers)
+  - **ActorDriver*** [Source Code](https://github.com/rivet-dev/rivet/blob/main/packages/core/src/actor/driver.ts)
+  - **ManagerDriver*** [Source Code](https://github.com/rivet-dev/rivet/blob/main/packages/core/src/manager/driver.ts)
+- **Driver Implementations**: [Source Code](https://github.com/rivet-dev/rivet/tree/main/packages/core/src/drivers)
 
 

--- a/website/src/content/docs/drivers/file-system.mdx
+++ b/website/src/content/docs/drivers/file-system.mdx
@@ -85,7 +85,7 @@ If running on a single node, make sure to back up your actors folder regularly. 
 ## Examples
 
 <CardGroup>
-<Card title="Basic File System" href="https://github.com/rivet-dev/rivetkit/tree/main/examples/basic" target="_blank">
+<Card title="Basic File System" href="https://github.com/rivet-dev/rivet/tree/main/examples/basic" target="_blank">
 Basic File System driver setup and configuration example.
 </Card>
 </CardGroup>

--- a/website/src/content/docs/integrations/better-auth.mdx
+++ b/website/src/content/docs/integrations/better-auth.mdx
@@ -5,7 +5,7 @@ Integrate Rivet with Better Auth for authentication
 Better Auth provides a comprehensive authentication solution that integrates seamlessly with Rivet Actors using the `onAuth` hook.
 
 <CardGroup>
-<Card title="View Example on GitHub" icon="github" href="https://github.com/rivet-dev/rivetkit/tree/main/examples/better-auth-external-db">
+<Card title="View Example on GitHub" icon="github" href="https://github.com/rivet-dev/rivet/tree/main/examples/better-auth-external-db">
 	Check out the complete example
 </Card>
 </CardGroup>

--- a/website/src/content/docs/integrations/elysia.mdx
+++ b/website/src/content/docs/integrations/elysia.mdx
@@ -5,7 +5,7 @@ Integrate Rivet with Elysia for fast TypeScript web applications
 Elysia is a fast and type-safe web framework for Bun. Rivet integrates seamlessly with Elysia using the `.mount()` method.
 
 <CardGroup>
-<Card title="View Example on GitHub" icon="github" href="https://github.com/rivet-dev/rivetkit/tree/main/examples/elysia">
+<Card title="View Example on GitHub" icon="github" href="https://github.com/rivet-dev/rivet/tree/main/examples/elysia">
 	Check out the complete example
 </Card>
 </CardGroup>

--- a/website/src/content/docs/integrations/express.mdx
+++ b/website/src/content/docs/integrations/express.mdx
@@ -5,7 +5,7 @@ Integrate Rivet with Express.js for Node.js web applications
 Express.js is a popular Node.js web framework. Rivet integrates seamlessly with Express using middleware mounting.
 
 <CardGroup>
-<Card title="View Example on GitHub" icon="github" href="https://github.com/rivet-dev/rivetkit/tree/main/examples/express">
+<Card title="View Example on GitHub" icon="github" href="https://github.com/rivet-dev/rivet/tree/main/examples/express">
 	Check out the complete example
 </Card>
 </CardGroup>

--- a/website/src/content/docs/integrations/hono.mdx
+++ b/website/src/content/docs/integrations/hono.mdx
@@ -5,7 +5,7 @@ Integrate Rivet with Hono for ultra-fast web applications
 Hono is an ultra-fast web framework that works on any runtime. Rivet integrates seamlessly with Hono through the `serve()` method.
 
 <CardGroup>
-<Card title="View Example on GitHub" icon="github" href="https://github.com/rivet-dev/rivetkit/tree/main/examples/hono">
+<Card title="View Example on GitHub" icon="github" href="https://github.com/rivet-dev/rivet/tree/main/examples/hono">
 	Check out the complete example
 </Card>
 </CardGroup>

--- a/website/src/content/docs/integrations/next-js.mdx
+++ b/website/src/content/docs/integrations/next-js.mdx
@@ -6,7 +6,7 @@ import { InstallPackage } from "@/components/docs/InstallPackage";
 Next.js is a powerful React framework that allows you to build server-rendered applications with ease. The Rivet Next.js client enables you to connect to and interact with actors in your Next.js applications.
 
 <CardGroup>
-<Card title="View Example on GitHub" icon="github" href="https://github.com/rivet-dev/rivetkit/tree/main/examples/next-js">
+<Card title="View Example on GitHub" icon="github" href="https://github.com/rivet-dev/rivet/tree/main/examples/next-js">
 	Check out the complete example
 </Card>
 <Card title="View client integration" icon="github" href="https://rivet.dev/docs/clients/next-js/">

--- a/website/src/content/docs/integrations/trpc.mdx
+++ b/website/src/content/docs/integrations/trpc.mdx
@@ -5,7 +5,7 @@ Integrate Rivet with tRPC for end-to-end type-safe APIs
 tRPC provides end-to-end type safety for your APIs. Rivet integrates seamlessly with tRPC, allowing you to create type-safe procedures that call Rivet Actors.
 
 <CardGroup>
-<Card title="View Example on GitHub" icon="github" href="https://github.com/rivet-dev/rivetkit/tree/main/examples/trpc">
+<Card title="View Example on GitHub" icon="github" href="https://github.com/rivet-dev/rivet/tree/main/examples/trpc">
 	Check out the complete example
 </Card>
 </CardGroup>

--- a/website/src/content/docs/use-cases/ai-agent.mdx
+++ b/website/src/content/docs/use-cases/ai-agent.mdx
@@ -64,5 +64,5 @@ c.log("Tool executed", { tool: toolName, duration: ms, result });
 ## Full Example Projects
 
 <CardGroup>
-<Card href="https://github.com/rivet-dev/rivetkit/tree/main/examples/ai-agent" title="AI Agent Starter" />
+<Card href="https://github.com/rivet-dev/rivet/tree/main/examples/ai-agent" title="AI Agent Starter" />
 </CardGroup>

--- a/website/src/content/docs/use-cases/background-jobs.mdx
+++ b/website/src/content/docs/use-cases/background-jobs.mdx
@@ -73,5 +73,5 @@ const jobProcessor = actor({
 ## Full Example Projects
 
 <CardGroup>
-<Card href="https://github.com/rivet-dev/rivetkit/tree/main/examples/background-jobs" title="Background Jobs Example" />
+<Card href="https://github.com/rivet-dev/rivet/tree/main/examples/background-jobs" title="Background Jobs Example" />
 </CardGroup>

--- a/website/src/content/docs/use-cases/bots.mdx
+++ b/website/src/content/docs/use-cases/bots.mdx
@@ -47,5 +47,5 @@ const discordBot = actor({
 ## Full Example Projects
 
 <CardGroup>
-<Card href="https://github.com/rivet-dev/rivetkit/tree/main/examples/bots" title="Bot Starter" />
+<Card href="https://github.com/rivet-dev/rivet/tree/main/examples/bots" title="Bot Starter" />
 </CardGroup>

--- a/website/src/content/docs/use-cases/crdt.mdx
+++ b/website/src/content/docs/use-cases/crdt.mdx
@@ -51,5 +51,5 @@ const collaborativeDoc = actor({
 ## Full Example Projects
 
 <CardGroup>
-<Card href="https://github.com/rivet-dev/rivetkit/tree/main/examples/crdt" title="Collaborative CRDT Docs" />
+<Card href="https://github.com/rivet-dev/rivet/tree/main/examples/crdt" title="Collaborative CRDT Docs" />
 </CardGroup>

--- a/website/src/content/docs/use-cases/database.mdx
+++ b/website/src/content/docs/use-cases/database.mdx
@@ -57,5 +57,5 @@ const userDatabase = actor({
 ## Full Example Projects
 
 <CardGroup>
-<Card href="https://github.com/rivet-dev/rivetkit/tree/main/examples/database" title="Per-User Database Example" />
+<Card href="https://github.com/rivet-dev/rivet/tree/main/examples/database" title="Per-User Database Example" />
 </CardGroup>

--- a/website/src/content/docs/use-cases/game.mdx
+++ b/website/src/content/docs/use-cases/game.mdx
@@ -61,5 +61,5 @@ const gameRoom = actor({
 ## Full Example Projects
 
 <CardGroup>
-<Card href="https://github.com/rivet-dev/rivetkit/tree/main/examples/game" title="Multiplayer Game Example" />
+<Card href="https://github.com/rivet-dev/rivet/tree/main/examples/game" title="Multiplayer Game Example" />
 </CardGroup>

--- a/website/src/content/docs/use-cases/rate.mdx
+++ b/website/src/content/docs/use-cases/rate.mdx
@@ -81,5 +81,5 @@ const rateLimiter = actor({
 ## Full Example Projects
 
 <CardGroup>
-<Card href="https://github.com/rivet-dev/rivetkit/tree/main/examples/rate" title="Rate Limiting Example" />
+<Card href="https://github.com/rivet-dev/rivet/tree/main/examples/rate" title="Rate Limiting Example" />
 </CardGroup>

--- a/website/src/content/docs/use-cases/sync.mdx
+++ b/website/src/content/docs/use-cases/sync.mdx
@@ -64,5 +64,5 @@ const userSync = actor({
 ## Full Example Projects
 
 <CardGroup>
-<Card href="https://github.com/rivet-dev/rivetkit/tree/main/examples/sync" title="Local-First Sync Example" />
+<Card href="https://github.com/rivet-dev/rivet/tree/main/examples/sync" title="Local-First Sync Example" />
 </CardGroup>

--- a/website/src/content/docs/use-cases/workflows.mdx
+++ b/website/src/content/docs/use-cases/workflows.mdx
@@ -61,5 +61,5 @@ const orderWorkflow = actor({
 ## Full Example Projects
 
 <CardGroup>
-<Card href="https://github.com/rivet-dev/rivetkit/tree/main/examples/workflows" title="Workflow Examples" />
+<Card href="https://github.com/rivet-dev/rivet/tree/main/examples/workflows" title="Workflow Examples" />
 </CardGroup>


### PR DESCRIPTION
- clean up the examples and docs so they stop pointing at the old rivetkit repo/site
- now every README and docs card sends folks to the live rivet repo and rivet.dev