### PR TITLE
refactor(rivetkit): add state manager for conn with symbol-based access

### DIFF
--- a/rivetkit-typescript/packages/cloudflare-workers/src/actor-driver.ts
+++ b/rivetkit-typescript/packages/cloudflare-workers/src/actor-driver.ts
@@ -6,10 +6,10 @@ import type {
 } from "rivetkit";
 import { lookupInRegistry } from "rivetkit";
 import type { Client } from "rivetkit/client";
-import {
-	type ActorDriver,
-	type AnyActorInstance,
-	type ManagerDriver,
+import type {
+	ActorDriver,
+	AnyActorInstance,
+	ManagerDriver,
 } from "rivetkit/driver-helpers";
 import { promiseWithResolvers } from "rivetkit/utils";
 import { KEYS } from "./actor-handler-do";
@@ -239,7 +239,6 @@ export class CloudflareActorsActorDriver implements ActorDriver {
 		// Persist data key
 		return Uint8Array.from([1]);
 	}
-
 }
 
 export function createCloudflareActorsActorDriverBuilder(

--- a/rivetkit-typescript/packages/rivetkit/src/actor/conn/state-manager.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/conn/state-manager.ts
@@ -1,0 +1,139 @@
+import onChange from "on-change";
+import { isCborSerializable } from "@/common/utils";
+import * as errors from "../errors";
+import type { PersistedConn } from "../instance/persisted";
+import { CONN_ACTOR_SYMBOL, CONN_STATE_ENABLED_SYMBOL, type Conn } from "./mod";
+
+/**
+ * Manages connection state persistence, proxying, and change tracking.
+ * Handles automatic state change detection for connection-specific state.
+ */
+export class StateManager<CP, CS> {
+	#conn: Conn<any, CP, CS, any, any, any>;
+
+	// State tracking
+	#persist!: PersistedConn<CP, CS>;
+	#persistRaw!: PersistedConn<CP, CS>;
+	#changed = false;
+
+	constructor(conn: Conn<any, CP, CS, any, any, any>) {
+		this.#conn = conn;
+	}
+
+	// MARK: - Public API
+
+	get persist(): PersistedConn<CP, CS> {
+		return this.#persist;
+	}
+
+	get persistRaw(): PersistedConn<CP, CS> {
+		return this.#persistRaw;
+	}
+
+	get changed(): boolean {
+		return this.#changed;
+	}
+
+	get stateEnabled(): boolean {
+		return this.#conn[CONN_ACTOR_SYMBOL].connStateEnabled;
+	}
+
+	get state(): CS {
+		this.#validateStateEnabled();
+		if (!this.#persist.state) throw new Error("state should exists");
+		return this.#persist.state;
+	}
+
+	set state(value: CS) {
+		this.#validateStateEnabled();
+		this.#persist.state = value;
+	}
+
+	get params(): CP {
+		return this.#persist.params;
+	}
+
+	// MARK: - Initialization
+
+	/**
+	 * Creates proxy for persist object that handles automatic state change detection.
+	 */
+	initPersistProxy(target: PersistedConn<CP, CS>) {
+		// Set raw persist object
+		this.#persistRaw = target;
+
+		// If this can't be proxied, return raw value
+		if (target === null || typeof target !== "object") {
+			this.#persist = target;
+			return;
+		}
+
+		// Listen for changes to the object
+		this.#persist = onChange(
+			target,
+			(
+				path: string,
+				value: any,
+				_previousValue: any,
+				_applyData: any,
+			) => {
+				this.#handleChange(path, value);
+			},
+			{ ignoreDetached: true },
+		);
+	}
+
+	// MARK: - Change Management
+
+	/**
+	 * Returns whether this connection has unsaved changes
+	 */
+	hasChanges(): boolean {
+		return this.#changed;
+	}
+
+	/**
+	 * Marks changes as saved
+	 */
+	markSaved() {
+		this.#changed = false;
+	}
+
+	// MARK: - Private Helpers
+
+	#validateStateEnabled() {
+		if (!this.stateEnabled) {
+			throw new errors.ConnStateNotEnabled();
+		}
+	}
+
+	#handleChange(path: string, value: any) {
+		// Validate CBOR serializability for state changes
+		if (path.startsWith("state")) {
+			let invalidPath = "";
+			if (
+				!isCborSerializable(
+					value,
+					(invalidPathPart: string) => {
+						invalidPath = invalidPathPart;
+					},
+					"",
+				)
+			) {
+				throw new errors.InvalidStateType({
+					path: path + (invalidPath ? `.${invalidPath}` : ""),
+				});
+			}
+		}
+
+		this.#changed = true;
+		this.#conn[CONN_ACTOR_SYMBOL].rLog.debug({
+			msg: "conn onChange triggered",
+			connId: this.#conn.id,
+			path,
+		});
+
+		// Notify actor that this connection has changed
+		this.#conn[CONN_ACTOR_SYMBOL].markConnChanged(this.#conn);
+	}
+}

--- a/rivetkit-typescript/packages/rivetkit/src/actor/instance/connection-manager.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/instance/connection-manager.ts
@@ -4,7 +4,10 @@ import type { OnConnectOptions } from "../config";
 import type { ConnDriver } from "../conn/driver";
 import {
 	CONN_DRIVER_SYMBOL,
+	CONN_MARK_SAVED_SYMBOL,
+	CONN_PERSIST_RAW_SYMBOL,
 	CONN_PERSIST_SYMBOL,
+	CONN_STATE_ENABLED_SYMBOL,
 	Conn,
 	type ConnId,
 } from "../conn/mod";
@@ -202,9 +205,9 @@ export class ConnectionManager<
 		for (const connId of this.#changedConnections) {
 			const conn = this.#connections.get(connId);
 			if (conn) {
-				const connData = cbor.encode(conn.persistRaw);
+				const connData = cbor.encode(conn[CONN_PERSIST_RAW_SYMBOL]);
 				entries.push([makeConnKey(connId), connData]);
-				conn.markSaved();
+				conn[CONN_MARK_SAVED_SYMBOL]();
 			}
 		}
 

--- a/rivetkit-typescript/packages/rivetkit/src/actor/instance/event-manager.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/instance/event-manager.ts
@@ -2,7 +2,11 @@ import * as cbor from "cbor-x";
 import type * as protocol from "@/schemas/client-protocol/mod";
 import { TO_CLIENT_VERSIONED } from "@/schemas/client-protocol/versioned";
 import { bufferToArrayBuffer } from "@/utils";
-import { CONN_PERSIST_SYMBOL, type Conn } from "../conn/mod";
+import {
+	CONN_PERSIST_SYMBOL,
+	CONN_SEND_MESSAGE_SYMBOL,
+	type Conn,
+} from "../conn/mod";
 import type { AnyDatabaseProvider } from "../database";
 import { CachedSerializer } from "../protocol/serde";
 import type { ActorInstance } from "./mod";
@@ -192,7 +196,7 @@ export class EventManager<S, CP, CS, V, I, DB extends AnyDatabaseProvider> {
 		let sentCount = 0;
 		for (const connection of subscribers) {
 			try {
-				connection.sendMessage(toClientSerializer);
+				connection[CONN_SEND_MESSAGE_SYMBOL](toClientSerializer);
 				sentCount++;
 			} catch (error) {
 				this.#actor.rLog.error({

--- a/rivetkit-typescript/packages/rivetkit/src/actor/protocol/old.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/protocol/old.ts
@@ -15,7 +15,7 @@ import {
 } from "@/schemas/client-protocol/versioned";
 import { deserializeWithEncoding } from "@/serde";
 import { assertUnreachable, bufferToArrayBuffer } from "../../utils";
-import type { Conn } from "../conn/mod";
+import { CONN_SEND_MESSAGE_SYMBOL, type Conn } from "../conn/mod";
 import { ActionContext } from "../contexts/action";
 import type { ActorInstance } from "../instance/mod";
 
@@ -160,7 +160,7 @@ export async function processMessage<
 			});
 
 			// Send the response back to the client
-			conn.sendMessage(
+			conn[CONN_SEND_MESSAGE_SYMBOL](
 				new CachedSerializer<protocol.ToClient>(
 					{
 						body: {
@@ -229,7 +229,7 @@ export async function processMessage<
 		});
 
 		// Build response
-		conn.sendMessage(
+		conn[CONN_SEND_MESSAGE_SYMBOL](
 			new CachedSerializer<protocol.ToClient>(
 				{
 					body: {


### PR DESCRIPTION
- Created StateManager class for connection state management
- Moved state proxying and change tracking to dedicated manager
- Changed conn methods to use symbols for internal access:
  - actor, stateEnabled, persistRaw (getters)
  - hasChanges(), markSaved(), sendMessage() (methods)
- Updated all references across codebase to use new symbols
- Maintains backward compatibility for public API (send, disconnect, etc)
- Consistent naming pattern with instance/mod.ts StateManager