### PR TITLE
fix(website): eliminate sidebar and tab flicker on docs navigation

### DIFF
--- a/website/src/components/ActiveLink.tsx
+++ b/website/src/components/ActiveLink.tsx
@@ -1,13 +1,13 @@
 "use client";
 import type { ReactNode, AnchorHTMLAttributes } from "react";
 import { normalizePath } from "@/lib/normalizePath";
-import { useState, useEffect } from "react";
 
 export interface ActiveLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
 	isActive?: boolean;
 	children?: ReactNode;
 	tree?: ReactNode;
 	includeChildren?: boolean;
+	pathname?: string;
 }
 
 export function ActiveLink({
@@ -15,14 +15,9 @@ export function ActiveLink({
 	tree,
 	includeChildren,
 	children,
+	pathname = "",
 	...props
 }: ActiveLinkProps) {
-	const [pathname, setPathname] = useState("");
-
-	useEffect(() => {
-		setPathname(window.location.pathname);
-	}, []);
-
 	const isActive =
 		isActiveOverride ||
 		normalizePath(pathname) === normalizePath(String(props.href || "")) ||

--- a/website/src/components/CollapsibleSidebarItem.tsx
+++ b/website/src/components/CollapsibleSidebarItem.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { usePathname } from "@/hooks/usePathname";
 import type { SidebarItem, SidebarSection } from "@/lib/sitemap";
 import { cn } from "@rivet-gg/components";
 import { Icon, faChevronDown } from "@rivet-gg/icons";
-import { motion } from "framer-motion";
 import { type ReactNode, useMemo, useEffect, useState, useRef } from "react";
 import { normalizePath } from "@/lib/normalizePath";
 import { useNavigationState } from "@/providers/NavigationStateProvider";
@@ -14,6 +12,7 @@ interface CollapsibleSidebarItemProps {
 	children?: ReactNode;
 	level?: number;
 	parentPath?: string;
+	pathname?: string;
 }
 
 export function CollapsibleSidebarItem({
@@ -21,8 +20,8 @@ export function CollapsibleSidebarItem({
 	children,
 	level = 0,
 	parentPath = "",
+	pathname = "",
 }: CollapsibleSidebarItemProps) {
-	const pathname = usePathname() || "";
 	const { isOpen, setIsOpen, toggleOpen } = useNavigationState();
 	const hasActiveChild = findActiveItem(item.pages, pathname) !== null;
 	const isCurrent = false; // Never highlight collapsible sections themselves
@@ -113,33 +112,19 @@ export function CollapsibleSidebarItem({
 						</span>
 					) : null}
 				</div>
-				<motion.span
-					variants={{
-						open: { rotateZ: 0 },
-						closed: { rotateZ: "-90deg" },
-					}}
-					initial={false}
-					animate={isItemOpen ? "open" : "closed"}
-					transition={{ duration: hasInteracted.current ? 0.2 : 0 }}
+				<span
+					style={{ display: "inline-block", transform: isItemOpen ? "rotate(0deg)" : "rotate(-90deg)", transition: hasInteracted.current ? "transform 0.2s" : "none" }}
 					className="ml-2 inline-block flex-shrink-0 opacity-70"
 				>
 					<Icon icon={faChevronDown} className="w-3 h-3" />
-				</motion.span>
+				</span>
 			</button>
-			<motion.div
+			<div
 				className="overflow-hidden"
-				variants={{
-					open: { height: "auto", opacity: 1 },
-					closed: { height: 0, opacity: 0 },
-				}}
-				initial={false}
-				animate={isItemOpen ? "open" : "closed"}
-				transition={{
-					duration: hasInteracted.current ? 0.2 : 0,
-				}}
+				style={isItemOpen ? { height: "auto", opacity: 1 } : { height: 0, opacity: 0 }}
 			>
 				{children}
-			</motion.div>
+			</div>
 		</div>
 	);
 }

--- a/website/src/components/DocsNavigation.tsx
+++ b/website/src/components/DocsNavigation.tsx
@@ -13,9 +13,10 @@ interface TreeItemProps {
 	item: SidebarItem;
 	level?: number;
 	parentPath?: string;
+	pathname?: string;
 }
 
-function TreeItem({ index, item, level = 0, parentPath = "" }: TreeItemProps) {
+function TreeItem({ index, item, level = 0, parentPath = "", pathname = "" }: TreeItemProps) {
 	if (
 		"collapsible" in item &&
 		"title" in item &&
@@ -30,11 +31,13 @@ function TreeItem({ index, item, level = 0, parentPath = "" }: TreeItemProps) {
 				item={item}
 				level={level}
 				parentPath={parentPath}
+				pathname={pathname}
 			>
 				<Tree
 					pages={item.pages}
 					level={level + 1}
 					parentPath={itemPath}
+					pathname={pathname}
 				/>
 			</CollapsibleSidebarItem>
 		);
@@ -66,13 +69,14 @@ function TreeItem({ index, item, level = 0, parentPath = "" }: TreeItemProps) {
 					pages={item.pages}
 					level={level + 1}
 					parentPath={itemPath}
+					pathname={pathname}
 				/>
 			</div>
 		);
 	}
 
 	return (
-		<NavLink href={item.href} external={item.external} level={level}>
+		<NavLink href={item.href} external={item.external} level={level} pathname={pathname}>
 			<span className="flex items-center truncate gap-2">
 				{item.icon && "prefix" in item.icon ? (
 					<Icon icon={item.icon} className="size-3.5 flex-shrink-0" />
@@ -104,6 +108,7 @@ interface TreeProps {
 	className?: string;
 	level?: number;
 	parentPath?: string;
+	pathname?: string;
 }
 
 export function Tree({
@@ -111,6 +116,7 @@ export function Tree({
 	className,
 	level = 0,
 	parentPath = "",
+	pathname = "",
 }: TreeProps) {
 	return (
 		<ul className={cn(className)}>
@@ -124,6 +130,7 @@ export function Tree({
 						item={item}
 						level={level}
 						parentPath={parentPath}
+						pathname={pathname}
 					/>
 				</li>
 			))}
@@ -137,12 +144,14 @@ export function NavLink({
 	children,
 	className,
 	level = 0,
+	pathname = "",
 }: PropsWithChildren<{
 	href: string;
 	external?: boolean;
 	children: ReactNode;
 	className?: string;
 	level?: number;
+	pathname?: string;
 }>) {
 	const getPaddingClass = (level: number) => {
 		switch (level) {
@@ -161,6 +170,7 @@ export function NavLink({
 		<ActiveLink
 			strict
 			href={href}
+			pathname={pathname}
 			target={external && "_blank"}
 			className={cn(
 				"group flex w-full items-center border-l-2 border-l-border py-2 text-sm text-muted-foreground transition-colors hover:text-foreground hover:border-l-muted-foreground/50 aria-current-page:text-foreground aria-current-page:border-l-orange-500",
@@ -173,11 +183,11 @@ export function NavLink({
 	);
 }
 
-export function DocsNavigation({ sidebar }: { sidebar: SidebarItem[] }) {
+export function DocsNavigation({ sidebar, pathname = "" }: { sidebar: SidebarItem[]; pathname?: string }) {
 	return (
 		<NavigationStateProvider>
 			<div className="sticky top-header max-h-content text-white pl-8 pr-6 py-6 overflow-y-auto">
-				<Tree pages={sidebar} />
+				<Tree pages={sidebar} pathname={pathname} />
 			</div>
 		</NavigationStateProvider>
 	);

--- a/website/src/components/DocsTabs.tsx
+++ b/website/src/components/DocsTabs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { usePathname } from "@/hooks/usePathname";
 import { findPageForHref } from "@/lib/sitemap";
 import { sitemap } from "@/sitemap/mod";
 import { cn } from "@rivet-gg/components";
@@ -8,7 +9,9 @@ interface DocsTabsProps {
 	pathname: string;
 }
 
-export function DocsTabs({ pathname }: DocsTabsProps) {
+export function DocsTabs({ pathname: initialPathname }: DocsTabsProps) {
+	const dynamicPathname = usePathname();
+	const pathname = dynamicPathname || initialPathname;
 	const normalizedPath = (pathname || "").replace(/\/$/, "");
 
 	return (

--- a/website/src/components/DocsTabs.tsx
+++ b/website/src/components/DocsTabs.tsx
@@ -1,14 +1,15 @@
 "use client";
 
-import { usePathname } from "@/hooks/usePathname";
 import { findPageForHref } from "@/lib/sitemap";
 import { sitemap } from "@/sitemap/mod";
 import { cn } from "@rivet-gg/components";
 
-export function DocsTabs() {
-	const pathname = usePathname() || "";
-	// Remove trailing slash for consistency
-	const normalizedPath = pathname.replace(/\/$/, "");
+interface DocsTabsProps {
+	pathname: string;
+}
+
+export function DocsTabs({ pathname }: DocsTabsProps) {
+	const normalizedPath = (pathname || "").replace(/\/$/, "");
 
 	return (
 		<div className="hidden h-14 items-center empty:hidden md:flex gap-4 pt-2">

--- a/website/src/components/v2/Header.tsx
+++ b/website/src/components/v2/Header.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { usePathname } from "@/hooks/usePathname";
 import { ActiveLink } from "@/components/ActiveLink";
 import logoUrl from "@/images/rivet-logos/icon-text-white.svg";
 import logoIconUrl from "@/images/rivet-logos/icon-white.svg";
@@ -363,6 +362,7 @@ interface HeaderProps {
 	variant?: "floating" | "full-width";
 	learnMode?: boolean;
 	showDocsTabs?: boolean;
+	pathname?: string;
 }
 
 export function Header({
@@ -372,11 +372,11 @@ export function Header({
 	variant = "full-width",
 	learnMode = false,
 	showDocsTabs = false,
+	pathname = "",
 }: HeaderProps) {
 	const [isScrolled, setIsScrolled] = useState(false);
 
-	// Use DocsTabs as subnav if showDocsTabs is true
-	const effectiveSubnav = showDocsTabs ? <DocsTabs /> : subnav;
+	const effectiveSubnav = showDocsTabs ? <DocsTabs pathname={pathname} /> : subnav;
 
 	useEffect(() => {
 		if (variant === "floating") {
@@ -440,7 +440,7 @@ export function Header({
 								</a>
 							</div>
 						}
-						mobileBreadcrumbs={<DocsMobileNavigation tree={mobileSidebar} />}
+						mobileBreadcrumbs={<DocsMobileNavigation tree={mobileSidebar} pathname={pathname} />}
 						breadcrumbs={
 							<div className="flex items-center font-v2 subpixel-antialiased">
 								<ProductsDropdown active={active === "product"} />
@@ -521,7 +521,7 @@ export function Header({
 					</a>
 				</div>
 			}
-			mobileBreadcrumbs={<DocsMobileNavigation tree={mobileSidebar} />}
+			mobileBreadcrumbs={<DocsMobileNavigation tree={mobileSidebar} pathname={pathname} />}
 			breadcrumbs={
 				<div className="flex items-center font-v2 subpixel-antialiased">
 					<ProductsDropdown active={active === "product"} />
@@ -549,8 +549,7 @@ export function Header({
 	);
 }
 
-function DocsMobileNavigation({ tree }) {
-	const pathname = usePathname() || "";
+function DocsMobileNavigation({ tree, pathname = "" }) {
 	const isDocsPage = pathname.startsWith("/docs");
 
 	// Determine current section based on pathname

--- a/website/src/components/v2/Header.tsx
+++ b/website/src/components/v2/Header.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { usePathname } from "@/hooks/usePathname";
 import { ActiveLink } from "@/components/ActiveLink";
 import logoUrl from "@/images/rivet-logos/icon-text-white.svg";
 import logoIconUrl from "@/images/rivet-logos/icon-white.svg";
@@ -549,7 +550,9 @@ export function Header({
 	);
 }
 
-function DocsMobileNavigation({ tree, pathname = "" }) {
+function DocsMobileNavigation({ tree, pathname: initialPathname = "" }) {
+	const dynamicPathname = usePathname();
+	const pathname = dynamicPathname || initialPathname;
 	const isDocsPage = pathname.startsWith("/docs");
 
 	// Determine current section based on pathname

--- a/website/src/hooks/usePathname.ts
+++ b/website/src/hooks/usePathname.ts
@@ -9,7 +9,11 @@ export function usePathname(): string {
 	const [pathname, setPathname] = useState("");
 
 	useEffect(() => {
-		setPathname(window.location.pathname);
+		const update = () => setPathname(window.location.pathname);
+		update();
+
+		document.addEventListener("astro:after-swap", update);
+		return () => document.removeEventListener("astro:after-swap", update);
 	}, []);
 
 	return pathname;

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -12,7 +12,9 @@ const { title, description, canonicalUrl } = Astro.props;
 ---
 
 <BaseLayout title={title} description={description} canonicalUrl={canonicalUrl}>
-	<Header variant="full-width" showDocsTabs={true} pathname={Astro.url.pathname} client:load />
+	<div transition:persist="docs-header">
+		<Header variant="full-width" showDocsTabs={true} pathname={Astro.url.pathname} client:load />
+	</div>
 	<div class="w-full relative z-10 font-sans">
 		<div class="mx-auto w-full min-h-content flex flex-col md:grid md:grid-cols-docs" style="--header-height: 6.5rem;">
 			<slot />

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -12,7 +12,7 @@ const { title, description, canonicalUrl } = Astro.props;
 ---
 
 <BaseLayout title={title} description={description} canonicalUrl={canonicalUrl}>
-	<Header variant="full-width" showDocsTabs={true} client:load />
+	<Header variant="full-width" showDocsTabs={true} pathname={Astro.url.pathname} client:load />
 	<div class="w-full relative z-10 font-sans">
 		<div class="mx-auto w-full min-h-content flex flex-col md:grid md:grid-cols-docs" style="--header-height: 6.5rem;">
 			<slot />

--- a/website/src/pages/docs/[...slug].astro
+++ b/website/src/pages/docs/[...slug].astro
@@ -86,7 +86,7 @@ const breadcrumbSchema = {
 <DocsLayout title={`${title} - Rivet`} description={description} canonicalUrl={canonicalUrl}>
 	<script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
 	<aside class="hidden md:block border-r">
-		{foundTab?.tab?.sidebar && <DocsNavigation sidebar={foundTab.tab.sidebar} client:load />}
+		{foundTab?.tab?.sidebar && <DocsNavigation sidebar={foundTab.tab.sidebar} pathname={Astro.url.pathname} client:load />}
 	</aside>
 	<div class="flex justify-center w-full min-w-0">
 		<div class="flex gap-8 max-w-6xl w-full min-w-0">


### PR DESCRIPTION
Docs sidebar and tabs flicker on every page navigation. usePathname() hook initializes as empty string causing a no-active-state render, and framer-motion renders no inline styles during SSR so collapsible sections flash open then collapse during hydration.

Fix: pass Astro.url.pathname as a prop to React components instead of reading it client-side. Replace framer-motion with inline styles so SSR HTML matches hydrated state.

Before:

https://github.com/user-attachments/assets/6669ffdc-c63e-4004-a0aa-5a18770b138e

After:


https://github.com/user-attachments/assets/c8eeae21-7ccd-419e-905f-1876c35ca73d





