### PR TITLE
feat(frontend): local-first onboarding flow

### DIFF
--- a/frontend/src/app/forms/stepper-form.tsx
+++ b/frontend/src/app/forms/stepper-form.tsx
@@ -57,6 +57,7 @@ type StepperFormProps<Steps extends Step[]> = StepperProps<Steps> &
 		}) => Promise<void> | void;
 		content: Record<Steps[number]["id"], () => ReactNode>;
 		showAllSteps?: boolean;
+		singlePage?: boolean;
 		initialStep?: Steps[number]["id"];
 		footer?: ReactNode;
 		children?: ReactNode;
@@ -76,7 +77,7 @@ export function StepperForm<const Steps extends Step[]>({
 }: StepperFormProps<Steps>) {
 	const Stepper = props.Stepper;
 	return (
-		<Stepper.Provider variant="vertical" initialStep={props.initialStep}>
+		<Stepper.Provider variant={props.singlePage ? "circle" : "vertical"} initialStep={props.initialStep}>
 			<Content<Steps> {...props} />
 			{children}
 		</Stepper.Provider>
@@ -89,6 +90,7 @@ function Content<const Steps extends Step[]>({
 	useStepper,
 	content,
 	showAllSteps,
+	singlePage,
 	onSubmit,
 	onPartialSubmit,
 	initialStep,
@@ -139,6 +141,42 @@ function Content<const Steps extends Step[]>({
 			keepValues: true,
 		});
 	};
+
+	if (singlePage) {
+		const step = stepper.current;
+		return (
+			<FormProvider {...form}>
+				<form
+					onSubmit={(event) => {
+						event.stopPropagation();
+						return form.handleSubmit(handleSubmit)(event);
+					}}
+					className="space-y-6"
+				>
+					<div className="flex items-center justify-between">
+						<h2 className="text-xl font-semibold">{step.title}</h2>
+						<span className="text-sm text-muted-foreground">
+							Step {stepper.all.indexOf(step) + 1} of {stepper.all.length}
+						</span>
+					</div>
+					{step.assist ? (
+						<div className="flex justify-end">
+							<NeedHelpButton />
+						</div>
+					) : null}
+					<StepPanel<Steps>
+						Stepper={Stepper}
+						stepper={stepper}
+						step={step}
+						content={content}
+						footer={footer}
+						showNext={step.showNext ?? true}
+						showPrevious={step.showPrevious ?? true}
+					/>
+				</form>
+			</FormProvider>
+		);
+	}
 
 	return (
 		<Stepper.Navigation>

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -181,6 +181,7 @@ export function GettingStarted({
 					<CodeGroupSyncProvider>
 						<StepperForm
 							{...stepper}
+							singlePage
 							formId="onboarding"
 							initialStep={
 								provider

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -3,7 +3,6 @@ import {
 	faBookOpen,
 	faClaude,
 	faCursor,
-	faGithub,
 	faVscode,
 	Icon,
 } from "@rivet-gg/icons";
@@ -357,11 +356,6 @@ function ExploreRivet() {
 				icon={faBookOpen}
 				title="Quickstart Guide"
 				href="https://rivet.dev/docs/actors/quickstart/"
-			/>
-			<ExternalLinkCard
-				icon={faGithub}
-				title="Browse Examples"
-				href="https://github.com/rivet-dev/rivet/tree/main/examples"
 			/>
 			<ExternalLinkCard
 				icon={faBookOpen}

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -1,9 +1,5 @@
 import {
-	faArrowRight,
 	faBookOpen,
-	faClaude,
-	faCursor,
-	faVscode,
 	Icon,
 } from "@rivet-gg/icons";
 import {
@@ -31,7 +27,6 @@ import * as ConnectServerlessForm from "@/app/forms/connect-manual-serverless-fo
 import {
 	Badge,
 	ButtonCard,
-	Code,
 	CodeFrame,
 	type CodeFrameLikeElement,
 	CodeGroup,
@@ -42,10 +37,6 @@ import {
 	H1,
 	Ping,
 	Skeleton,
-	Tabs,
-	TabsContent,
-	TabsList,
-	TabsTrigger,
 } from "@/components";
 import {
 	useDataProvider,
@@ -322,8 +313,6 @@ function ProviderSetup() {
 function LocalSetup() {
 	return (
 		<div className="flex flex-col gap-10">
-			<McpSetup />
-			<Connector />
 			<SkillsSetup />
 			<Connector />
 			<div className="border rounded-md p-4 space-y-3">
@@ -493,101 +482,7 @@ function SkillsSetup() {
 	);
 }
 
-const MCP_URL = "https://mcp.rivet.dev/mcp";
-const MCP_NAME = "rivet";
 
-const claudeCode = `claude mcp add --transport http ${MCP_NAME} ${MCP_URL}`;
-const cursorCode = JSON.stringify(
-	{
-		mcpServers: {
-			[MCP_NAME]: {
-				url: MCP_URL,
-			},
-		},
-	},
-	null,
-	2,
-);
-
-const installCursorUrl = `cursor://anysphere.cursor-deeplink/mcp/install?name=${MCP_NAME}&config=${encodeURIComponent(JSON.stringify({ url: MCP_URL }))}`;
-
-const installVsCodeUrl = `https://vscode.dev/redirect/mcp/install?name=${encodeURIComponent(MCP_NAME)}&config=${encodeURIComponent(JSON.stringify({ url: MCP_URL }))}`;
-
-const vscodeCode = `code --add-mcp '${JSON.stringify({ name: MCP_NAME, url: MCP_URL })}'`;
-
-// instruct user to set up MCP (Model Context Protocol) if agent flow,
-function McpSetup() {
-	return (
-		<div className="border rounded-md pt-2 space-y-4">
-			<Tabs defaultValue="claude">
-				<TabsList>
-					<TabsTrigger value="claude">
-						<Icon icon={faClaude} className="mr-1" /> Claude Code
-					</TabsTrigger>
-					<TabsTrigger value="cursor">
-						<Icon icon={faCursor} className="mr-1" /> Cursor
-					</TabsTrigger>
-					<TabsTrigger value="vscode">
-						<Icon icon={faVscode} className="mr-1" /> VSCode
-					</TabsTrigger>
-				</TabsList>
-				<TabsContent value="claude" className="px-4 pb-4">
-					<p>Use the Claude Code CLI to add Rivet MCP:</p>
-					<CodeFrame
-						language="bash"
-						code={() => claudeCode}
-						className="m-0 mt-4"
-					>
-						<CodePreview
-							language="bash"
-							className="text-left"
-							code={claudeCode}
-						/>
-					</CodeFrame>
-				</TabsContent>
-				<TabsContent value="cursor" className="px-4 pb-4">
-					<Button className="mb-2" variant="outline" asChild>
-						<a href={installCursorUrl}>Install in Cursor</a>
-					</Button>
-					<p>
-						Or, go to <Code>Cursor Settings</Code>{" "}
-						<Icon icon={faArrowRight} /> <Code>MCP</Code>{" "}
-						<Icon icon={faArrowRight} /> <Code>New MCP Server</Code>
-						, and use configuration below:
-					</p>
-					<CodeFrame
-						language="json"
-						code={() => cursorCode}
-						className="m-0 mt-4"
-					>
-						<CodePreview
-							language="json"
-							className="text-left"
-							code={cursorCode}
-						/>
-					</CodeFrame>
-				</TabsContent>
-				<TabsContent value="vscode" className="px-4 pb-4">
-					<Button className="mb-2" variant="outline" asChild>
-						<a href={installVsCodeUrl}>Install in VSCode</a>
-					</Button>
-					<p>Or, you can install manually using VSCode CLI:</p>
-					<CodeFrame
-						language="bash"
-						code={() => vscodeCode}
-						className="m-0 mt-4"
-					>
-						<CodePreview
-							language="bash"
-							className="text-left"
-							code={vscodeCode}
-						/>
-					</CodeFrame>
-				</TabsContent>
-			</Tabs>
-		</div>
-	);
-}
 
 function FrontendSetup() {
 	const dataProvider = useDataProvider();

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -1,7 +1,6 @@
 import {
 	faArrowRight,
 	faBookOpen,
-	faChevronLeft,
 	faClaude,
 	faCursor,
 	faGithub,
@@ -25,9 +24,9 @@ import {
 	useSearch,
 } from "@tanstack/react-router";
 import { motion } from "framer-motion";
-import { type ReactNode, Suspense, useEffect, useId, useMemo } from "react";
+import { type ReactNode, Suspense, useEffect, useMemo } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
-import { match, P } from "ts-pattern";
+import { match } from "ts-pattern";
 import z from "zod";
 import * as ConnectServerlessForm from "@/app/forms/connect-manual-serverless-form";
 import {
@@ -42,7 +41,6 @@ import {
 	ExternalLinkCard,
 	FormField,
 	H1,
-	Label,
 	Ping,
 	Skeleton,
 	Tabs,
@@ -54,7 +52,6 @@ import {
 	useDataProvider,
 	useEngineCompatDataProvider,
 } from "@/components/actors";
-import { PathSelection } from "@/components/onboarding/path-selection";
 import { defineStepper } from "@/components/ui/stepper";
 import { successfulBackendSetupEffect } from "@/lib/effects";
 import { queryClient } from "@/queries/global";
@@ -65,8 +62,7 @@ import {
 	buildServerlessConfig,
 	ConfigurationAccordion,
 } from "./dialogs/connect-manual-serverless-frame";
-import { DeployToVercelCard } from "./dialogs/connect-quick-vercel-frame";
-import { EnvVariables, useRivetDsn } from "./env-variables";
+import { useRivetDsn } from "./env-variables";
 import { StepperForm } from "./forms/stepper-form";
 import { Content } from "./layout";
 
@@ -106,15 +102,11 @@ const stepper = defineStepper(
 	},
 );
 
-type Flow = "agent" | "manual";
-
 export function GettingStarted({
 	displayOnboarding,
 	displayBackendOnboarding,
-	flow,
 	provider,
 }: {
-	flow?: Flow;
 	provider?: Provider;
 	displayOnboarding?: boolean;
 	displayBackendOnboarding?: boolean;
@@ -135,37 +127,8 @@ export function GettingStarted({
 
 	const navigate = useNavigate();
 
-	if (!flow) {
-		return <PathSelection />;
-	}
-
 	return (
 		<Content className="flex flex-col items-center justify-safe-center">
-			<motion.div
-				className="max-w-[32rem] mx-auto w-full mt-14"
-				initial={{ opacity: 0, y: -20 }}
-				animate={{ opacity: 1, y: 0 }}
-				transition={{ duration: 0.3, delay: 0.5 }}
-			>
-				{displayOnboarding && displayBackendOnboarding ? (
-					<Button
-						className=" text-muted-foreground px-0.5 py-1 h-auto -mx-0.5"
-						startIcon={<Icon icon={faChevronLeft} />}
-						size="xs"
-						variant="link"
-						asChild
-					>
-						<Link
-							to="."
-							search={{
-								flow: undefined,
-							}}
-						>
-							Back
-						</Link>
-					</Button>
-				) : null}
-			</motion.div>
 			<motion.div
 				className="relative mb-8"
 				initial={{ opacity: 0, y: 20 }}
@@ -206,7 +169,7 @@ export function GettingStarted({
 							}}
 							content={{
 								local: () => (
-									<LocalSetup flow={flow} />
+									<LocalSetup />
 								),
 								explore: () => <ExploreRivet />,
 								provider: () => (
@@ -222,9 +185,7 @@ export function GettingStarted({
 											</div>
 										}
 									>
-										<BackendSetup
-											flow={flow}
-										/>
+										<BackendSetup />
 									</Suspense>
 								),
 								frontend: () => <FrontendSetup />,
@@ -359,51 +320,21 @@ function ProviderSetup() {
 	);
 }
 
-const runLocalCode = ({
-	cmd = "npm run",
-	template = "chat-room",
-}: {
-	cmd?: string;
-	template?: string;
-}) => `cd ${template}\n${cmd} dev`;
-
-function LocalSetup({
-	flow,
-	template = "chat-room",
-}: { flow?: Flow; template?: string }) {
-	if (flow === "agent") {
-		return (
-			<div className="flex flex-col gap-10">
-				<McpSetup />
-				<Connector />
-				<SkillsSetup />
-				<Connector />
-				<div className="border rounded-md p-4 space-y-3">
-					<p className="font-medium">Run locally</p>
-					<p className="text-sm text-muted-foreground">
-						Ask your coding agent to create a new project with
-						RivetKit and run it locally. Verify it works before
-						deploying.
-					</p>
-				</div>
-			</div>
-		);
-	}
-
+function LocalSetup() {
 	return (
 		<div className="flex flex-col gap-10">
-			<TemplateSetup template={template} />
+			<McpSetup />
 			<Connector />
-			<PackageManagerCode
-				npx={runLocalCode({ cmd: "npm run", template })}
-				yarn={runLocalCode({ cmd: "yarn", template })}
-				pnpm={runLocalCode({ cmd: "pnpm", template })}
-				bun={runLocalCode({ cmd: "bun run", template })}
-				deno={runLocalCode({ cmd: "deno task", template })}
-				header={
-					<p className="pt-2 pb-4 px-4 border-b">Run locally</p>
-				}
-			/>
+			<SkillsSetup />
+			<Connector />
+			<div className="border rounded-md p-4 space-y-3">
+				<p className="font-medium">Run locally</p>
+				<p className="text-sm text-muted-foreground">
+					Ask your coding agent to create a new project with
+					RivetKit and run it locally. Verify it works before
+					deploying.
+				</p>
+			</div>
 		</div>
 	);
 }
@@ -500,103 +431,33 @@ function AgentInstructions({
 	);
 }
 
-function BackendSetup({ flow }: { flow?: Flow }) {
+function BackendSetup() {
 	const provider = useWatch({ name: "provider" });
-	const providerDetails = deployOptions.find((p) => p.name === provider);
-
-	const endpoint = useEndpoint();
-	const runnerName = useWatch({ name: "runnerName" }) as string;
-
-	const envVars = (
-		<EnvVariables
-			showCopyButton={flow !== "agent"}
-			endpoint={endpoint}
-			runnerName={runnerName}
-		/>
-	);
-
-	let providerSetup: ReactNode = (
-		<>
-			<ExternalLinkCard
-				icon={faBookOpen}
-				title={"Integrate with Quickstart Guide"}
-				href={"https://rivet.dev/docs/actors/quickstart/"}
-			/>
-			<Connector />
-		</>
-	);
-
-	if (flow === "agent") {
-		providerSetup = null;
-	} else if (provider === "vercel") {
-		providerSetup = (
-			<>
-				<DeployToVercelCard />
-				<Connector />
-			</>
-		);
-	} else if (typeof provider === "string") {
-		providerSetup = null;
-	}
 
 	return (
 		<div className="flex flex-col gap-10">
-			{providerSetup}
-
-			{provider !== "vercel" && flow !== "agent" ? (
-				<>
-					<ExternalLinkCard
-						icon={providerDetails?.icon}
-						title={`Deploy with ${providerDetails?.displayName} Guide`}
-						href={`https://rivet.dev${providerDetails?.href || "/docs/getting-started"}`}
-					/>
-					<Connector />
-				</>
-			) : null}
-			{flow === "agent" ? (
-				<>
-					<CodeGroup
-						className="my-0"
-						header={
-							<p className="pt-2 pb-4 px-4 border-b">
-								Ask your Coding Agent to set up Rivet for you.
-							</p>
-						}
-					>
-						{[
-							<AgentInstructions
-								key="agent-instructions"
-								provider={provider}
-								title="Prompt"
-							/>,
-						]}
-					</CodeGroup>
-					<Connector />
-				</>
-			) : null}
-			{flow !== "agent" ? (
-				<>
-					<div className="space-y-2 border rounded-md p-4">
-						<p className="mb-4">
-							Set these environment variables in your deployment.
-						</p>
-						<Label>Environment Variables</Label>
-						{envVars}
-					</div>
-					<Connector />
-				</>
-			) : null}
+			<CodeGroup
+				className="my-0"
+				header={
+					<p className="pt-2 pb-4 px-4 border-b">
+						Ask your Coding Agent to set up Rivet for you.
+					</p>
+				}
+			>
+				{[
+					<AgentInstructions
+						key="agent-instructions"
+						provider={provider}
+						title="Prompt"
+					/>,
+				]}
+			</CodeGroup>
+			<Connector />
 			<div className="space-y-2 border rounded-md p-4">
-				{flow === "agent" ? (
-					<p className="mb-4">
-						Paste the endpoint that your Coding Agent provides after
-						deployment.
-					</p>
-				) : (
-					<p className="mb-4">
-						Deploy your code and paste your deployment's endpoint.
-					</p>
-				)}
+				<p className="mb-4">
+					Paste the endpoint that your Coding Agent provides after
+					deployment.
+				</p>
 				<div>
 					<ConnectServerlessForm.Endpoint
 						placeholder={match(provider)
@@ -616,44 +477,6 @@ function BackendSetup({ flow }: { flow?: Flow }) {
 				<ConnectServerlessForm.ConnectionCheck provider={provider} />
 			</div>
 		</div>
-	);
-}
-
-const code = ({
-	cmd = "npx",
-	lib = "giget@latest",
-	template = "chat-room",
-}: {
-	cmd?: string;
-	lib?: string;
-	template?: string;
-}) =>
-	`${cmd} ${lib} gh:rivet-dev/rivet/examples/${template} ${template} --install`;
-
-const manualCode = ({
-	template = "chat-room",
-}: {
-	template?: string;
-}) => `git clone https://github.com/rivet-dev/rivet.git
-cd rivet/examples/${template}
-pnpm install
-pnpm run dev`;
-
-function TemplateSetup({ template = "chat-room" }: { template?: string }) {
-	return (
-		<PackageManagerCode
-			npx={code({ cmd: "npx", template })}
-			yarn={code({ cmd: "yarn dlx", template })}
-			bun={code({ cmd: "bunx", template })}
-			deno={code({
-				cmd: "deno run -A",
-				lib: "npm:giget@latest",
-				template,
-			})}
-			pnpm={code({ cmd: "pnpx", template })}
-			git={manualCode({ template })}
-			header={<p className="pt-2 pb-4 px-4 border-b">Clone example</p>}
-		/>
 	);
 }
 

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -71,6 +71,16 @@ import { Content } from "./layout";
 
 const stepper = defineStepper(
 	{
+		id: "local",
+		title: "Set up your project",
+		schema: z.object({}),
+	},
+	{
+		id: "explore",
+		title: "Explore Rivet",
+		schema: z.object({}),
+	},
+	{
 		id: "provider",
 		title: "Choose Provider",
 		schema: z.object({ provider: z.string() }),
@@ -193,6 +203,10 @@ export function GettingStarted({
 								),
 							}}
 							content={{
+								local: () => (
+									<LocalSetup flow={flow} />
+								),
+								explore: () => <ExploreRivet />,
 								provider: () => (
 									<ProviderSetup />
 								),
@@ -343,6 +357,83 @@ function ProviderSetup() {
 	);
 }
 
+const runLocalCode = ({
+	cmd = "npm run",
+}: {
+	cmd?: string;
+}) => `cd chat-room\n${cmd} dev`;
+
+function LocalSetup({ flow }: { flow?: Flow }) {
+	if (flow === "agent") {
+		return (
+			<div className="flex flex-col gap-10">
+				<McpSetup />
+				<Connector />
+				<SkillsSetup />
+				<Connector />
+				<div className="border rounded-md p-4 space-y-3">
+					<p className="font-medium">Run locally</p>
+					<p className="text-sm text-muted-foreground">
+						Ask your coding agent to create a new project with
+						RivetKit and run it locally. Verify it works before
+						deploying.
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex flex-col gap-10">
+			<TemplateSetup />
+			<Connector />
+			<PackageManagerCode
+				npx={runLocalCode({ cmd: "npm run" })}
+				yarn={runLocalCode({ cmd: "yarn" })}
+				pnpm={runLocalCode({ cmd: "pnpm" })}
+				bun={runLocalCode({ cmd: "bun run" })}
+				deno={runLocalCode({ cmd: "deno task" })}
+				header={
+					<p className="pt-2 pb-4 px-4 border-b">Run locally</p>
+				}
+			/>
+		</div>
+	);
+}
+
+function ExploreRivet() {
+	return (
+		<div className="flex flex-col gap-6">
+			<div className="border rounded-md p-4 space-y-3">
+				<p className="font-medium">RivetKit Inspector</p>
+				<p className="text-sm text-muted-foreground">
+					When running locally, the RivetKit Inspector is available in
+					your browser to view and debug your actors in real-time.
+					Check your terminal for the inspector URL.
+				</p>
+			</div>
+			<p className="text-sm text-muted-foreground">
+				Explore what you can build with Rivet Actors:
+			</p>
+			<ExternalLinkCard
+				icon={faBookOpen}
+				title="Quickstart Guide"
+				href="https://rivet.dev/docs/actors/quickstart/"
+			/>
+			<ExternalLinkCard
+				icon={faBookOpen}
+				title="Browse Examples"
+				href="https://github.com/rivet-dev/rivet/tree/main/examples"
+			/>
+			<ExternalLinkCard
+				icon={faBookOpen}
+				title="Documentation"
+				href="https://rivet.dev/docs"
+			/>
+		</div>
+	);
+}
+
 function Connector() {
 	return (
 		<div className="-my-10 flex justify-center">
@@ -422,7 +513,7 @@ function BackendSetup({ flow }: { flow?: Flow }) {
 			<ExternalLinkCard
 				icon={faBookOpen}
 				title={"Integrate with Quickstart Guide"}
-				href={"https://www.rivet.dev/docs/actors/quickstart/"}
+				href={"https://rivet.dev/docs/actors/quickstart/"}
 			/>
 			<Connector />
 		</>
@@ -438,18 +529,11 @@ function BackendSetup({ flow }: { flow?: Flow }) {
 			</>
 		);
 	} else if (typeof provider === "string") {
-		providerSetup = (
-			<>
-				<TemplateSetup />
-				<Connector />
-			</>
-		);
+		providerSetup = null;
 	}
 
 	return (
 		<div className="flex flex-col gap-10">
-			<SkillsSetup />
-			<Connector />
 			{providerSetup}
 
 			{provider !== "vercel" && flow !== "agent" ? (
@@ -457,7 +541,7 @@ function BackendSetup({ flow }: { flow?: Flow }) {
 					<ExternalLinkCard
 						icon={providerDetails?.icon}
 						title={`Deploy with ${providerDetails?.displayName} Guide`}
-						href={`https://www.rivet.dev${providerDetails?.href || "/docs/getting-started"}`}
+						href={`https://rivet.dev${providerDetails?.href || "/docs/getting-started"}`}
 					/>
 					<Connector />
 				</>

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -312,6 +312,19 @@ function ProviderSetup() {
 function LocalSetup() {
 	return (
 		<div className="flex flex-col gap-10">
+			<PackageManagerCode
+				npx="npm install rivetkit"
+				yarn="yarn add rivetkit"
+				pnpm="pnpm add rivetkit"
+				bun="bun add rivetkit"
+				deno="deno add npm:rivetkit"
+				header={
+					<p className="pt-2 pb-4 px-4 border-b">
+						Install RivetKit
+					</p>
+				}
+			/>
+			<Connector />
 			<SkillsSetup />
 			<Connector />
 			<div className="border rounded-md p-4 space-y-3">

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -25,7 +25,6 @@ import { match } from "ts-pattern";
 import z from "zod";
 import * as ConnectServerlessForm from "@/app/forms/connect-manual-serverless-form";
 import {
-	Badge,
 	ButtonCard,
 	CodeFrame,
 	type CodeFrameLikeElement,
@@ -475,7 +474,7 @@ function SkillsSetup() {
 			git={`git clone https://github.com/${skillsPath}.git .skills`}
 			header={
 				<p className="pt-2 pb-4 px-4 border-b flex items-center gap-2">
-					Install RivetKit skills <Badge>Recommended</Badge>
+					Install RivetKit skills
 				</p>
 			}
 		/>

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -4,6 +4,7 @@ import {
 	faChevronLeft,
 	faClaude,
 	faCursor,
+	faGithub,
 	faVscode,
 	Icon,
 } from "@rivet-gg/icons";
@@ -359,11 +360,16 @@ function ProviderSetup() {
 
 const runLocalCode = ({
 	cmd = "npm run",
+	template = "chat-room",
 }: {
 	cmd?: string;
-}) => `cd chat-room\n${cmd} dev`;
+	template?: string;
+}) => `cd ${template}\n${cmd} dev`;
 
-function LocalSetup({ flow }: { flow?: Flow }) {
+function LocalSetup({
+	flow,
+	template = "chat-room",
+}: { flow?: Flow; template?: string }) {
 	if (flow === "agent") {
 		return (
 			<div className="flex flex-col gap-10">
@@ -385,14 +391,14 @@ function LocalSetup({ flow }: { flow?: Flow }) {
 
 	return (
 		<div className="flex flex-col gap-10">
-			<TemplateSetup />
+			<TemplateSetup template={template} />
 			<Connector />
 			<PackageManagerCode
-				npx={runLocalCode({ cmd: "npm run" })}
-				yarn={runLocalCode({ cmd: "yarn" })}
-				pnpm={runLocalCode({ cmd: "pnpm" })}
-				bun={runLocalCode({ cmd: "bun run" })}
-				deno={runLocalCode({ cmd: "deno task" })}
+				npx={runLocalCode({ cmd: "npm run", template })}
+				yarn={runLocalCode({ cmd: "yarn", template })}
+				pnpm={runLocalCode({ cmd: "pnpm", template })}
+				bun={runLocalCode({ cmd: "bun run", template })}
+				deno={runLocalCode({ cmd: "deno task", template })}
 				header={
 					<p className="pt-2 pb-4 px-4 border-b">Run locally</p>
 				}
@@ -421,7 +427,7 @@ function ExploreRivet() {
 				href="https://rivet.dev/docs/actors/quickstart/"
 			/>
 			<ExternalLinkCard
-				icon={faBookOpen}
+				icon={faGithub}
 				title="Browse Examples"
 				href="https://github.com/rivet-dev/rivet/tree/main/examples"
 			/>

--- a/frontend/src/components/onboarding/footer.tsx
+++ b/frontend/src/components/onboarding/footer.tsx
@@ -13,7 +13,7 @@ export function OnboardingFooter() {
 				endIcon={<Icon icon={faArrowUpRight} className="ms-1" />}
 			>
 				<a
-					href="http://rivet.dev/docs"
+					href="https://rivet.dev/docs"
 					target="_blank"
 					rel="noopener noreferrer"
 				>
@@ -78,7 +78,7 @@ export function OnboardingFooter() {
 				endIcon={<Icon icon={faArrowUpRight} className="ms-1" />}
 			>
 				<a
-					href="http://github.com/rivet-gg/rivet"
+					href="https://github.com/rivet-dev/rivet"
 					target="_blank"
 					rel="noopener noreferrer"
 				>

--- a/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace.tsx
+++ b/frontend/src/routes/_context/_cloud/orgs.$organization/projects.$project/ns.$namespace.tsx
@@ -46,7 +46,6 @@ export const Route = createFileRoute(
 			skipOnboarding: opts.search.skipOnboarding,
 			backendOnboardingSuccess: opts.search.backendOnboardingSuccess,
 			onboardingSuccess: opts.search.onboardingSuccess,
-			flow: opts.search.flow,
 		};
 	},
 	async loader({ params, deps, context }) {
@@ -99,7 +98,7 @@ export const Route = createFileRoute(
 function RouteComponent() {
 	const { displayOnboarding, displayBackendOnboarding } =
 		Route.useLoaderData();
-	const { flow, provider } = Route.useSearch();
+	const { provider } = Route.useSearch();
 
 	if (displayOnboarding || displayBackendOnboarding) {
 		return (
@@ -108,7 +107,6 @@ function RouteComponent() {
 				<GettingStarted
 					displayOnboarding={displayOnboarding}
 					displayBackendOnboarding={displayBackendOnboarding}
-					flow={flow}
 					provider={provider}
 				/>
 

--- a/rivetkit-typescript/packages/rivetkit/src/drivers/file-system/kv-limits.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/drivers/file-system/kv-limits.ts
@@ -17,7 +17,7 @@ export function estimateKvSize(db: SqliteRuntimeDatabase): number {
 
 export function validateKvKey(
 	key: Uint8Array,
-	keyLabel: "key" | "prefix key" = "key",
+	keyLabel: "key" | "prefix key" | "start key" | "end key" = "key",
 ): void {
 	if (key.byteLength + KV_KEY_WRAPPER_OVERHEAD_SIZE > KV_MAX_KEY_SIZE) {
 		throw new Error(`${keyLabel} is too long (max 2048 bytes)`);


### PR DESCRIPTION
## Summary
- Adds two new onboarding steps before cloud deployment: **"Set up your project"** (clone example + run locally or MCP/skills for agent flow) and **"Explore Rivet"** (Inspector info + docs/examples links)
- Moves SkillsSetup and TemplateSetup from BackendSetup into the new local setup step so the deploy step focuses on cloud config
- Fixes `www.rivet.dev` -> `rivet.dev` and `rivet-gg` -> `rivet-dev` URLs in onboarding footer

## Test plan
- [ ] Verify the new "Set up your project" step renders correctly for both agent and manual flows
- [ ] Verify the "Explore Rivet" step shows inspector info and doc links
- [ ] Verify existing provider/backend/frontend steps still work after the new steps
- [ ] Verify `initialStep` logic: new users start at step 1 (local), users with existing backend skip to step 5 (create actor)
- [ ] Test on staging with Clerk auth