### PR TITLE
Use KV range ops in workflow, queue, and SQLite

### DIFF
--- a/engine/sdks/typescript/runner/src/mod.ts
+++ b/engine/sdks/typescript/runner/src/mod.ts
@@ -1452,6 +1452,8 @@ export class Runner {
 		actorId: string,
 		start: Uint8Array,
 		end: Uint8Array,
+		// Internal-only protocol knob. Public RivetKit APIs use half-open ranges
+		// and should not surface inclusive end semantics as a user-facing option.
 		exclusive?: boolean,
 		options?: KvListOptions,
 	): Promise<[Uint8Array, Uint8Array][]> {

--- a/rivetkit-typescript/packages/rivetkit/src/actor/instance/kv.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/instance/kv.ts
@@ -23,6 +23,10 @@ type KvValueOptions<T extends KvValueType = "text"> = {
 	type?: T;
 };
 
+type KvKeyOptions<K extends KvKeyType = "text"> = {
+	keyType?: K;
+};
+
 type KvListOptions<
 	T extends KvValueType = "text",
 	K extends KvKeyType = "text",
@@ -223,11 +227,15 @@ export class ActorKv {
 	/**
 	 * Delete all keys in the half-open range [start, end).
 	 */
-	async deleteRange(start: KvKey, end: KvKey): Promise<void> {
+	async deleteRange<K extends KvKeyType = "text">(
+		start: KvKeyTypeMap[K],
+		end: KvKeyTypeMap[K],
+		options?: KvKeyOptions<K>,
+	): Promise<void> {
 		await this.#driver.kvDeleteRange(
 			this.#actorId,
-			makePrefixedKey(encodeKey(start)),
-			makePrefixedKey(encodeKey(end)),
+			makePrefixedKey(encodeKey(start, options?.keyType)),
+			makePrefixedKey(encodeKey(end, options?.keyType)),
 		);
 	}
 

--- a/rivetkit-typescript/packages/rivetkit/src/actor/instance/mod.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/instance/mod.ts
@@ -1462,6 +1462,10 @@ export class ActorInstance<
 					batchPut: (entries) => this.driver.kvBatchPut(this.#actorId, entries),
 					batchGet: (keys) => this.driver.kvBatchGet(this.#actorId, keys),
 					batchDelete: (keys) => this.driver.kvBatchDelete(this.#actorId, keys),
+					deleteRange: (start, end) =>
+						this.driver.kvDeleteRange(this.#actorId, start, end),
+					listRange: (start, end, options) =>
+						this.driver.kvListRange(this.#actorId, start, end, options),
 				},
 				sqliteVfs: this.#sqliteVfs,
 			});

--- a/rivetkit-typescript/packages/rivetkit/src/actor/instance/queue-manager.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/instance/queue-manager.ts
@@ -358,12 +358,12 @@ export class QueueManager<
 	): Promise<void> {
 		const nameSet =
 			names && names.length > 0 ? new Set(names) : undefined;
-		const existing = await this.#loadQueueMessages();
 		if (nameSet) {
+			const existing = await this.#loadQueueMessages();
 			if (existing.some((message) => nameSet.has(message.name))) {
 				return;
 			}
-		} else if (existing.length > 0) {
+		} else if ((await this.#loadQueueMessages({ limit: 1 })).length > 0) {
 			return;
 		}
 
@@ -422,15 +422,22 @@ export class QueueManager<
 		if (ids.length === 0) {
 			return [];
 		}
-		const idSet = new Set(ids.map((id) => id.toString()));
-		const entries = await this.#loadQueueMessages();
-		const toRemove = entries.filter((entry) =>
-			idSet.has(entry.id.toString()),
+		const idEntries = ids.map((id) => ({
+			id,
+			key: makeQueueMessageKey(id),
+		}));
+		const existing = await this.#driver.kvBatchGet(
+			this.#actor.id,
+			idEntries.map((entry) => entry.key),
 		);
+		const toRemove = idEntries.filter((_, idx) => existing[idx] !== null);
 		if (toRemove.length === 0) {
 			return [];
 		}
-		await this.#removeMessages(toRemove);
+		await this.#deleteMessageKeys(
+			toRemove.map((entry) => entry.key),
+			toRemove.length,
+		);
 		return toRemove.map((entry) => entry.id);
 	}
 
@@ -442,7 +449,9 @@ export class QueueManager<
 		if (this.#metadata.size === 0) {
 			return [];
 		}
-		const entries = await this.#loadQueueMessages();
+		const entries = await this.#loadQueueMessages(
+			nameSet ? undefined : { limit: count },
+		);
 		const matched = nameSet
 			? entries.filter((entry) => nameSet.has(entry.name))
 			: entries;
@@ -466,10 +475,13 @@ export class QueueManager<
 		return selected;
 	}
 
-	async #loadQueueMessages(): Promise<QueueMessage[]> {
+	async #loadQueueMessages(options?: { limit?: number }): Promise<QueueMessage[]> {
 		const entries = await this.#driver.kvListPrefix(
 			this.#actor.id,
 			QUEUE_MESSAGES_PREFIX,
+			{
+				limit: options?.limit,
+			},
 		);
 		const decoded: QueueMessage[] = [];
 		for (const [key, value] of entries) {
@@ -494,7 +506,17 @@ export class QueueManager<
 			}
 		}
 		decoded.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
-		if (this.#metadata.size !== decoded.length) {
+		if (
+			options?.limit !== undefined &&
+			entries.length === options.limit &&
+			decoded.length < options.limit
+		) {
+			return await this.#loadQueueMessages();
+		}
+		if (
+			options?.limit === undefined &&
+			this.#metadata.size !== decoded.length
+		) {
 			this.#metadata.size = decoded.length;
 			this.#actor.inspector.updateQueueSize(this.#metadata.size);
 		}
@@ -525,22 +547,10 @@ export class QueueManager<
 		if (messages.length === 0) {
 			return;
 		}
-		const keys = messages.map((message) => makeQueueMessageKey(message.id));
-
-		// Update metadata
-		this.#metadata.size = Math.max(
-			0,
-			this.#metadata.size - messages.length,
+		await this.#deleteMessageKeys(
+			messages.map((message) => makeQueueMessageKey(message.id)),
+			messages.length,
 		);
-
-		// Delete messages and update metadata
-		// Note: kvBatchDelete doesn't support mixed operations, so we do two calls
-		await this.#driver.kvBatchDelete(this.#actor.id, keys);
-		await this.#driver.kvBatchPut(this.#actor.id, [
-			[QUEUE_METADATA_KEY, this.#serializeMetadata()],
-		]);
-
-		this.#actor.inspector.updateQueueSize(this.#metadata.size);
 	}
 
 	async #maybeResolveWaiters() {
@@ -598,6 +608,26 @@ export class QueueManager<
 			},
 			ACTOR_PERSIST_CURRENT_VERSION,
 		);
+	}
+
+	async #deleteMessageKeys(
+		keys: Uint8Array[],
+		deletedCount: number,
+	): Promise<void> {
+		if (keys.length === 0) {
+			return;
+		}
+
+		this.#metadata.size = Math.max(0, this.#metadata.size - deletedCount);
+
+		// Delete messages and update metadata.
+		// Note: kvBatchDelete doesn't support mixed operations, so we do two calls.
+		await this.#driver.kvBatchDelete(this.#actor.id, keys);
+		await this.#driver.kvBatchPut(this.#actor.id, [
+			[QUEUE_METADATA_KEY, this.#serializeMetadata()],
+		]);
+
+		this.#actor.inspector.updateQueueSize(this.#metadata.size);
 	}
 
 }

--- a/rivetkit-typescript/packages/rivetkit/src/actor/instance/traces-driver.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/instance/traces-driver.ts
@@ -82,10 +82,17 @@ export class ActorTracesDriver implements TracesDriver {
 		prefix: Uint8Array,
 	): Promise<Array<{ key: Uint8Array; value: Uint8Array }>> {
 		const fullPrefix = concatPrefix(this.#prefix, prefix);
-		const entries = await this.#driver.kvListPrefix(
-			this.#actorId,
-			fullPrefix,
-		);
+		const fullEnd = computeUpperBound(fullPrefix);
+		const entries = fullEnd
+			? await this.#driver.kvListRange(
+					this.#actorId,
+					fullPrefix,
+					fullEnd,
+				)
+			: await this.#driver.kvListPrefix(
+					this.#actorId,
+					fullPrefix,
+				);
 		return entries.map(([key, value]) => ({
 			key: stripPrefix(this.#prefix, key),
 			value,

--- a/rivetkit-typescript/packages/rivetkit/src/db/config.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/db/config.ts
@@ -32,6 +32,15 @@ export interface DatabaseProviderContext {
 		batchPut: (entries: [Uint8Array, Uint8Array][]) => Promise<void>;
 		batchGet: (keys: Uint8Array[]) => Promise<(Uint8Array | null)[]>;
 		batchDelete: (keys: Uint8Array[]) => Promise<void>;
+		deleteRange: (start: Uint8Array, end: Uint8Array) => Promise<void>;
+		listRange: (
+			start: Uint8Array,
+			end: Uint8Array,
+			options?: {
+				reverse?: boolean;
+				limit?: number;
+			},
+		) => Promise<[Uint8Array, Uint8Array][]>;
 	};
 
 	/**

--- a/rivetkit-typescript/packages/rivetkit/src/db/shared.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/db/shared.ts
@@ -56,6 +56,19 @@ export function createActorKvStore(kv: ActorKvOperations): KvVfsOptions {
 		deleteBatch: async (keys: Uint8Array[]) => {
 			await kv.batchDelete(keys);
 		},
+		deleteRange: async (start: Uint8Array, end: Uint8Array) => {
+			await kv.deleteRange(start, end);
+		},
+		listRange: async (
+			start: Uint8Array,
+			end: Uint8Array,
+			options?: {
+				reverse?: boolean;
+				limit?: number;
+			},
+		) => {
+			return await kv.listRange(start, end, options);
+		},
 	};
 }
 

--- a/rivetkit-typescript/packages/rivetkit/src/workflow/driver.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/workflow/driver.ts
@@ -4,6 +4,7 @@ import { makeWorkflowKey, workflowStoragePrefix } from "@/actor/instance/keys";
 import type {
 	EngineDriver,
 	KVEntry,
+	KVListOptions,
 	KVWrite,
 	Message,
 	WorkflowMessageDriver,
@@ -170,6 +171,25 @@ export class ActorWorkflowDriver implements EngineDriver {
 			this.#actor.driver.kvListPrefix(
 				this.#actor.id,
 				makeWorkflowKey(prefix),
+			),
+		);
+		return entries.map(([key, value]) => ({
+			key: stripWorkflowKey(key),
+			value,
+		}));
+	}
+
+	async listRange(
+		start: Uint8Array,
+		end: Uint8Array,
+		options?: KVListOptions,
+	): Promise<KVEntry[]> {
+		const entries = await this.#runCtx.keepAwake(
+			this.#actor.driver.kvListRange(
+				this.#actor.id,
+				makeWorkflowKey(start),
+				makeWorkflowKey(end),
+				options,
 			),
 		);
 		return entries.map(([key, value]) => ({

--- a/rivetkit-typescript/packages/sqlite-vfs-test/tests/sqlite-vfs.test.ts
+++ b/rivetkit-typescript/packages/sqlite-vfs-test/tests/sqlite-vfs.test.ts
@@ -35,6 +35,31 @@ function createKvStore(): KvVfsOptions {
 				store.delete(keyToString(key));
 			}
 		},
+		deleteRange: async (start, end) => {
+			for (const [encodedKey] of store) {
+				const key = Uint8Array.from(Buffer.from(encodedKey, "hex"));
+				if (Buffer.compare(key, start) >= 0 && Buffer.compare(key, end) < 0) {
+					store.delete(encodedKey);
+				}
+			}
+		},
+		listRange: async (start, end, options) => {
+			const entries: [Uint8Array, Uint8Array][] = [];
+			for (const [encodedKey, value] of store) {
+				const key = Uint8Array.from(Buffer.from(encodedKey, "hex"));
+				if (Buffer.compare(key, start) >= 0 && Buffer.compare(key, end) < 0) {
+					entries.push([key, new Uint8Array(value)]);
+				}
+			}
+			entries.sort(([a], [b]) => Buffer.compare(a, b));
+			if (options?.reverse) {
+				entries.reverse();
+			}
+			if (options?.limit !== undefined) {
+				return entries.slice(0, options.limit);
+			}
+			return entries;
+		},
 	};
 }
 

--- a/rivetkit-typescript/packages/sqlite-vfs/src/types.ts
+++ b/rivetkit-typescript/packages/sqlite-vfs/src/types.ts
@@ -9,4 +9,15 @@ export interface KvVfsOptions {
 	putBatch: (entries: [Uint8Array, Uint8Array][]) => Promise<void>;
 	/** Delete multiple keys */
 	deleteBatch: (keys: Uint8Array[]) => Promise<void>;
+	/** Delete all keys in the half-open range [start, end). */
+	deleteRange: (start: Uint8Array, end: Uint8Array) => Promise<void>;
+	/** List keys in the half-open range [start, end). */
+	listRange: (
+		start: Uint8Array,
+		end: Uint8Array,
+		options?: {
+			reverse?: boolean;
+			limit?: number;
+		},
+	) => Promise<[Uint8Array, Uint8Array][]>;
 }

--- a/rivetkit-typescript/packages/sqlite-vfs/src/vfs.ts
+++ b/rivetkit-typescript/packages/sqlite-vfs/src/vfs.ts
@@ -909,13 +909,12 @@ class SqliteSystem implements SqliteVfsRegistration {
 		const lastExistingChunk = Math.floor((file.size - 1) / CHUNK_SIZE);
 
 		// Delete chunks beyond the new size
-		const keysToDelete: Uint8Array[] = [];
-		for (let i = lastChunkToKeep + 1; i <= lastExistingChunk; i++) {
-			keysToDelete.push(this.#chunkKey(file, i));
-		}
-
-		if (keysToDelete.length > 0) {
-			await options.deleteBatch(keysToDelete);
+		const firstChunkToDelete = lastChunkToKeep + 1;
+		if (firstChunkToDelete <= lastExistingChunk) {
+			await options.deleteRange(
+				this.#chunkKey(file, firstChunkToDelete),
+				this.#chunkKey(file, lastExistingChunk + 1),
+			);
 		}
 
 		// Truncate the last kept chunk if needed
@@ -983,13 +982,14 @@ class SqliteSystem implements SqliteVfsRegistration {
 		const size = decodeFileMeta(sizeData);
 
 		// Delete all chunks
-		const keysToDelete: Uint8Array[] = [metaKey];
 		const numChunks = Math.ceil(size / CHUNK_SIZE);
-		for (let i = 0; i < numChunks; i++) {
-			keysToDelete.push(getChunkKey(fileTag, i));
+		await options.deleteBatch([metaKey]);
+		if (numChunks > 0) {
+			await options.deleteRange(
+				getChunkKey(fileTag, 0),
+				getChunkKey(fileTag, numChunks),
+			);
 		}
-
-		await options.deleteBatch(keysToDelete);
 	}
 
 	async xAccess(

--- a/rivetkit-typescript/packages/workflow-engine/QUICKSTART.md
+++ b/rivetkit-typescript/packages/workflow-engine/QUICKSTART.md
@@ -65,6 +65,7 @@ interface EngineDriver {
   deletePrefix(prefix: Uint8Array): Promise<void>;
   deleteRange(start: Uint8Array, end: Uint8Array): Promise<void>;
   list(prefix: Uint8Array): Promise<KVEntry[]>;  // MUST be sorted
+  listRange(start: Uint8Array, end: Uint8Array, options?: { reverse?: boolean; limit?: number }): Promise<KVEntry[]>;  // MUST be sorted
   batch(writes: KVWrite[]): Promise<void>;       // Should be atomic
 
   // Scheduling

--- a/rivetkit-typescript/packages/workflow-engine/architecture.md
+++ b/rivetkit-typescript/packages/workflow-engine/architecture.md
@@ -59,14 +59,14 @@ This isolation model means:
 
 The `EngineDriver` implementation must satisfy these requirements:
 
-1. **Sorted list results** - `list()` MUST return entries sorted by key in lexicographic byte order. The workflow engine relies on this for:
+1. **Sorted list results** - `list()` and `listRange()` MUST return entries sorted by key in lexicographic byte order. The workflow engine relies on this for:
    - Message FIFO ordering (messages consumed in order received)
    - Name registry reconstruction (names at correct indices)
    - Deterministic replay behavior
 
 2. **Atomic batch writes** - `batch()` SHOULD be atomic (all-or-nothing). If atomicity is not possible, partial writes may cause inconsistent state on crash.
 
-3. **Prefix isolation** - `list(prefix)` and `deletePrefix(prefix)` must only affect keys that start with the exact prefix bytes.
+3. **Range and prefix isolation** - `list(prefix)`, `listRange(start, end)`, `deletePrefix(prefix)`, and `deleteRange(start, end)` must only affect the intended byte ranges.
 
 4. **No concurrent modification** - The driver may assume no other writer modifies the KV during workflow execution (see Isolation Model).
 
@@ -257,7 +257,7 @@ Location segments in keys:
 ```
 
 The fdb-tuple encoding ensures:
-- Proper lexicographic byte ordering for `list()` operations
+- Proper lexicographic byte ordering for `list()` and `listRange()` operations
 - Compact representation for numeric indices
 - Nested tuples for complex segments (loop iterations)
 

--- a/rivetkit-typescript/packages/workflow-engine/src/driver.ts
+++ b/rivetkit-typescript/packages/workflow-engine/src/driver.ts
@@ -16,6 +16,11 @@ export interface KVWrite {
 	value: Uint8Array;
 }
 
+export interface KVListOptions {
+	reverse?: boolean;
+	limit?: number;
+}
+
 /**
  * The engine driver provides the KV and scheduling interface.
  * Implementations must provide these methods to integrate with different backends.
@@ -67,6 +72,17 @@ export interface EngineDriver {
 	 * non-deterministic replay behavior.
 	 */
 	list(prefix: Uint8Array): Promise<KVEntry[]>;
+
+	/**
+	 * List all key-value pairs in the half-open range [start, end).
+	 *
+	 * IMPORTANT: Results MUST be sorted by key in lexicographic byte order.
+	 */
+	listRange(
+		start: Uint8Array,
+		end: Uint8Array,
+		options?: KVListOptions,
+	): Promise<KVEntry[]>;
 
 	/**
 	 * Batch write multiple key-value pairs.

--- a/rivetkit-typescript/packages/workflow-engine/src/index.ts
+++ b/rivetkit-typescript/packages/workflow-engine/src/index.ts
@@ -12,7 +12,7 @@ export {
 	WorkflowContextImpl,
 } from "./context.js";
 // Driver
-export type { EngineDriver, KVEntry, KVWrite } from "./driver.js";
+export type { EngineDriver, KVEntry, KVListOptions, KVWrite } from "./driver.js";
 // Errors
 export {
 	CancelledError,
@@ -139,6 +139,7 @@ import {
 } from "./errors.js";
 import {
 	buildEntryMetadataPrefix,
+	computePrefixUpperBound,
 	buildWorkflowErrorKey,
 	buildWorkflowInputKey,
 	buildWorkflowOutputKey,
@@ -594,9 +595,14 @@ export function runWorkflow<TInput, TOutput>(
 				return;
 			}
 
-			const metadataEntries = await driver.list(
-				buildEntryMetadataPrefix(),
-			);
+			const metadataPrefix = buildEntryMetadataPrefix();
+			const metadataEntries = await (() => {
+				const metadataEnd = computePrefixUpperBound(metadataPrefix);
+				if (!metadataEnd) {
+					return driver.list(metadataPrefix);
+				}
+				return driver.listRange(metadataPrefix, metadataEnd);
+			})();
 			const writes: { key: Uint8Array; value: Uint8Array }[] = [];
 
 			for (const entry of metadataEntries) {

--- a/rivetkit-typescript/packages/workflow-engine/src/keys.ts
+++ b/rivetkit-typescript/packages/workflow-engine/src/keys.ts
@@ -280,6 +280,21 @@ export function keyStartsWith(key: Uint8Array, prefix: Uint8Array): boolean {
 }
 
 /**
+ * Compute the smallest exclusive upper bound for all keys with a given prefix.
+ * Returns null if the prefix is all 0xFF bytes.
+ */
+export function computePrefixUpperBound(prefix: Uint8Array): Uint8Array | null {
+	const upperBound = prefix.slice();
+	for (let i = upperBound.length - 1; i >= 0; i--) {
+		if (upperBound[i] !== 0xff) {
+			upperBound[i]++;
+			return upperBound.slice(0, i + 1);
+		}
+	}
+	return null;
+}
+
+/**
  * Compare two keys lexicographically.
  * Returns negative if a < b, 0 if a === b, positive if a > b.
  */

--- a/rivetkit-typescript/packages/workflow-engine/src/storage.ts
+++ b/rivetkit-typescript/packages/workflow-engine/src/storage.ts
@@ -23,7 +23,7 @@ import {
 	buildWorkflowErrorKey,
 	buildWorkflowOutputKey,
 	buildWorkflowStateKey,
-	compareKeys,
+	computePrefixUpperBound,
 	parseNameKey,
 } from "./keys.js";
 import { isLocationPrefix, locationToKey } from "./location.js";
@@ -135,9 +135,8 @@ export async function loadStorage(
 	const storage = createStorage();
 
 	// Load name registry
-	const nameEntries = await driver.list(buildNamePrefix());
-	// Sort by index to ensure correct order
-	nameEntries.sort((a, b) => compareKeys(a.key, b.key));
+	const namePrefix = buildNamePrefix();
+	const nameEntries = await listPrefixRange(driver, namePrefix);
 	for (const entry of nameEntries) {
 		const index = parseNameKey(entry.key);
 		storage.nameRegistry[index] = deserializeName(entry.value);
@@ -146,7 +145,10 @@ export async function loadStorage(
 	storage.flushedNameCount = storage.nameRegistry.length;
 
 	// Load history entries
-	const historyEntries = await driver.list(buildHistoryPrefixAll());
+	const historyEntries = await listPrefixRange(
+		driver,
+		buildHistoryPrefixAll(),
+	);
 	for (const entry of historyEntries) {
 		const parsed = deserializeEntry(entry.value);
 		parsed.dirty = false;
@@ -336,6 +338,17 @@ export async function flush(
 	}
 }
 
+async function listPrefixRange(
+	driver: EngineDriver,
+	prefix: Uint8Array,
+) {
+	const end = computePrefixUpperBound(prefix);
+	if (!end) {
+		return await driver.list(prefix);
+	}
+	return await driver.listRange(prefix, end);
+}
+
 /**
  * Delete entries with a given location prefix (used for loop forgetting).
  * Also cleans up associated metadata from both memory and driver.
@@ -349,10 +362,17 @@ export async function deleteEntriesWithPrefix(
 	const deletions = collectDeletionsForPrefix(storage, prefixLocation);
 
 	// Apply deletions to driver
-	await driver.deletePrefix(deletions.prefixes[0]!);
-	await Promise.all(
-		deletions.keys.map((key) => driver.delete(key)),
-	);
+	const deleteOps: Promise<void>[] = [];
+	for (const prefix of deletions.prefixes) {
+		deleteOps.push(driver.deletePrefix(prefix));
+	}
+	for (const range of deletions.ranges) {
+		deleteOps.push(driver.deleteRange(range.start, range.end));
+	}
+	for (const key of deletions.keys) {
+		deleteOps.push(driver.delete(key));
+	}
+	await Promise.all(deleteOps);
 
 	if (deletions.keys.length > 0 && onHistoryUpdated) {
 		onHistoryUpdated();
@@ -368,10 +388,14 @@ export function collectDeletionsForPrefix(
 	storage: Storage,
 	prefixLocation: Location,
 ): PendingDeletions {
+	const historyPrefix = buildHistoryPrefix(prefixLocation);
+	const historyEnd = computePrefixUpperBound(historyPrefix);
 	const pending: PendingDeletions = {
-		prefixes: [buildHistoryPrefix(prefixLocation)],
+		prefixes: historyEnd ? [] : [historyPrefix],
 		keys: [],
-		ranges: [],
+		ranges: historyEnd
+			? [{ start: historyPrefix, end: historyEnd }]
+			: [],
 	};
 
 	for (const [key, entry] of storage.history.entries) {

--- a/rivetkit-typescript/packages/workflow-engine/src/testing.ts
+++ b/rivetkit-typescript/packages/workflow-engine/src/testing.ts
@@ -1,4 +1,4 @@
-import type { EngineDriver, KVEntry, KVWrite } from "./driver.js";
+import type { EngineDriver, KVEntry, KVListOptions, KVWrite } from "./driver.js";
 import { EvictedError } from "./errors.js";
 import { compareKeys, keyStartsWith, keyToHex } from "./keys.js";
 import type { Message, WorkflowMessageDriver } from "./types.js";
@@ -195,6 +195,31 @@ export class InMemoryDriver implements EngineDriver {
 		}
 		// Sort by key lexicographically
 		return results.sort((a, b) => compareKeys(a.key, b.key));
+	}
+
+	async listRange(
+		start: Uint8Array,
+		end: Uint8Array,
+		options?: KVListOptions,
+	): Promise<KVEntry[]> {
+		await sleep(this.latency);
+		const results: KVEntry[] = [];
+		for (const entry of this.kv.values()) {
+			if (
+				compareKeys(entry.key, start) >= 0 &&
+				compareKeys(entry.key, end) < 0
+			) {
+				results.push({ key: entry.key, value: entry.value });
+			}
+		}
+		results.sort((a, b) => compareKeys(a.key, b.key));
+		if (options?.reverse) {
+			results.reverse();
+		}
+		if (options?.limit !== undefined) {
+			return results.slice(0, options.limit);
+		}
+		return results;
 	}
 
 	async batch(writes: KVWrite[]): Promise<void> {

--- a/rivetkit-typescript/packages/workflow-engine/tests/driver-kv.test.ts
+++ b/rivetkit-typescript/packages/workflow-engine/tests/driver-kv.test.ts
@@ -103,6 +103,28 @@ for (const mode of modes) {
 				expect(await driver.get(keyC)).toEqual(encode("c"));
 			});
 
+			it("should list only keys within a half-open range", async () => {
+				const keyA = encode("range-0");
+				const keyB = encode("range-1");
+				const keyBChild = encode("range-1-child");
+				const keyC = encode("range-2");
+
+				await driver.set(keyA, encode("a"));
+				await driver.set(keyB, encode("b"));
+				await driver.set(keyBChild, encode("b-child"));
+				await driver.set(keyC, encode("c"));
+
+				const entries = await driver.listRange(keyB, keyC, {
+					reverse: true,
+					limit: 2,
+				});
+
+				expect(entries).toEqual([
+					{ key: keyBChild, value: encode("b-child") },
+					{ key: keyB, value: encode("b") },
+				]);
+			});
+
 			it("should list name keys in sorted order", async () => {
 				await driver.set(buildNameKey(1), encode("two"));
 				await driver.set(buildNameKey(0), encode("one"));


### PR DESCRIPTION
# Description

This wires the new KV range operations through RivetKit and uses them in the highest-value internal paths. It makes `deleteRange` symmetric with `listRange`, exposes range ops through the SQLite KV adapter, uses `deleteRange` in SQLite truncate/delete paths, adds workflow-engine `listRange` support, and tightens queue and traces hot paths to avoid unnecessary full prefix scans.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Ran `pnpm run build && pnpm test driver-kv removals messages && pnpm run check-types` in `rivetkit-typescript/packages/workflow-engine`, `pnpm test sqlite-vfs` in `rivetkit-typescript/packages/sqlite-vfs-test`, and `pnpm run check-types` in `rivetkit-typescript/packages/sqlite-vfs`. The new workflow-engine `driver-kv` coverage passed, SQLite tests passed, and SQLite/workflow-engine type checks passed after generating workflow-engine schemas. The two failing `workflow-engine` `messages` tests (`should not replay the previous loop message after queue.next timeout` in `yield` and `live`) also fail on `origin/main`. The `rivetkit` package `check-types` script remains red with pre-existing schema/module-resolution errors that also reproduce on `origin/main`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
