### PR TITLE
refactor: explicit protocol version conversions

### DIFF
--- a/engine/CLAUDE.md
+++ b/engine/CLAUDE.md
@@ -1,0 +1,28 @@
+# Engine Notes
+
+## VBARE migrations
+
+When changing a versioned VBARE schema, follow the existing migration pattern.
+
+1. Never edit an existing published `*.bare` schema in place. Add a new versioned schema instead.
+2. Update the matching `versioned.rs` like this:
+   - If the bytes did not change, deserialize both versions into the new wrapper variant:
+
+   ```rust
+   6 | 7 => Ok(ToClientMk2::V7(serde_bare::from_slice(payload)?))
+   ```
+
+   - If the bytes did change, write the conversion field by field.
+
+   - Do not do this:
+
+   ```rust
+   let bytes = serde_bare::to_vec(&x)?;
+   serde_bare::from_slice(&bytes)?
+   ```
+3. Verify the affected Rust crate still builds.
+4. For the runner protocol specifically:
+   - Bump both protocol constants together:
+     - `engine/sdks/rust/runner-protocol/src/lib.rs` `PROTOCOL_MK2_VERSION`
+     - `engine/sdks/typescript/runner/src/mod.ts` `PROTOCOL_VERSION`
+   - Update the Rust latest re-export in `engine/sdks/rust/runner-protocol/src/lib.rs` to the new generated module.

--- a/engine/sdks/rust/runner-protocol/src/versioned.rs
+++ b/engine/sdks/rust/runner-protocol/src/versioned.rs
@@ -2180,7 +2180,7 @@ impl ActorCommandKeyData {
 
 	fn v7_to_v4(self) -> Result<Self> {
 		if let ActorCommandKeyData::V7(x) = self {
-			// Since v4 commands have generation but v6 doesn't, use generation 0 as a placeholder
+			// Since v4 commands have generation but v7 doesn't, use generation 0 as a placeholder
 			let inner = match x {
 				v7::ActorCommandKeyData::CommandStartActor(start) => {
 					v4::ActorCommandKeyData::CommandStartActor(v4::CommandStartActor {

--- a/engine/sdks/rust/runner-protocol/src/versioned.rs
+++ b/engine/sdks/rust/runner-protocol/src/versioned.rs
@@ -5,19 +5,9 @@ use crate::PROTOCOL_MK1_VERSION;
 use crate::generated::{v1, v2, v3, v4, v5, v6, v7};
 use crate::uuid_compat::{decode_bytes_from_uuid, encode_bytes_to_uuid};
 
-fn convert_wire_compatible<T, U>(value: T) -> Result<U>
-where
-	T: serde::Serialize,
-	U: serde::de::DeserializeOwned,
-{
-	let bytes = serde_bare::to_vec(&value)?;
-	Ok(serde_bare::from_slice(&bytes)?)
-}
-
 pub enum ToClientMk2 {
 	V4(v4::ToClient),
 	V5(v5::ToClient),
-	V6(v6::ToClient),
 	V7(v7::ToClient),
 }
 
@@ -40,8 +30,7 @@ impl OwnedVersionedData for ToClientMk2 {
 		match version {
 			4 => Ok(ToClientMk2::V4(serde_bare::from_slice(payload)?)),
 			5 => Ok(ToClientMk2::V5(serde_bare::from_slice(payload)?)),
-			6 => Ok(ToClientMk2::V6(serde_bare::from_slice(payload)?)),
-			7 => Ok(ToClientMk2::V7(serde_bare::from_slice(payload)?)),
+			6 | 7 => Ok(ToClientMk2::V7(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -50,19 +39,16 @@ impl OwnedVersionedData for ToClientMk2 {
 		match self {
 			ToClientMk2::V4(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ToClientMk2::V5(data) => serde_bare::to_vec(&data).map_err(Into::into),
-			ToClientMk2::V6(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ToClientMk2::V7(data) => serde_bare::to_vec(&data).map_err(Into::into),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		// No changes between v1 and v4
-		vec![Ok, Ok, Ok, Self::v4_to_v5, Self::v5_to_v6, Self::v6_to_v7]
+		vec![Ok, Ok, Ok, Self::v4_to_v5, Self::v5_to_v7, Ok]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		// No changes between v1 and v4
-		vec![Self::v7_to_v6, Self::v6_to_v5, Self::v5_to_v4, Ok, Ok, Ok]
+		vec![Ok, Self::v7_to_v5, Self::v5_to_v4, Ok, Ok, Ok]
 	}
 }
 
@@ -241,30 +227,30 @@ impl ToClientMk2 {
 		}
 	}
 
-	fn v5_to_v6(self) -> Result<Self> {
+	fn v5_to_v7(self) -> Result<Self> {
 		if let ToClientMk2::V5(x) = self {
 			let inner = match x {
-				v5::ToClient::ToClientInit(init) => v6::ToClient::ToClientInit(v6::ToClientInit {
+				v5::ToClient::ToClientInit(init) => v7::ToClient::ToClientInit(v7::ToClientInit {
 					runner_id: init.runner_id,
-					metadata: v6::ProtocolMetadata {
+					metadata: v7::ProtocolMetadata {
 						runner_lost_threshold: init.metadata.runner_lost_threshold,
 						actor_stop_threshold: 0,
 						serverless_drain_grace_period: None,
 					},
 				}),
-				v5::ToClient::ToClientCommands(commands) => v6::ToClient::ToClientCommands(
+				v5::ToClient::ToClientCommands(commands) => v7::ToClient::ToClientCommands(
 					commands
 						.into_iter()
-						.map(|cmd| v6::CommandWrapper {
-							checkpoint: v6::ActorCheckpoint {
+						.map(|cmd| v7::CommandWrapper {
+							checkpoint: v7::ActorCheckpoint {
 								actor_id: cmd.checkpoint.actor_id,
 								generation: cmd.checkpoint.generation,
 								index: cmd.checkpoint.index,
 							},
 							inner: match cmd.inner {
 								v5::Command::CommandStartActor(start) => {
-									v6::Command::CommandStartActor(v6::CommandStartActor {
-										config: v6::ActorConfig {
+									v7::Command::CommandStartActor(v7::CommandStartActor {
+										config: v7::ActorConfig {
 											name: start.config.name,
 											key: start.config.key,
 											create_ts: start.config.create_ts,
@@ -273,24 +259,24 @@ impl ToClientMk2 {
 										hibernating_requests: start
 											.hibernating_requests
 											.into_iter()
-											.map(|req| v6::HibernatingRequest {
+											.map(|req| v7::HibernatingRequest {
 												gateway_id: req.gateway_id,
 												request_id: req.request_id,
 											})
 											.collect(),
 									})
 								}
-								v5::Command::CommandStopActor => v6::Command::CommandStopActor,
+								v5::Command::CommandStopActor => v7::Command::CommandStopActor,
 							},
 						})
 						.collect(),
 				),
 				v5::ToClient::ToClientAckEvents(ack) => {
-					v6::ToClient::ToClientAckEvents(v6::ToClientAckEvents {
+					v7::ToClient::ToClientAckEvents(v7::ToClientAckEvents {
 						last_event_checkpoints: ack
 							.last_event_checkpoints
 							.into_iter()
-							.map(|cp| v6::ActorCheckpoint {
+							.map(|cp| v7::ActorCheckpoint {
 								actor_id: cp.actor_id,
 								generation: cp.generation,
 								index: cp.index,
@@ -299,44 +285,44 @@ impl ToClientMk2 {
 					})
 				}
 				v5::ToClient::ToClientKvResponse(resp) => {
-					v6::ToClient::ToClientKvResponse(v6::ToClientKvResponse {
+					v7::ToClient::ToClientKvResponse(v7::ToClientKvResponse {
 						request_id: resp.request_id,
-						data: convert_kv_response_data_v5_to_v6(resp.data),
+						data: convert_kv_response_data_v5_to_v7(resp.data),
 					})
 				}
 				v5::ToClient::ToClientTunnelMessage(msg) => {
-					v6::ToClient::ToClientTunnelMessage(v6::ToClientTunnelMessage {
-						message_id: v6::MessageId {
+					v7::ToClient::ToClientTunnelMessage(v7::ToClientTunnelMessage {
+						message_id: v7::MessageId {
 							gateway_id: msg.message_id.gateway_id,
 							request_id: msg.message_id.request_id,
 							message_index: msg.message_id.message_index,
 						},
-						message_kind: convert_to_client_tunnel_message_kind_v5_to_v6(
+						message_kind: convert_to_client_tunnel_message_kind_v5_to_v7(
 							msg.message_kind,
 						),
 					})
 				}
 				v5::ToClient::ToClientPing(ping) => {
-					v6::ToClient::ToClientPing(v6::ToClientPing { ts: ping.ts })
+					v7::ToClient::ToClientPing(v7::ToClientPing { ts: ping.ts })
 				}
 			};
 
-			Ok(ToClientMk2::V6(inner))
+			Ok(ToClientMk2::V7(inner))
 		} else {
 			bail!("unexpected version");
 		}
 	}
 
-	fn v6_to_v5(self) -> Result<Self> {
-		if let ToClientMk2::V6(x) = self {
+	fn v7_to_v5(self) -> Result<Self> {
+		if let ToClientMk2::V7(x) = self {
 			let inner = match x {
-				v6::ToClient::ToClientInit(init) => v5::ToClient::ToClientInit(v5::ToClientInit {
+				v7::ToClient::ToClientInit(init) => v5::ToClient::ToClientInit(v5::ToClientInit {
 					runner_id: init.runner_id,
 					metadata: v5::ProtocolMetadata {
 						runner_lost_threshold: init.metadata.runner_lost_threshold,
 					},
 				}),
-				v6::ToClient::ToClientCommands(commands) => v5::ToClient::ToClientCommands(
+				v7::ToClient::ToClientCommands(commands) => v5::ToClient::ToClientCommands(
 					commands
 						.into_iter()
 						.map(|cmd| v5::CommandWrapper {
@@ -346,7 +332,7 @@ impl ToClientMk2 {
 								index: cmd.checkpoint.index,
 							},
 							inner: match cmd.inner {
-								v6::Command::CommandStartActor(start) => {
+								v7::Command::CommandStartActor(start) => {
 									v5::Command::CommandStartActor(v5::CommandStartActor {
 										config: v5::ActorConfig {
 											name: start.config.name,
@@ -364,12 +350,12 @@ impl ToClientMk2 {
 											.collect(),
 									})
 								}
-								v6::Command::CommandStopActor => v5::Command::CommandStopActor,
+								v7::Command::CommandStopActor => v5::Command::CommandStopActor,
 							},
 						})
 						.collect(),
 				),
-				v6::ToClient::ToClientAckEvents(ack) => {
+				v7::ToClient::ToClientAckEvents(ack) => {
 					v5::ToClient::ToClientAckEvents(v5::ToClientAckEvents {
 						last_event_checkpoints: ack
 							.last_event_checkpoints
@@ -382,46 +368,30 @@ impl ToClientMk2 {
 							.collect(),
 					})
 				}
-				v6::ToClient::ToClientKvResponse(resp) => {
+				v7::ToClient::ToClientKvResponse(resp) => {
 					v5::ToClient::ToClientKvResponse(v5::ToClientKvResponse {
 						request_id: resp.request_id,
-						data: convert_kv_response_data_v6_to_v5(resp.data),
+						data: convert_kv_response_data_v7_to_v5(resp.data),
 					})
 				}
-				v6::ToClient::ToClientTunnelMessage(msg) => {
+				v7::ToClient::ToClientTunnelMessage(msg) => {
 					v5::ToClient::ToClientTunnelMessage(v5::ToClientTunnelMessage {
 						message_id: v5::MessageId {
 							gateway_id: msg.message_id.gateway_id,
 							request_id: msg.message_id.request_id,
 							message_index: msg.message_id.message_index,
 						},
-						message_kind: convert_to_client_tunnel_message_kind_v6_to_v5(
+						message_kind: convert_to_client_tunnel_message_kind_v7_to_v5(
 							msg.message_kind,
 						),
 					})
 				}
-				v6::ToClient::ToClientPing(ping) => {
+				v7::ToClient::ToClientPing(ping) => {
 					v5::ToClient::ToClientPing(v5::ToClientPing { ts: ping.ts })
 				}
 			};
 
 			Ok(ToClientMk2::V5(inner))
-		} else {
-			bail!("unexpected version");
-		}
-	}
-
-	fn v6_to_v7(self) -> Result<Self> {
-		if let ToClientMk2::V6(x) = self {
-			Ok(ToClientMk2::V7(convert_wire_compatible(x)?))
-		} else {
-			bail!("unexpected version");
-		}
-	}
-
-	fn v7_to_v6(self) -> Result<Self> {
-		if let ToClientMk2::V7(x) = self {
-			Ok(ToClientMk2::V6(convert_wire_compatible(x)?))
 		} else {
 			bail!("unexpected version");
 		}
@@ -684,18 +654,93 @@ impl ToServerMk2 {
 	fn v6_to_v7(self) -> Result<Self> {
 		if let ToServerMk2::V6(x) = self {
 			let inner = match x {
-				v6::ToServer::ToServerInit(init) => {
-					v7::ToServer::ToServerInit(convert_wire_compatible(init)?)
-				}
-				v6::ToServer::ToServerEvents(events) => {
-					v7::ToServer::ToServerEvents(convert_wire_compatible(events)?)
-				}
+				v6::ToServer::ToServerInit(init) => v7::ToServer::ToServerInit(v7::ToServerInit {
+					name: init.name,
+					version: init.version,
+					total_slots: init.total_slots,
+					prepopulate_actor_names: init.prepopulate_actor_names.map(|map| {
+						map.into_iter()
+							.map(|(k, v)| {
+								(
+									k,
+									v7::ActorName {
+										metadata: v.metadata,
+									},
+								)
+							})
+							.collect()
+					}),
+					metadata: init.metadata,
+				}),
+				v6::ToServer::ToServerEvents(events) => v7::ToServer::ToServerEvents(
+					events
+						.into_iter()
+						.map(|event| v7::EventWrapper {
+							checkpoint: v7::ActorCheckpoint {
+								actor_id: event.checkpoint.actor_id,
+								generation: event.checkpoint.generation,
+								index: event.checkpoint.index,
+							},
+							inner: match event.inner {
+								v6::Event::EventActorIntent(intent) => {
+									v7::Event::EventActorIntent(v7::EventActorIntent {
+										intent: match intent.intent {
+											v6::ActorIntent::ActorIntentSleep => {
+												v7::ActorIntent::ActorIntentSleep
+											}
+											v6::ActorIntent::ActorIntentStop => {
+												v7::ActorIntent::ActorIntentStop
+											}
+										},
+									})
+								}
+								v6::Event::EventActorStateUpdate(state) => {
+									v7::Event::EventActorStateUpdate(v7::EventActorStateUpdate {
+										state: match state.state {
+											v6::ActorState::ActorStateRunning => {
+												v7::ActorState::ActorStateRunning
+											}
+											v6::ActorState::ActorStateStopped(stopped) => {
+												v7::ActorState::ActorStateStopped(
+													v7::ActorStateStopped {
+														code: match stopped.code {
+															v6::StopCode::Ok => v7::StopCode::Ok,
+															v6::StopCode::Error => {
+																v7::StopCode::Error
+															}
+														},
+														message: stopped.message,
+													},
+												)
+											}
+										},
+									})
+								}
+								v6::Event::EventActorSetAlarm(alarm) => {
+									v7::Event::EventActorSetAlarm(v7::EventActorSetAlarm {
+										alarm_ts: alarm.alarm_ts,
+									})
+								}
+							},
+						})
+						.collect(),
+				),
 				v6::ToServer::ToServerAckCommands(ack) => {
-					v7::ToServer::ToServerAckCommands(convert_wire_compatible(ack)?)
+					v7::ToServer::ToServerAckCommands(v7::ToServerAckCommands {
+						last_command_checkpoints: ack
+							.last_command_checkpoints
+							.into_iter()
+							.map(|cp| v7::ActorCheckpoint {
+								actor_id: cp.actor_id,
+								generation: cp.generation,
+								index: cp.index,
+							})
+							.collect(),
+					})
 				}
 				v6::ToServer::ToServerStopping => v7::ToServer::ToServerStopping,
 				v6::ToServer::ToServerPong(pong) => {
-					v7::ToServer::ToServerPong(convert_wire_compatible(pong)?)
+					v7::ToServer::ToServerPong(v7::ToServerPong { ts: pong.ts })
 				}
 				v6::ToServer::ToServerKvRequest(req) => {
 					v7::ToServer::ToServerKvRequest(v7::ToServerKvRequest {
@@ -705,7 +750,65 @@ impl ToServerMk2 {
 					})
 				}
 				v6::ToServer::ToServerTunnelMessage(msg) => {
-					v7::ToServer::ToServerTunnelMessage(convert_wire_compatible(msg)?)
+					v7::ToServer::ToServerTunnelMessage(v7::ToServerTunnelMessage {
+						message_id: v7::MessageId {
+							gateway_id: msg.message_id.gateway_id,
+							request_id: msg.message_id.request_id,
+							message_index: msg.message_id.message_index,
+						},
+						message_kind: match msg.message_kind {
+							v6::ToServerTunnelMessageKind::ToServerResponseStart(resp) => {
+								v7::ToServerTunnelMessageKind::ToServerResponseStart(
+									v7::ToServerResponseStart {
+										status: resp.status,
+										headers: resp.headers,
+										body: resp.body,
+										stream: resp.stream,
+									},
+								)
+							}
+							v6::ToServerTunnelMessageKind::ToServerResponseChunk(chunk) => {
+								v7::ToServerTunnelMessageKind::ToServerResponseChunk(
+									v7::ToServerResponseChunk {
+										body: chunk.body,
+										finish: chunk.finish,
+									},
+								)
+							}
+							v6::ToServerTunnelMessageKind::ToServerResponseAbort => {
+								v7::ToServerTunnelMessageKind::ToServerResponseAbort
+							}
+							v6::ToServerTunnelMessageKind::ToServerWebSocketOpen(open) => {
+								v7::ToServerTunnelMessageKind::ToServerWebSocketOpen(
+									v7::ToServerWebSocketOpen {
+										can_hibernate: open.can_hibernate,
+									},
+								)
+							}
+							v6::ToServerTunnelMessageKind::ToServerWebSocketMessage(message) => {
+								v7::ToServerTunnelMessageKind::ToServerWebSocketMessage(
+									v7::ToServerWebSocketMessage {
+										data: message.data,
+										binary: message.binary,
+									},
+								)
+							}
+							v6::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(ack) => {
+								v7::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(
+									v7::ToServerWebSocketMessageAck { index: ack.index },
+								)
+							}
+							v6::ToServerTunnelMessageKind::ToServerWebSocketClose(close) => {
+								v7::ToServerTunnelMessageKind::ToServerWebSocketClose(
+									v7::ToServerWebSocketClose {
+										code: close.code,
+										reason: close.reason,
+										hibernate: close.hibernate,
+									},
+								)
+							}
+						},
+					})
 				}
 			};
 
@@ -718,18 +821,93 @@ impl ToServerMk2 {
 	fn v7_to_v6(self) -> Result<Self> {
 		if let ToServerMk2::V7(x) = self {
 			let inner = match x {
-				v7::ToServer::ToServerInit(init) => {
-					v6::ToServer::ToServerInit(convert_wire_compatible(init)?)
-				}
-				v7::ToServer::ToServerEvents(events) => {
-					v6::ToServer::ToServerEvents(convert_wire_compatible(events)?)
-				}
+				v7::ToServer::ToServerInit(init) => v6::ToServer::ToServerInit(v6::ToServerInit {
+					name: init.name,
+					version: init.version,
+					total_slots: init.total_slots,
+					prepopulate_actor_names: init.prepopulate_actor_names.map(|map| {
+						map.into_iter()
+							.map(|(k, v)| {
+								(
+									k,
+									v6::ActorName {
+										metadata: v.metadata,
+									},
+								)
+							})
+							.collect()
+					}),
+					metadata: init.metadata,
+				}),
+				v7::ToServer::ToServerEvents(events) => v6::ToServer::ToServerEvents(
+					events
+						.into_iter()
+						.map(|event| v6::EventWrapper {
+							checkpoint: v6::ActorCheckpoint {
+								actor_id: event.checkpoint.actor_id,
+								generation: event.checkpoint.generation,
+								index: event.checkpoint.index,
+							},
+							inner: match event.inner {
+								v7::Event::EventActorIntent(intent) => {
+									v6::Event::EventActorIntent(v6::EventActorIntent {
+										intent: match intent.intent {
+											v7::ActorIntent::ActorIntentSleep => {
+												v6::ActorIntent::ActorIntentSleep
+											}
+											v7::ActorIntent::ActorIntentStop => {
+												v6::ActorIntent::ActorIntentStop
+											}
+										},
+									})
+								}
+								v7::Event::EventActorStateUpdate(state) => {
+									v6::Event::EventActorStateUpdate(v6::EventActorStateUpdate {
+										state: match state.state {
+											v7::ActorState::ActorStateRunning => {
+												v6::ActorState::ActorStateRunning
+											}
+											v7::ActorState::ActorStateStopped(stopped) => {
+												v6::ActorState::ActorStateStopped(
+													v6::ActorStateStopped {
+														code: match stopped.code {
+															v7::StopCode::Ok => v6::StopCode::Ok,
+															v7::StopCode::Error => {
+																v6::StopCode::Error
+															}
+														},
+														message: stopped.message,
+													},
+												)
+											}
+										},
+									})
+								}
+								v7::Event::EventActorSetAlarm(alarm) => {
+									v6::Event::EventActorSetAlarm(v6::EventActorSetAlarm {
+										alarm_ts: alarm.alarm_ts,
+									})
+								}
+							},
+						})
+						.collect(),
+				),
 				v7::ToServer::ToServerAckCommands(ack) => {
-					v6::ToServer::ToServerAckCommands(convert_wire_compatible(ack)?)
+					v6::ToServer::ToServerAckCommands(v6::ToServerAckCommands {
+						last_command_checkpoints: ack
+							.last_command_checkpoints
+							.into_iter()
+							.map(|cp| v6::ActorCheckpoint {
+								actor_id: cp.actor_id,
+								generation: cp.generation,
+								index: cp.index,
+							})
+							.collect(),
+					})
 				}
 				v7::ToServer::ToServerStopping => v6::ToServer::ToServerStopping,
 				v7::ToServer::ToServerPong(pong) => {
-					v6::ToServer::ToServerPong(convert_wire_compatible(pong)?)
+					v6::ToServer::ToServerPong(v6::ToServerPong { ts: pong.ts })
 				}
 				v7::ToServer::ToServerKvRequest(req) => {
 					v6::ToServer::ToServerKvRequest(v6::ToServerKvRequest {
@@ -739,7 +917,65 @@ impl ToServerMk2 {
 					})
 				}
 				v7::ToServer::ToServerTunnelMessage(msg) => {
-					v6::ToServer::ToServerTunnelMessage(convert_wire_compatible(msg)?)
+					v6::ToServer::ToServerTunnelMessage(v6::ToServerTunnelMessage {
+						message_id: v6::MessageId {
+							gateway_id: msg.message_id.gateway_id,
+							request_id: msg.message_id.request_id,
+							message_index: msg.message_id.message_index,
+						},
+						message_kind: match msg.message_kind {
+							v7::ToServerTunnelMessageKind::ToServerResponseStart(resp) => {
+								v6::ToServerTunnelMessageKind::ToServerResponseStart(
+									v6::ToServerResponseStart {
+										status: resp.status,
+										headers: resp.headers,
+										body: resp.body,
+										stream: resp.stream,
+									},
+								)
+							}
+							v7::ToServerTunnelMessageKind::ToServerResponseChunk(chunk) => {
+								v6::ToServerTunnelMessageKind::ToServerResponseChunk(
+									v6::ToServerResponseChunk {
+										body: chunk.body,
+										finish: chunk.finish,
+									},
+								)
+							}
+							v7::ToServerTunnelMessageKind::ToServerResponseAbort => {
+								v6::ToServerTunnelMessageKind::ToServerResponseAbort
+							}
+							v7::ToServerTunnelMessageKind::ToServerWebSocketOpen(open) => {
+								v6::ToServerTunnelMessageKind::ToServerWebSocketOpen(
+									v6::ToServerWebSocketOpen {
+										can_hibernate: open.can_hibernate,
+									},
+								)
+							}
+							v7::ToServerTunnelMessageKind::ToServerWebSocketMessage(message) => {
+								v6::ToServerTunnelMessageKind::ToServerWebSocketMessage(
+									v6::ToServerWebSocketMessage {
+										data: message.data,
+										binary: message.binary,
+									},
+								)
+							}
+							v7::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(ack) => {
+								v6::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(
+									v6::ToServerWebSocketMessageAck { index: ack.index },
+								)
+							}
+							v7::ToServerTunnelMessageKind::ToServerWebSocketClose(close) => {
+								v6::ToServerTunnelMessageKind::ToServerWebSocketClose(
+									v6::ToServerWebSocketClose {
+										code: close.code,
+										reason: close.reason,
+										hibernate: close.hibernate,
+									},
+								)
+							}
+						},
+					})
 				}
 			};
 
@@ -752,7 +988,6 @@ impl ToServerMk2 {
 
 pub enum ToRunnerMk2 {
 	V4(v4::ToRunner),
-	V6(v6::ToRunner),
 	V7(v7::ToRunner),
 }
 
@@ -774,9 +1009,7 @@ impl OwnedVersionedData for ToRunnerMk2 {
 	fn deserialize_version(payload: &[u8], version: u16) -> Result<Self> {
 		match version {
 			4 => Ok(ToRunnerMk2::V4(serde_bare::from_slice(payload)?)),
-			// v5 and v6 have the same ToRunner binary format
-			5 | 6 => Ok(ToRunnerMk2::V6(serde_bare::from_slice(payload)?)),
-			7 => Ok(ToRunnerMk2::V7(serde_bare::from_slice(payload)?)),
+			5 | 6 | 7 => Ok(ToRunnerMk2::V7(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -784,37 +1017,34 @@ impl OwnedVersionedData for ToRunnerMk2 {
 	fn serialize_version(self, _version: u16) -> Result<Vec<u8>> {
 		match self {
 			ToRunnerMk2::V4(data) => serde_bare::to_vec(&data).map_err(Into::into),
-			ToRunnerMk2::V6(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ToRunnerMk2::V7(data) => serde_bare::to_vec(&data).map_err(Into::into),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		// No changes between v1 and v4, no changes between v5 and v6
-		vec![Ok, Ok, Ok, Self::v4_to_v6, Ok, Self::v6_to_v7]
+		vec![Ok, Ok, Ok, Self::v4_to_v7, Ok, Ok]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		// No changes between v1 and v4, no changes between v5 and v6
-		vec![Self::v7_to_v6, Ok, Self::v6_to_v4, Ok, Ok, Ok]
+		vec![Ok, Ok, Self::v7_to_v4, Ok, Ok, Ok]
 	}
 }
 
 impl ToRunnerMk2 {
-	fn v4_to_v6(self) -> Result<Self> {
+	fn v4_to_v7(self) -> Result<Self> {
 		if let ToRunnerMk2::V4(x) = self {
 			let inner = match x {
-				v4::ToRunner::ToRunnerPing(ping) => v6::ToRunner::ToRunnerPing(v6::ToRunnerPing {
+				v4::ToRunner::ToRunnerPing(ping) => v7::ToRunner::ToRunnerPing(v7::ToRunnerPing {
 					gateway_id: ping.gateway_id,
 					request_id: ping.request_id,
 					ts: ping.ts,
 				}),
-				v4::ToRunner::ToRunnerClose => v6::ToRunner::ToRunnerClose,
-				v4::ToRunner::ToClientCommands(commands) => v6::ToRunner::ToClientCommands(
+				v4::ToRunner::ToRunnerClose => v7::ToRunner::ToRunnerClose,
+				v4::ToRunner::ToClientCommands(commands) => v7::ToRunner::ToClientCommands(
 					commands
 						.into_iter()
-						.map(|cmd| v6::CommandWrapper {
-							checkpoint: v6::ActorCheckpoint {
+						.map(|cmd| v7::CommandWrapper {
+							checkpoint: v7::ActorCheckpoint {
 								actor_id: cmd.checkpoint.actor_id,
 								generation: match &cmd.inner {
 									v4::Command::CommandStartActor(start) => start.generation,
@@ -824,8 +1054,8 @@ impl ToRunnerMk2 {
 							},
 							inner: match cmd.inner {
 								v4::Command::CommandStartActor(start) => {
-									v6::Command::CommandStartActor(v6::CommandStartActor {
-										config: v6::ActorConfig {
+									v7::Command::CommandStartActor(v7::CommandStartActor {
+										config: v7::ActorConfig {
 											name: start.config.name,
 											key: start.config.key,
 											create_ts: start.config.create_ts,
@@ -834,24 +1064,24 @@ impl ToRunnerMk2 {
 										hibernating_requests: start
 											.hibernating_requests
 											.into_iter()
-											.map(|req| v6::HibernatingRequest {
+											.map(|req| v7::HibernatingRequest {
 												gateway_id: req.gateway_id,
 												request_id: req.request_id,
 											})
 											.collect(),
 									})
 								}
-								v4::Command::CommandStopActor(_) => v6::Command::CommandStopActor,
+								v4::Command::CommandStopActor(_) => v7::Command::CommandStopActor,
 							},
 						})
 						.collect(),
 				),
 				v4::ToRunner::ToClientAckEvents(ack) => {
-					v6::ToRunner::ToClientAckEvents(v6::ToClientAckEvents {
+					v7::ToRunner::ToClientAckEvents(v7::ToClientAckEvents {
 						last_event_checkpoints: ack
 							.last_event_checkpoints
 							.into_iter()
-							.map(|cp| v6::ActorCheckpoint {
+							.map(|cp| v7::ActorCheckpoint {
 								actor_id: cp.actor_id,
 								generation: 0, // Unknown in v4, use default
 								index: cp.index,
@@ -860,35 +1090,35 @@ impl ToRunnerMk2 {
 					})
 				}
 				v4::ToRunner::ToClientTunnelMessage(msg) => {
-					v6::ToRunner::ToClientTunnelMessage(v6::ToClientTunnelMessage {
-						message_id: v6::MessageId {
+					v7::ToRunner::ToClientTunnelMessage(v7::ToClientTunnelMessage {
+						message_id: v7::MessageId {
 							gateway_id: msg.message_id.gateway_id,
 							request_id: msg.message_id.request_id,
 							message_index: msg.message_id.message_index,
 						},
-						message_kind: convert_to_client_tunnel_message_kind_v4_to_v6(
+						message_kind: convert_to_client_tunnel_message_kind_v4_to_v7(
 							msg.message_kind,
 						),
 					})
 				}
 			};
 
-			Ok(ToRunnerMk2::V6(inner))
+			Ok(ToRunnerMk2::V7(inner))
 		} else {
 			bail!("unexpected version");
 		}
 	}
 
-	fn v6_to_v4(self) -> Result<Self> {
-		if let ToRunnerMk2::V6(x) = self {
+	fn v7_to_v4(self) -> Result<Self> {
+		if let ToRunnerMk2::V7(x) = self {
 			let inner = match x {
-				v6::ToRunner::ToRunnerPing(ping) => v4::ToRunner::ToRunnerPing(v4::ToRunnerPing {
+				v7::ToRunner::ToRunnerPing(ping) => v4::ToRunner::ToRunnerPing(v4::ToRunnerPing {
 					gateway_id: ping.gateway_id,
 					request_id: ping.request_id,
 					ts: ping.ts,
 				}),
-				v6::ToRunner::ToRunnerClose => v4::ToRunner::ToRunnerClose,
-				v6::ToRunner::ToClientCommands(commands) => v4::ToRunner::ToClientCommands(
+				v7::ToRunner::ToRunnerClose => v4::ToRunner::ToRunnerClose,
+				v7::ToRunner::ToClientCommands(commands) => v4::ToRunner::ToClientCommands(
 					commands
 						.into_iter()
 						.map(|cmd| v4::CommandWrapper {
@@ -897,7 +1127,7 @@ impl ToRunnerMk2 {
 								index: cmd.checkpoint.index,
 							},
 							inner: match cmd.inner {
-								v6::Command::CommandStartActor(start) => {
+								v7::Command::CommandStartActor(start) => {
 									v4::Command::CommandStartActor(v4::CommandStartActor {
 										generation: cmd.checkpoint.generation,
 										config: v4::ActorConfig {
@@ -916,7 +1146,7 @@ impl ToRunnerMk2 {
 											.collect(),
 									})
 								}
-								v6::Command::CommandStopActor => {
+								v7::Command::CommandStopActor => {
 									v4::Command::CommandStopActor(v4::CommandStopActor {
 										generation: cmd.checkpoint.generation,
 									})
@@ -925,7 +1155,7 @@ impl ToRunnerMk2 {
 						})
 						.collect(),
 				),
-				v6::ToRunner::ToClientAckEvents(ack) => {
+				v7::ToRunner::ToClientAckEvents(ack) => {
 					v4::ToRunner::ToClientAckEvents(v4::ToClientAckEvents {
 						last_event_checkpoints: ack
 							.last_event_checkpoints
@@ -937,14 +1167,14 @@ impl ToRunnerMk2 {
 							.collect(),
 					})
 				}
-				v6::ToRunner::ToClientTunnelMessage(msg) => {
+				v7::ToRunner::ToClientTunnelMessage(msg) => {
 					v4::ToRunner::ToClientTunnelMessage(v4::ToClientTunnelMessage {
 						message_id: v4::MessageId {
 							gateway_id: msg.message_id.gateway_id,
 							request_id: msg.message_id.request_id,
 							message_index: msg.message_id.message_index,
 						},
-						message_kind: convert_to_client_tunnel_message_kind_v6_to_v4(
+						message_kind: convert_to_client_tunnel_message_kind_v7_to_v4(
 							msg.message_kind,
 						),
 					})
@@ -952,22 +1182,6 @@ impl ToRunnerMk2 {
 			};
 
 			Ok(ToRunnerMk2::V4(inner))
-		} else {
-			bail!("unexpected version");
-		}
-	}
-
-	fn v6_to_v7(self) -> Result<Self> {
-		if let ToRunnerMk2::V6(x) = self {
-			Ok(ToRunnerMk2::V7(convert_wire_compatible(x)?))
-		} else {
-			bail!("unexpected version");
-		}
-	}
-
-	fn v7_to_v6(self) -> Result<Self> {
-		if let ToRunnerMk2::V7(x) = self {
-			Ok(ToRunnerMk2::V6(convert_wire_compatible(x)?))
 		} else {
 			bail!("unexpected version");
 		}
@@ -1704,7 +1918,6 @@ impl OwnedVersionedData for ToRunner {
 
 pub enum ToGateway {
 	V3(v3::ToGateway),
-	V6(v6::ToGateway),
 	V7(v7::ToGateway),
 }
 
@@ -1727,9 +1940,7 @@ impl OwnedVersionedData for ToGateway {
 	fn deserialize_version(payload: &[u8], version: u16) -> Result<Self> {
 		match version {
 			1 | 2 | 3 => Ok(ToGateway::V3(serde_bare::from_slice(payload)?)),
-			// v4, v5, and v6 have the same ToGateway binary format
-			4 | 5 | 6 => Ok(ToGateway::V6(serde_bare::from_slice(payload)?)),
-			7 => Ok(ToGateway::V7(serde_bare::from_slice(payload)?)),
+			4 | 5 | 6 | 7 => Ok(ToGateway::V7(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -1737,62 +1948,59 @@ impl OwnedVersionedData for ToGateway {
 	fn serialize_version(self, _version: u16) -> Result<Vec<u8>> {
 		match self {
 			ToGateway::V3(data) => serde_bare::to_vec(&data).map_err(Into::into),
-			ToGateway::V6(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ToGateway::V7(data) => serde_bare::to_vec(&data).map_err(Into::into),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		// No changes between v1-v6 but we need a converter to bridge mk1 to mk2.
-		vec![Ok, Ok, Self::v3_to_v6, Ok, Ok, Self::v6_to_v7]
+		vec![Ok, Ok, Self::v3_to_v7, Ok, Ok, Ok]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		// No changes between v1-v6 but we need a converter to bridge mk2 to mk1.
-		vec![Self::v7_to_v6, Ok, Ok, Self::v6_to_v3, Ok, Ok]
+		vec![Ok, Ok, Ok, Self::v7_to_v3, Ok, Ok]
 	}
 }
 
 impl ToGateway {
-	pub fn v3_to_v6(self) -> Result<Self> {
+	pub fn v3_to_v7(self) -> Result<Self> {
 		if let ToGateway::V3(x) = self {
 			let inner = match x {
 				v3::ToGateway::ToGatewayPong(pong) => {
-					v6::ToGateway::ToGatewayPong(v6::ToGatewayPong {
+					v7::ToGateway::ToGatewayPong(v7::ToGatewayPong {
 						request_id: pong.request_id,
 						ts: pong.ts,
 					})
 				}
 				v3::ToGateway::ToServerTunnelMessage(msg) => {
-					v6::ToGateway::ToServerTunnelMessage(v6::ToServerTunnelMessage {
-						message_id: v6::MessageId {
+					v7::ToGateway::ToServerTunnelMessage(v7::ToServerTunnelMessage {
+						message_id: v7::MessageId {
 							gateway_id: msg.message_id.gateway_id,
 							request_id: msg.message_id.request_id,
 							message_index: msg.message_id.message_index,
 						},
-						message_kind: convert_to_server_tunnel_message_kind_v3_to_v4(
-							msg.message_kind,
+						message_kind: convert_to_server_tunnel_message_kind_v6_to_v7(
+							convert_to_server_tunnel_message_kind_v3_to_v4(msg.message_kind),
 						),
 					})
 				}
 			};
 
-			Ok(ToGateway::V6(inner))
+			Ok(ToGateway::V7(inner))
 		} else {
 			bail!("unexpected version");
 		}
 	}
 
-	fn v6_to_v3(self) -> Result<Self> {
-		if let ToGateway::V6(x) = self {
+	fn v7_to_v3(self) -> Result<Self> {
+		if let ToGateway::V7(x) = self {
 			let inner = match x {
-				v6::ToGateway::ToGatewayPong(pong) => {
+				v7::ToGateway::ToGatewayPong(pong) => {
 					v3::ToGateway::ToGatewayPong(v3::ToGatewayPong {
 						request_id: pong.request_id,
 						ts: pong.ts,
 					})
 				}
-				v6::ToGateway::ToServerTunnelMessage(msg) => {
+				v7::ToGateway::ToServerTunnelMessage(msg) => {
 					v3::ToGateway::ToServerTunnelMessage(v3::ToServerTunnelMessage {
 						message_id: v3::MessageId {
 							gateway_id: msg.message_id.gateway_id,
@@ -1800,7 +2008,7 @@ impl ToGateway {
 							message_index: msg.message_id.message_index,
 						},
 						message_kind: convert_to_server_tunnel_message_kind_v4_to_v3(
-							msg.message_kind,
+							convert_to_server_tunnel_message_kind_v7_to_v6(msg.message_kind),
 						)?,
 					})
 				}
@@ -1811,27 +2019,10 @@ impl ToGateway {
 			bail!("unexpected version");
 		}
 	}
-
-	fn v6_to_v7(self) -> Result<Self> {
-		if let ToGateway::V6(x) = self {
-			Ok(ToGateway::V7(convert_wire_compatible(x)?))
-		} else {
-			bail!("unexpected version");
-		}
-	}
-
-	fn v7_to_v6(self) -> Result<Self> {
-		if let ToGateway::V7(x) = self {
-			Ok(ToGateway::V6(convert_wire_compatible(x)?))
-		} else {
-			bail!("unexpected version");
-		}
-	}
 }
 
 pub enum ToServerlessServer {
 	V3(v3::ToServerlessServer),
-	V6(v6::ToServerlessServer),
 	V7(v7::ToServerlessServer),
 }
 
@@ -1854,9 +2045,7 @@ impl OwnedVersionedData for ToServerlessServer {
 	fn deserialize_version(payload: &[u8], version: u16) -> Result<Self> {
 		match version {
 			1 | 2 | 3 => Ok(ToServerlessServer::V3(serde_bare::from_slice(payload)?)),
-			// v4, v5, and v6 have the same ToServerlessServer binary format
-			4 | 5 | 6 => Ok(ToServerlessServer::V6(serde_bare::from_slice(payload)?)),
-			7 => Ok(ToServerlessServer::V7(serde_bare::from_slice(payload)?)),
+			4 | 5 | 6 | 7 => Ok(ToServerlessServer::V7(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -1864,44 +2053,41 @@ impl OwnedVersionedData for ToServerlessServer {
 	fn serialize_version(self, _version: u16) -> Result<Vec<u8>> {
 		match self {
 			ToServerlessServer::V3(data) => serde_bare::to_vec(&data).map_err(Into::into),
-			ToServerlessServer::V6(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ToServerlessServer::V7(data) => serde_bare::to_vec(&data).map_err(Into::into),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		// No changes between v1-v3, v4-v6
-		vec![Ok, Ok, Self::v3_to_v6, Ok, Ok, Self::v6_to_v7]
+		vec![Ok, Ok, Self::v3_to_v7, Ok, Ok, Ok]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		// No changes between v1-v3, v4-v6
-		vec![Self::v7_to_v6, Ok, Ok, Self::v6_to_v3, Ok, Ok]
+		vec![Ok, Ok, Ok, Self::v7_to_v3, Ok, Ok]
 	}
 }
 
 impl ToServerlessServer {
-	fn v3_to_v6(self) -> Result<Self> {
+	fn v3_to_v7(self) -> Result<Self> {
 		if let ToServerlessServer::V3(x) = self {
 			let inner = match x {
 				v3::ToServerlessServer::ToServerlessServerInit(init) => {
-					v6::ToServerlessServer::ToServerlessServerInit(v6::ToServerlessServerInit {
+					v7::ToServerlessServer::ToServerlessServerInit(v7::ToServerlessServerInit {
 						runner_id: init.runner_id,
 						runner_protocol_version: PROTOCOL_MK1_VERSION,
 					})
 				}
 			};
 
-			Ok(ToServerlessServer::V6(inner))
+			Ok(ToServerlessServer::V7(inner))
 		} else {
 			bail!("unexpected version");
 		}
 	}
 
-	fn v6_to_v3(self) -> Result<Self> {
-		if let ToServerlessServer::V6(x) = self {
+	fn v7_to_v3(self) -> Result<Self> {
+		if let ToServerlessServer::V7(x) = self {
 			let inner = match x {
-				v6::ToServerlessServer::ToServerlessServerInit(init) => {
+				v7::ToServerlessServer::ToServerlessServerInit(init) => {
 					v3::ToServerlessServer::ToServerlessServerInit(v3::ToServerlessServerInit {
 						runner_id: init.runner_id,
 					})
@@ -1913,27 +2099,10 @@ impl ToServerlessServer {
 			bail!("unexpected version");
 		}
 	}
-
-	fn v6_to_v7(self) -> Result<Self> {
-		if let ToServerlessServer::V6(x) = self {
-			Ok(ToServerlessServer::V7(convert_wire_compatible(x)?))
-		} else {
-			bail!("unexpected version");
-		}
-	}
-
-	fn v7_to_v6(self) -> Result<Self> {
-		if let ToServerlessServer::V7(x) = self {
-			Ok(ToServerlessServer::V6(convert_wire_compatible(x)?))
-		} else {
-			bail!("unexpected version");
-		}
-	}
 }
 
 pub enum ActorCommandKeyData {
 	V4(v4::ActorCommandKeyData),
-	V6(v6::ActorCommandKeyData),
 	V7(v7::ActorCommandKeyData),
 }
 
@@ -1955,9 +2124,7 @@ impl OwnedVersionedData for ActorCommandKeyData {
 	fn deserialize_version(payload: &[u8], version: u16) -> Result<Self> {
 		match version {
 			4 => Ok(ActorCommandKeyData::V4(serde_bare::from_slice(payload)?)),
-			// v5 and v6 have the same ActorCommandKeyData binary format
-			5 | 6 => Ok(ActorCommandKeyData::V6(serde_bare::from_slice(payload)?)),
-			7 => Ok(ActorCommandKeyData::V7(serde_bare::from_slice(payload)?)),
+			5 | 6 | 7 => Ok(ActorCommandKeyData::V7(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -1965,29 +2132,26 @@ impl OwnedVersionedData for ActorCommandKeyData {
 	fn serialize_version(self, _version: u16) -> Result<Vec<u8>> {
 		match self {
 			ActorCommandKeyData::V4(data) => serde_bare::to_vec(&data).map_err(Into::into),
-			ActorCommandKeyData::V6(data) => serde_bare::to_vec(&data).map_err(Into::into),
 			ActorCommandKeyData::V7(data) => serde_bare::to_vec(&data).map_err(Into::into),
 		}
 	}
 
 	fn deserialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		// No changes between v1 and v4, no changes between v5 and v6
-		vec![Ok, Ok, Ok, Self::v4_to_v6, Ok, Self::v6_to_v7]
+		vec![Ok, Ok, Ok, Self::v4_to_v7, Ok, Ok]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
-		// No changes between v1 and v4, no changes between v5 and v6
-		vec![Self::v7_to_v6, Ok, Self::v6_to_v4, Ok, Ok, Ok]
+		vec![Ok, Ok, Self::v7_to_v4, Ok, Ok, Ok]
 	}
 }
 
 impl ActorCommandKeyData {
-	fn v4_to_v6(self) -> Result<Self> {
+	fn v4_to_v7(self) -> Result<Self> {
 		if let ActorCommandKeyData::V4(x) = self {
 			let inner = match x {
 				v4::ActorCommandKeyData::CommandStartActor(start) => {
-					v6::ActorCommandKeyData::CommandStartActor(v6::CommandStartActor {
-						config: v6::ActorConfig {
+					v7::ActorCommandKeyData::CommandStartActor(v7::CommandStartActor {
+						config: v7::ActorConfig {
 							name: start.config.name,
 							key: start.config.key,
 							create_ts: start.config.create_ts,
@@ -1996,7 +2160,7 @@ impl ActorCommandKeyData {
 						hibernating_requests: start
 							.hibernating_requests
 							.into_iter()
-							.map(|req| v6::HibernatingRequest {
+							.map(|req| v7::HibernatingRequest {
 								gateway_id: req.gateway_id,
 								request_id: req.request_id,
 							})
@@ -2004,21 +2168,21 @@ impl ActorCommandKeyData {
 					})
 				}
 				v4::ActorCommandKeyData::CommandStopActor(_) => {
-					v6::ActorCommandKeyData::CommandStopActor
+					v7::ActorCommandKeyData::CommandStopActor
 				}
 			};
 
-			Ok(ActorCommandKeyData::V6(inner))
+			Ok(ActorCommandKeyData::V7(inner))
 		} else {
 			bail!("unexpected version");
 		}
 	}
 
-	fn v6_to_v4(self) -> Result<Self> {
-		if let ActorCommandKeyData::V6(x) = self {
+	fn v7_to_v4(self) -> Result<Self> {
+		if let ActorCommandKeyData::V7(x) = self {
 			// Since v4 commands have generation but v6 doesn't, use generation 0 as a placeholder
 			let inner = match x {
-				v6::ActorCommandKeyData::CommandStartActor(start) => {
+				v7::ActorCommandKeyData::CommandStartActor(start) => {
 					v4::ActorCommandKeyData::CommandStartActor(v4::CommandStartActor {
 						generation: 0, // Lost during conversion
 						config: v4::ActorConfig {
@@ -2037,7 +2201,7 @@ impl ActorCommandKeyData {
 							.collect(),
 					})
 				}
-				v6::ActorCommandKeyData::CommandStopActor => {
+				v7::ActorCommandKeyData::CommandStopActor => {
 					v4::ActorCommandKeyData::CommandStopActor(v4::CommandStopActor {
 						generation: 0, // Lost during conversion
 					})
@@ -2045,22 +2209,6 @@ impl ActorCommandKeyData {
 			};
 
 			Ok(ActorCommandKeyData::V4(inner))
-		} else {
-			bail!("unexpected version");
-		}
-	}
-
-	fn v6_to_v7(self) -> Result<Self> {
-		if let ActorCommandKeyData::V6(x) = self {
-			Ok(ActorCommandKeyData::V7(convert_wire_compatible(x)?))
-		} else {
-			bail!("unexpected version");
-		}
-	}
-
-	fn v7_to_v6(self) -> Result<Self> {
-		if let ActorCommandKeyData::V7(x) = self {
-			Ok(ActorCommandKeyData::V6(convert_wire_compatible(x)?))
 		} else {
 			bail!("unexpected version");
 		}
@@ -3798,6 +3946,98 @@ fn convert_kv_metadata_v6_to_v5(metadata: v6::KvMetadata) -> v5::KvMetadata {
 	}
 }
 
+fn convert_kv_response_data_v5_to_v7(data: v5::KvResponseData) -> v7::KvResponseData {
+	convert_kv_response_data_v6_to_v7(convert_kv_response_data_v5_to_v6(data))
+}
+
+fn convert_kv_response_data_v7_to_v5(data: v7::KvResponseData) -> v5::KvResponseData {
+	convert_kv_response_data_v6_to_v5(convert_kv_response_data_v7_to_v6(data))
+}
+
+fn convert_kv_response_data_v6_to_v7(data: v6::KvResponseData) -> v7::KvResponseData {
+	match data {
+		v6::KvResponseData::KvErrorResponse(err) => {
+			v7::KvResponseData::KvErrorResponse(v7::KvErrorResponse {
+				message: err.message,
+			})
+		}
+		v6::KvResponseData::KvGetResponse(resp) => {
+			v7::KvResponseData::KvGetResponse(v7::KvGetResponse {
+				keys: resp.keys,
+				values: resp.values,
+				metadata: resp
+					.metadata
+					.into_iter()
+					.map(convert_kv_metadata_v6_to_v7)
+					.collect(),
+			})
+		}
+		v6::KvResponseData::KvListResponse(resp) => {
+			v7::KvResponseData::KvListResponse(v7::KvListResponse {
+				keys: resp.keys,
+				values: resp.values,
+				metadata: resp
+					.metadata
+					.into_iter()
+					.map(convert_kv_metadata_v6_to_v7)
+					.collect(),
+			})
+		}
+		v6::KvResponseData::KvPutResponse => v7::KvResponseData::KvPutResponse,
+		v6::KvResponseData::KvDeleteResponse => v7::KvResponseData::KvDeleteResponse,
+		v6::KvResponseData::KvDropResponse => v7::KvResponseData::KvDropResponse,
+	}
+}
+
+fn convert_kv_response_data_v7_to_v6(data: v7::KvResponseData) -> v6::KvResponseData {
+	match data {
+		v7::KvResponseData::KvErrorResponse(err) => {
+			v6::KvResponseData::KvErrorResponse(v6::KvErrorResponse {
+				message: err.message,
+			})
+		}
+		v7::KvResponseData::KvGetResponse(resp) => {
+			v6::KvResponseData::KvGetResponse(v6::KvGetResponse {
+				keys: resp.keys,
+				values: resp.values,
+				metadata: resp
+					.metadata
+					.into_iter()
+					.map(convert_kv_metadata_v7_to_v6)
+					.collect(),
+			})
+		}
+		v7::KvResponseData::KvListResponse(resp) => {
+			v6::KvResponseData::KvListResponse(v6::KvListResponse {
+				keys: resp.keys,
+				values: resp.values,
+				metadata: resp
+					.metadata
+					.into_iter()
+					.map(convert_kv_metadata_v7_to_v6)
+					.collect(),
+			})
+		}
+		v7::KvResponseData::KvPutResponse => v6::KvResponseData::KvPutResponse,
+		v7::KvResponseData::KvDeleteResponse => v6::KvResponseData::KvDeleteResponse,
+		v7::KvResponseData::KvDropResponse => v6::KvResponseData::KvDropResponse,
+	}
+}
+
+fn convert_kv_metadata_v6_to_v7(metadata: v6::KvMetadata) -> v7::KvMetadata {
+	v7::KvMetadata {
+		version: metadata.version,
+		update_ts: metadata.update_ts,
+	}
+}
+
+fn convert_kv_metadata_v7_to_v6(metadata: v7::KvMetadata) -> v6::KvMetadata {
+	v6::KvMetadata {
+		version: metadata.version,
+		update_ts: metadata.update_ts,
+	}
+}
+
 fn convert_to_client_tunnel_message_kind_v5_to_v6(
 	kind: v5::ToClientTunnelMessageKind,
 ) -> v6::ToClientTunnelMessageKind {
@@ -3883,6 +4123,222 @@ fn convert_to_client_tunnel_message_kind_v6_to_v5(
 			v5::ToClientTunnelMessageKind::ToClientWebSocketClose(v5::ToClientWebSocketClose {
 				code: close.code,
 				reason: close.reason,
+			})
+		}
+	}
+}
+
+fn convert_to_client_tunnel_message_kind_v5_to_v7(
+	kind: v5::ToClientTunnelMessageKind,
+) -> v7::ToClientTunnelMessageKind {
+	convert_to_client_tunnel_message_kind_v6_to_v7(convert_to_client_tunnel_message_kind_v5_to_v6(
+		kind,
+	))
+}
+
+fn convert_to_client_tunnel_message_kind_v7_to_v5(
+	kind: v7::ToClientTunnelMessageKind,
+) -> v5::ToClientTunnelMessageKind {
+	convert_to_client_tunnel_message_kind_v6_to_v5(convert_to_client_tunnel_message_kind_v7_to_v6(
+		kind,
+	))
+}
+
+fn convert_to_client_tunnel_message_kind_v4_to_v7(
+	kind: v4::ToClientTunnelMessageKind,
+) -> v7::ToClientTunnelMessageKind {
+	convert_to_client_tunnel_message_kind_v6_to_v7(convert_to_client_tunnel_message_kind_v4_to_v6(
+		kind,
+	))
+}
+
+fn convert_to_client_tunnel_message_kind_v7_to_v4(
+	kind: v7::ToClientTunnelMessageKind,
+) -> v4::ToClientTunnelMessageKind {
+	convert_to_client_tunnel_message_kind_v6_to_v4(convert_to_client_tunnel_message_kind_v7_to_v6(
+		kind,
+	))
+}
+
+fn convert_to_client_tunnel_message_kind_v6_to_v7(
+	kind: v6::ToClientTunnelMessageKind,
+) -> v7::ToClientTunnelMessageKind {
+	match kind {
+		v6::ToClientTunnelMessageKind::ToClientRequestStart(req) => {
+			v7::ToClientTunnelMessageKind::ToClientRequestStart(v7::ToClientRequestStart {
+				actor_id: req.actor_id,
+				method: req.method,
+				path: req.path,
+				headers: req.headers,
+				body: req.body,
+				stream: req.stream,
+			})
+		}
+		v6::ToClientTunnelMessageKind::ToClientRequestChunk(chunk) => {
+			v7::ToClientTunnelMessageKind::ToClientRequestChunk(v7::ToClientRequestChunk {
+				body: chunk.body,
+				finish: chunk.finish,
+			})
+		}
+		v6::ToClientTunnelMessageKind::ToClientRequestAbort => {
+			v7::ToClientTunnelMessageKind::ToClientRequestAbort
+		}
+		v6::ToClientTunnelMessageKind::ToClientWebSocketOpen(ws) => {
+			v7::ToClientTunnelMessageKind::ToClientWebSocketOpen(v7::ToClientWebSocketOpen {
+				actor_id: ws.actor_id,
+				path: ws.path,
+				headers: ws.headers,
+			})
+		}
+		v6::ToClientTunnelMessageKind::ToClientWebSocketMessage(msg) => {
+			v7::ToClientTunnelMessageKind::ToClientWebSocketMessage(v7::ToClientWebSocketMessage {
+				data: msg.data,
+				binary: msg.binary,
+			})
+		}
+		v6::ToClientTunnelMessageKind::ToClientWebSocketClose(close) => {
+			v7::ToClientTunnelMessageKind::ToClientWebSocketClose(v7::ToClientWebSocketClose {
+				code: close.code,
+				reason: close.reason,
+			})
+		}
+	}
+}
+
+fn convert_to_client_tunnel_message_kind_v7_to_v6(
+	kind: v7::ToClientTunnelMessageKind,
+) -> v6::ToClientTunnelMessageKind {
+	match kind {
+		v7::ToClientTunnelMessageKind::ToClientRequestStart(req) => {
+			v6::ToClientTunnelMessageKind::ToClientRequestStart(v6::ToClientRequestStart {
+				actor_id: req.actor_id,
+				method: req.method,
+				path: req.path,
+				headers: req.headers,
+				body: req.body,
+				stream: req.stream,
+			})
+		}
+		v7::ToClientTunnelMessageKind::ToClientRequestChunk(chunk) => {
+			v6::ToClientTunnelMessageKind::ToClientRequestChunk(v6::ToClientRequestChunk {
+				body: chunk.body,
+				finish: chunk.finish,
+			})
+		}
+		v7::ToClientTunnelMessageKind::ToClientRequestAbort => {
+			v6::ToClientTunnelMessageKind::ToClientRequestAbort
+		}
+		v7::ToClientTunnelMessageKind::ToClientWebSocketOpen(ws) => {
+			v6::ToClientTunnelMessageKind::ToClientWebSocketOpen(v6::ToClientWebSocketOpen {
+				actor_id: ws.actor_id,
+				path: ws.path,
+				headers: ws.headers,
+			})
+		}
+		v7::ToClientTunnelMessageKind::ToClientWebSocketMessage(msg) => {
+			v6::ToClientTunnelMessageKind::ToClientWebSocketMessage(v6::ToClientWebSocketMessage {
+				data: msg.data,
+				binary: msg.binary,
+			})
+		}
+		v7::ToClientTunnelMessageKind::ToClientWebSocketClose(close) => {
+			v6::ToClientTunnelMessageKind::ToClientWebSocketClose(v6::ToClientWebSocketClose {
+				code: close.code,
+				reason: close.reason,
+			})
+		}
+	}
+}
+
+fn convert_to_server_tunnel_message_kind_v6_to_v7(
+	kind: v6::ToServerTunnelMessageKind,
+) -> v7::ToServerTunnelMessageKind {
+	match kind {
+		v6::ToServerTunnelMessageKind::ToServerResponseStart(resp) => {
+			v7::ToServerTunnelMessageKind::ToServerResponseStart(v7::ToServerResponseStart {
+				status: resp.status,
+				headers: resp.headers,
+				body: resp.body,
+				stream: resp.stream,
+			})
+		}
+		v6::ToServerTunnelMessageKind::ToServerResponseChunk(chunk) => {
+			v7::ToServerTunnelMessageKind::ToServerResponseChunk(v7::ToServerResponseChunk {
+				body: chunk.body,
+				finish: chunk.finish,
+			})
+		}
+		v6::ToServerTunnelMessageKind::ToServerResponseAbort => {
+			v7::ToServerTunnelMessageKind::ToServerResponseAbort
+		}
+		v6::ToServerTunnelMessageKind::ToServerWebSocketOpen(open) => {
+			v7::ToServerTunnelMessageKind::ToServerWebSocketOpen(v7::ToServerWebSocketOpen {
+				can_hibernate: open.can_hibernate,
+			})
+		}
+		v6::ToServerTunnelMessageKind::ToServerWebSocketMessage(msg) => {
+			v7::ToServerTunnelMessageKind::ToServerWebSocketMessage(v7::ToServerWebSocketMessage {
+				data: msg.data,
+				binary: msg.binary,
+			})
+		}
+		v6::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(ack) => {
+			v7::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(
+				v7::ToServerWebSocketMessageAck { index: ack.index },
+			)
+		}
+		v6::ToServerTunnelMessageKind::ToServerWebSocketClose(close) => {
+			v7::ToServerTunnelMessageKind::ToServerWebSocketClose(v7::ToServerWebSocketClose {
+				code: close.code,
+				reason: close.reason,
+				hibernate: close.hibernate,
+			})
+		}
+	}
+}
+
+fn convert_to_server_tunnel_message_kind_v7_to_v6(
+	kind: v7::ToServerTunnelMessageKind,
+) -> v6::ToServerTunnelMessageKind {
+	match kind {
+		v7::ToServerTunnelMessageKind::ToServerResponseStart(resp) => {
+			v6::ToServerTunnelMessageKind::ToServerResponseStart(v6::ToServerResponseStart {
+				status: resp.status,
+				headers: resp.headers,
+				body: resp.body,
+				stream: resp.stream,
+			})
+		}
+		v7::ToServerTunnelMessageKind::ToServerResponseChunk(chunk) => {
+			v6::ToServerTunnelMessageKind::ToServerResponseChunk(v6::ToServerResponseChunk {
+				body: chunk.body,
+				finish: chunk.finish,
+			})
+		}
+		v7::ToServerTunnelMessageKind::ToServerResponseAbort => {
+			v6::ToServerTunnelMessageKind::ToServerResponseAbort
+		}
+		v7::ToServerTunnelMessageKind::ToServerWebSocketOpen(open) => {
+			v6::ToServerTunnelMessageKind::ToServerWebSocketOpen(v6::ToServerWebSocketOpen {
+				can_hibernate: open.can_hibernate,
+			})
+		}
+		v7::ToServerTunnelMessageKind::ToServerWebSocketMessage(msg) => {
+			v6::ToServerTunnelMessageKind::ToServerWebSocketMessage(v6::ToServerWebSocketMessage {
+				data: msg.data,
+				binary: msg.binary,
+			})
+		}
+		v7::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(ack) => {
+			v6::ToServerTunnelMessageKind::ToServerWebSocketMessageAck(
+				v6::ToServerWebSocketMessageAck { index: ack.index },
+			)
+		}
+		v7::ToServerTunnelMessageKind::ToServerWebSocketClose(close) => {
+			v6::ToServerTunnelMessageKind::ToServerWebSocketClose(v6::ToServerWebSocketClose {
+				code: close.code,
+				reason: close.reason,
+				hibernate: close.hibernate,
 			})
 		}
 	}


### PR DESCRIPTION
## Description

This change replaces the fragile `convert_wire_compatible` helper (which serialized then deserialized between types) with explicit, transparent field-by-field conversions for all version transitions in the runner protocol. Wire-compatible version ranges are collapsed into single enum variants to reduce unnecessary indirection.

## Changes

- **Removed** `convert_wire_compatible` helper function that silently broke when schemas diverged
- **Added** explicit field-by-field converters for all version transitions
- **Collapsed** wire-compatible version ranges (v6/v7 for ToClient, v5/v6 for ToServer, v5/v6/v7 for ToRunner) into single enum variants
- **Added** `engine/CLAUDE.md` to document the VBARE schema migration pattern and the serialize-then-deserialize anti-pattern

## Type of change

- [x] Refactoring (internal improvement without API changes)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing

Code reviewed and builder ran successfully. All converter chains verified against wire-compatibility claims in the `.bare` schema files.