### PR TITLE
fix: improve mobile layout for website and fix docs sidebar on mobile

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/drivers/file-system/kv-limits.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/drivers/file-system/kv-limits.ts
@@ -17,7 +17,7 @@ export function estimateKvSize(db: SqliteRuntimeDatabase): number {
 
 export function validateKvKey(
 	key: Uint8Array,
-	keyLabel: "key" | "prefix key" = "key",
+	keyLabel: "key" | "prefix key" | "start key" | "end key" = "key",
 ): void {
 	if (key.byteLength + KV_KEY_WRAPPER_OVERHEAD_SIZE > KV_MAX_KEY_SIZE) {
 		throw new Error(`${keyLabel} is too long (max 2048 bytes)`);

--- a/website/src/components/Footer.jsx
+++ b/website/src/components/Footer.jsx
@@ -134,9 +134,9 @@ export function PageNextPrevious({ navigation }) {
 function SmallPrint() {
 	return (
 		<div className="mx-auto max-w-7xl w-full py-16 selection:bg-[#FF4500]/30 selection:text-orange-200">
-			<div className="grid grid-cols-2 gap-8 md:grid-cols-4 lg:grid-cols-5">
+			<div className="grid grid-cols-1 min-[440px]:grid-cols-2 gap-8 md:grid-cols-4 lg:grid-cols-5">
 				{/* Brand column */}
-				<div className="col-span-2 md:col-span-4 lg:col-span-1 space-y-6">
+				<div className="col-span-1 min-[440px]:col-span-2 md:col-span-4 lg:col-span-1 space-y-6">
 					<img className="h-8 w-8" src={imgLogo.src} alt="Rivet" />
 					<p className="text-sm text-zinc-500">
 						The primitive for stateful workloads
@@ -228,7 +228,7 @@ function SmallPrint() {
 			</div>
 
 			{/* Investor badges */}
-			<div className="mt-12 flex flex-wrap items-center gap-4">
+			<div className="mt-12 flex flex-col min-[440px]:flex-row flex-wrap items-start min-[440px]:items-center gap-4">
 				<span className="text-xs text-zinc-600">Backed by</span>
 				<div className="flex flex-wrap items-center gap-2">
 					<div className="flex items-center gap-2 rounded-full border border-white/10 px-3 py-1.5 text-xs text-zinc-400">

--- a/website/src/components/marketing/sections/BuiltInFeatures.tsx
+++ b/website/src/components/marketing/sections/BuiltInFeatures.tsx
@@ -107,7 +107,7 @@ export const BuiltInFeatures = () => {
           </p>
         </motion.div>
 
-        <div className='grid grid-cols-1 gap-x-8 gap-y-6 min-[440px]:grid-cols-2 sm:grid-cols-3 lg:grid-cols-4'>
+        <div className='grid grid-cols-1 gap-x-8 gap-y-6 min-[440px]:grid-cols-2 lg:grid-cols-4'>
           {features.map((feature, idx) => {
             const Icon = feature.icon;
             return (

--- a/website/src/components/marketing/sections/HostingSection.tsx
+++ b/website/src/components/marketing/sections/HostingSection.tsx
@@ -5,7 +5,7 @@ import { motion } from 'framer-motion';
 import imgLogo from '@/images/rivet-logos/icon-white.svg';
 
 export const HostingSection = () => (
-  <section className='border-t border-white/10 py-48'>
+  <section className='border-t border-white/10 py-16 md:py-48'>
     <div className='mx-auto max-w-7xl px-6'>
       <div className='mb-12'>
         <motion.h2

--- a/website/src/components/marketing/sections/IntegrationsSection.tsx
+++ b/website/src/components/marketing/sections/IntegrationsSection.tsx
@@ -16,7 +16,7 @@ const frameworks = [
 ];
 
 export const IntegrationsSection = () => (
-  <section className='relative overflow-hidden border-t border-white/5 py-48'>
+  <section className='relative overflow-hidden border-t border-white/5 py-16 md:py-48'>
     <div className='relative z-10 mx-auto max-w-7xl px-6'>
       <div className='mb-12'>
         <motion.div

--- a/website/src/components/marketing/sections/ObservabilitySection.tsx
+++ b/website/src/components/marketing/sections/ObservabilitySection.tsx
@@ -30,7 +30,7 @@ export const ObservabilitySection = () => {
   ];
 
   return (
-    <section className='border-t border-white/10 bg-black py-48'>
+    <section className='border-t border-white/10 bg-black py-16 md:py-48'>
       <div className='mx-auto max-w-7xl px-6'>
         <div className='relative'>
           {/* Screenshot on top */}

--- a/website/src/components/marketing/sections/RedesignedCTA.tsx
+++ b/website/src/components/marketing/sections/RedesignedCTA.tsx
@@ -4,7 +4,7 @@ import { motion } from 'framer-motion';
 import { AnimatedCTATitle } from '../components/AnimatedCTATitle';
 
 export const RedesignedCTA = () => (
-  <section className='border-t border-white/10 px-6 py-48 text-center'>
+  <section className='border-t border-white/10 px-6 py-16 md:py-48 text-center'>
     <div className='mx-auto max-w-3xl'>
       <div className='mb-6'>
         <AnimatedCTATitle />

--- a/website/src/components/marketing/sections/SolutionsSection.tsx
+++ b/website/src/components/marketing/sections/SolutionsSection.tsx
@@ -55,7 +55,7 @@ const solutions: Solution[] = [
 ];
 
 export const SolutionsSection = () => (
-  <section className='border-t border-white/5 py-48'>
+  <section className='border-t border-white/5 py-16 md:py-48'>
     <div className='mx-auto max-w-7xl px-6'>
       <div className='mb-12'>
         <motion.h2

--- a/website/src/components/v2/Header.tsx
+++ b/website/src/components/v2/Header.tsx
@@ -1,6 +1,9 @@
 "use client";
 import { usePathname } from "@/hooks/usePathname";
 import { ActiveLink } from "@/components/ActiveLink";
+import { Tree } from "@/components/DocsNavigation";
+import { NavigationStateProvider } from "@/providers/NavigationStateProvider";
+import type { SidebarItem } from "@/lib/sitemap";
 import logoUrl from "@/images/rivet-logos/icon-text-white.svg";
 import logoIconUrl from "@/images/rivet-logos/icon-white.svg";
 import { cn } from "@rivet-gg/components";
@@ -360,6 +363,7 @@ interface HeaderProps {
 	| "learn";
 	subnav?: ReactNode;
 	mobileSidebar?: ReactNode;
+	sidebarData?: SidebarItem[];
 	variant?: "floating" | "full-width";
 	learnMode?: boolean;
 	showDocsTabs?: boolean;
@@ -369,6 +373,7 @@ export function Header({
 	active,
 	subnav,
 	mobileSidebar,
+	sidebarData,
 	variant = "full-width",
 	learnMode = false,
 	showDocsTabs = false,
@@ -440,7 +445,7 @@ export function Header({
 								</a>
 							</div>
 						}
-						mobileBreadcrumbs={<DocsMobileNavigation tree={mobileSidebar} />}
+						mobileBreadcrumbs={<DocsMobileNavigation tree={mobileSidebar} sidebarData={sidebarData} />}
 						breadcrumbs={
 							<div className="flex items-center font-v2 subpixel-antialiased">
 								<ProductsDropdown active={active === "product"} />
@@ -521,7 +526,7 @@ export function Header({
 					</a>
 				</div>
 			}
-			mobileBreadcrumbs={<DocsMobileNavigation tree={mobileSidebar} />}
+			mobileBreadcrumbs={<DocsMobileNavigation tree={mobileSidebar} sidebarData={sidebarData} />}
 			breadcrumbs={
 				<div className="flex items-center font-v2 subpixel-antialiased">
 					<ProductsDropdown active={active === "product"} />
@@ -549,7 +554,7 @@ export function Header({
 	);
 }
 
-function DocsMobileNavigation({ tree }) {
+function DocsMobileNavigation({ tree, sidebarData }: { tree?: ReactNode; sidebarData?: SidebarItem[] }) {
 	const pathname = usePathname() || "";
 	const isDocsPage = pathname.startsWith("/docs");
 
@@ -700,6 +705,13 @@ function DocsMobileNavigation({ tree }) {
 
 					{/* Tree/sidebar content */}
 					{tree && <div className="mt-1">{tree}</div>}
+					{!tree && sidebarData && (
+						<NavigationStateProvider>
+							<div className="mt-1">
+								<Tree pages={sidebarData} />
+							</div>
+						</NavigationStateProvider>
+					)}
 				</>
 			)}
 

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -1,18 +1,20 @@
 ---
 import BaseLayout from './BaseLayout.astro';
 import { Header } from '@/components/v2/Header';
+import type { SidebarItem } from '@/lib/sitemap';
 
 interface Props {
 	title: string;
 	description?: string;
 	canonicalUrl?: string;
+	sidebar?: SidebarItem[];
 }
 
-const { title, description, canonicalUrl } = Astro.props;
+const { title, description, canonicalUrl, sidebar } = Astro.props;
 ---
 
 <BaseLayout title={title} description={description} canonicalUrl={canonicalUrl}>
-	<Header variant="full-width" showDocsTabs={true} client:load />
+	<Header variant="full-width" showDocsTabs={true} sidebarData={sidebar} client:load />
 	<div class="w-full relative z-10 font-sans">
 		<div class="mx-auto w-full min-h-content flex flex-col md:grid md:grid-cols-docs" style="--header-height: 6.5rem;">
 			<slot />

--- a/website/src/pages/docs/[...slug].astro
+++ b/website/src/pages/docs/[...slug].astro
@@ -83,7 +83,7 @@ const breadcrumbSchema = {
 };
 ---
 
-<DocsLayout title={`${title} - Rivet`} description={description} canonicalUrl={canonicalUrl}>
+<DocsLayout title={`${title} - Rivet`} description={description} canonicalUrl={canonicalUrl} sidebar={foundTab?.tab?.sidebar}>
 	<script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
 	<aside class="hidden md:block border-r">
 		{foundTab?.tab?.sidebar && <DocsNavigation sidebar={foundTab.tab.sidebar} client:load />}


### PR DESCRIPTION
## Description

Improves mobile layout across the website and fixes the docs sidebar navigation not appearing in the mobile hamburger menu. These changes address viewport issues at 375px width and provide a better mobile experience overall.

## Changes

- **Docs sidebar on mobile**: The sidebar data is now passed through the DocsLayout to the Header component and rendered in the mobile navigation drawer, allowing users to navigate docs on mobile
- **Section padding**: Reduced excessive vertical padding on landing page sections from 192px (`py-48`) to 48px (`py-16`) on mobile, only expanding to 192px on desktop
- **Footer layout**: Changed footer grid to single-column layout on screens under 440px width
- **Features grid**: Removed the three-column breakpoint so the grid only goes 1 → 2 → 4 columns, providing better spacing

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested at 375px viewport width:
- Verified docs sidebar now appears in hamburger menu on mobile
- Confirmed landing page sections no longer have excessive padding gaps
- Verified footer stacks properly on narrow screens
- Checked that Features grid displays correctly with only 1, 2, or 4 column layouts
- Tested desktop viewports (1024px, 1440px) to ensure no regressions