### PR TITLE
docs: document serverless shutdown timeouts

### DIFF
--- a/website/src/content/docs/actors/limits.mdx
+++ b/website/src/content/docs/actors/limits.mdx
@@ -127,7 +127,7 @@ See [Actor Input](/docs/actors/input) for details.
 
 ### Serverless Shutdown
 
-These timeouts control how actors are shut down when a serverless request reaches its lifespan limit. See [Serverless Shutdown Sequence](/docs/general/runtime-modes#shutdown-sequence) for details.
+These timeouts control how actors are shut down when a serverless request reaches its lifespan limit. See [Shutdown Sequence](/docs/general/runtime-modes#shutdown-sequence) for details.
 
 | Name | Soft Limit | Hard Limit | Description |
 |------|------------|------------|-------------|

--- a/website/src/content/docs/actors/limits.mdx
+++ b/website/src/content/docs/actors/limits.mdx
@@ -125,6 +125,15 @@ See [Actor Input](/docs/actors/input) for details.
 | Sleep timeout | 30 seconds | — | Time of inactivity before actor hibernates. Configurable via `sleepTimeout`. |
 | State save interval | 10 seconds | — | Interval between automatic state saves. Configurable via `stateSaveInterval`. |
 
+### Serverless Shutdown
+
+These timeouts control how actors are shut down when a serverless request reaches its lifespan limit. See [Serverless Shutdown Sequence](/docs/general/runtime-modes#shutdown-sequence) for details.
+
+| Name | Soft Limit | Hard Limit | Description |
+|------|------------|------------|-------------|
+| Request lifespan | 900 seconds (15 min) | — | Total lifespan of a serverless request before drain begins. Configurable via `requestLifespan` in [`configureRunnerPool`](/docs/connect/registry-configuration). |
+| Serverless drain grace period | — | 10 seconds | Time reserved at the end of a request for actors to stop gracefully. Configurable via [engine config](/docs/self-hosting/configuration) (`pegboard.serverless_drain_grace_period`). |
+
 ### Actor Lifecycle
 
 | Name | Soft Limit | Hard Limit | Description |

--- a/website/src/content/docs/actors/versions.mdx
+++ b/website/src/content/docs/actors/versions.mdx
@@ -135,10 +135,6 @@ Several timeouts control how long each part of the shutdown process can take:
 
 The per-actor timeouts (`onSleepTimeout`, `runStopTimeout`, `waitUntilTimeout`) must fit within `actor_stop_threshold`. The runner's 120-second wait is a hard upper bound on the entire shutdown process.
 
-<Note>
-In [serverless mode](/docs/general/runtime-modes), shutdown is also triggered when the request reaches its lifespan limit. See [Serverless Shutdown Sequence](/docs/general/runtime-modes#shutdown-sequence) for details on how `requestLifespan` and `serverless_drain_grace_period` control this process.
-</Note>
-
 ## Related
 
 - [Runtime Modes](/docs/general/runtime-modes): Serverless vs runner deployment modes

--- a/website/src/content/docs/actors/versions.mdx
+++ b/website/src/content/docs/actors/versions.mdx
@@ -135,6 +135,10 @@ Several timeouts control how long each part of the shutdown process can take:
 
 The per-actor timeouts (`onSleepTimeout`, `runStopTimeout`, `waitUntilTimeout`) must fit within `actor_stop_threshold`. The runner's 120-second wait is a hard upper bound on the entire shutdown process.
 
+<Note>
+In [serverless mode](/docs/general/runtime-modes), shutdown is also triggered when the request reaches its lifespan limit. See [Serverless Shutdown Sequence](/docs/general/runtime-modes#shutdown-sequence) for details on how `requestLifespan` and `serverless_drain_grace_period` control this process.
+</Note>
+
 ## Related
 
 - [Runtime Modes](/docs/general/runtime-modes): Serverless vs runner deployment modes

--- a/website/src/content/docs/general/runtime-modes.mdx
+++ b/website/src/content/docs/general/runtime-modes.mdx
@@ -79,24 +79,11 @@ Read more about [how we handle timeouts](/blog/2025-10-20-how-we-built-websocket
 
 #### Shutdown Sequence
 
-When a serverless request approaches its lifespan limit, Rivet gracefully shuts down actors before the connection is closed:
+Each serverless request has a configurable lifespan (`requestLifespan`, default: 15 minutes). Set this to match your platform's function timeout (e.g. `requestLifespan: 300` for Vercel Pro).
 
-1. The engine tracks how long the serverless request has been running using the `requestLifespan` configuration (default: 15 minutes)
-2. When `requestLifespan - serverless_drain_grace_period` is reached, the engine sends stop commands to all actors on the runner
-3. Actors go through their normal shutdown sequence (`run` handler exits, `waitUntil` promises resolve, `onSleep` runs)
-4. After the full `requestLifespan` has elapsed, the connection is forcibly closed
-5. Any actors that didn't finish stopping are rescheduled on a new runner
+When the request nears its lifespan, the engine reserves a grace period (`serverless_drain_grace_period`, default: 10 seconds) at the end to gracefully stop actors. For example, with a 300-second lifespan, actors begin stopping at 290 seconds. After the full lifespan elapses, the connection is forcibly closed and any remaining actors are rescheduled.
 
-The `serverless_drain_grace_period` (default: 10 seconds) is how much time actors have to stop before the connection is closed. Your per-actor shutdown timeouts (`runStopTimeout`, `waitUntilTimeout`, `onSleepTimeout`) must fit within this window.
-
-| Setting | Default | Description |
-|---------|---------|-------------|
-| `requestLifespan` | 900s (15 min) | Total lifespan of the serverless request. Configured via [`configureRunnerPool`](/docs/connect/registry-configuration). |
-| `serverless_drain_grace_period` | 10s | Time reserved at the end for actors to stop gracefully. Configured via [engine config](/docs/self-hosting/configuration) (`pegboard.serverless_drain_grace_period`). |
-
-<Note>
-Set `requestLifespan` to match your platform's function timeout. For example, Vercel Pro allows 300 seconds, so set `requestLifespan: 300`. The `serverless_drain_grace_period` is subtracted from this, so actors will begin stopping at 290 seconds.
-</Note>
+See [Limits](/docs/actors/limits#serverless-shutdown) for configuration details.
 
 ## Runners
 

--- a/website/src/content/docs/general/runtime-modes.mdx
+++ b/website/src/content/docs/general/runtime-modes.mdx
@@ -77,6 +77,27 @@ Serverless platforms like Vercel have function timeouts. Rivet handles this auto
 
 Read more about [how we handle timeouts](/blog/2025-10-20-how-we-built-websocket-servers-for-vercel-functions/#timeouts-and-failover).
 
+#### Shutdown Sequence
+
+When a serverless request approaches its lifespan limit, Rivet gracefully shuts down actors before the connection is closed:
+
+1. The engine tracks how long the serverless request has been running using the `requestLifespan` configuration (default: 15 minutes)
+2. When `requestLifespan - serverless_drain_grace_period` is reached, the engine sends stop commands to all actors on the runner
+3. Actors go through their normal shutdown sequence (`run` handler exits, `waitUntil` promises resolve, `onSleep` runs)
+4. After the full `requestLifespan` has elapsed, the connection is forcibly closed
+5. Any actors that didn't finish stopping are rescheduled on a new runner
+
+The `serverless_drain_grace_period` (default: 10 seconds) is how much time actors have to stop before the connection is closed. Your per-actor shutdown timeouts (`runStopTimeout`, `waitUntilTimeout`, `onSleepTimeout`) must fit within this window.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `requestLifespan` | 900s (15 min) | Total lifespan of the serverless request. Configured via [`configureRunnerPool`](/docs/connect/registry-configuration). |
+| `serverless_drain_grace_period` | 10s | Time reserved at the end for actors to stop gracefully. Configured via [engine config](/docs/self-hosting/configuration) (`pegboard.serverless_drain_grace_period`). |
+
+<Note>
+Set `requestLifespan` to match your platform's function timeout. For example, Vercel Pro allows 300 seconds, so set `requestLifespan: 300`. The `serverless_drain_grace_period` is subtracted from this, so actors will begin stopping at 290 seconds.
+</Note>
+
 ## Runners
 
 Runners run actors as long-running background processes without exposing an HTTP endpoint.


### PR DESCRIPTION
## Summary

Documents the serverless-specific shutdown flow, including `requestLifespan` and `serverless_drain_grace_period` timeouts. This addresses RVT-5996 by explaining how actors are gracefully shut down when serverless requests approach their lifespan limit.

## Changes

- **runtime-modes.mdx**: Added "Shutdown Sequence" section explaining the step-by-step serverless shutdown flow with practical examples
- **limits.mdx**: Added "Serverless Shutdown" section documenting `requestLifespan` and `serverless_drain_grace_period` in the standard limits table
- **versions.mdx**: Added note linking to serverless shutdown docs from the existing shutdown timeouts section

## Testing

Documentation-only changes. Links verified against existing documentation pages.