### PR TITLE
fix: add runner metadata version handling to release script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,6 +256,7 @@ Data structures often include:
 ## Development Warnings
 
 - Do not run ./scripts/cargo/fix.sh. Do not format the code yourself.
+- When adding or changing any version value in the repo, verify `scripts/release/update_version.ts` updates that location so release bumps cannot leave stale versions behind.
 
 ## Testing Guidelines
 - When running tests, always pipe the test to a file in /tmp/ then grep it in a second step. You can grep test logs multiple times to search for different log lines.

--- a/scripts/release/update_version.ts
+++ b/scripts/release/update_version.ts
@@ -1,5 +1,5 @@
 import * as fs from "node:fs/promises";
-import * as path from "node:path";
+import * as pathModule from "node:path";
 import { $ } from "execa";
 import { glob } from "glob";
 import type { ReleaseOpts } from "./main";
@@ -33,6 +33,12 @@ export async function updateVersion(opts: ReleaseOpts) {
 			find: /"version": ".*"/,
 			replace: `"version": "${opts.version}"`,
 		},
+		{
+			path: "examples/**/package.json",
+			find: /"(@rivetkit\/[^"]+|rivetkit)": "\^?[0-9]+\.[0-9]+\.[0-9]+(?:-[^"]+)?"/g,
+			replace: `"$1": "^${opts.version}"`,
+			required: false,
+		},
 		// TODO: Update docs with pinned version
 		// {
 		// 	path: "site/src/content/docs/cloud/install.mdx",
@@ -52,16 +58,28 @@ export async function updateVersion(opts: ReleaseOpts) {
 	];
 
 	// Substitute all files
-	for (const { path: globPath, find, replace } of findReplace) {
+	for (const { path: globPath, find, replace, required = true } of findReplace) {
 		const paths = await glob(globPath, { cwd: opts.root });
 		assert(paths.length > 0, `no paths matched: ${globPath}`);
-		for (const path of paths) {
-			const file = await fs.readFile(path, "utf-8");
-			assert(find.test(file), `file does not match ${find}: ${path}`);
-			const newFile = file.replace(find, replace);
-			await fs.writeFile(path, newFile);
+		for (const fileRelPath of paths) {
+			const filePath = pathModule.join(opts.root, fileRelPath);
+			const file = await fs.readFile(filePath, "utf-8");
 
-			await $({ cwd: opts.root })`git add ${path}`;
+			find.lastIndex = 0;
+			const hasMatch = find.test(file);
+			if (!hasMatch) {
+				if (required) {
+					assert(false, `file does not match ${find}: ${fileRelPath}`);
+				}
+
+				continue;
+			}
+
+			find.lastIndex = 0;
+			const newFile = file.replace(find, replace);
+			await fs.writeFile(filePath, newFile);
+
+			await $({ cwd: opts.root })`git add ${fileRelPath}`;
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Update the release script to handle RivetKit version updates in example package.json files. This ensures that version bumps are consistently applied across the repository, preventing stale versions in examples.

## Changes

- Add support for updating `@rivetkit/*` and `rivetkit` dependencies in `examples/**/package.json`
- Introduce optional file matching for patterns that may not exist in all release scenarios
- Fix path handling by renaming conflicting `path` import to `pathModule`
- Reset regex `lastIndex` before test/replace operations to prevent state-related bugs
- Add development warning in CLAUDE.md to ensure version updates are tracked in the script

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

The changes have been reviewed against the codebase to ensure compatibility with the existing release workflow.