### PR TITLE
docs(actors): clarify circular type dependency in bidirectional calls

### DIFF
--- a/website/src/content/docs/actors/communicating-between-actors.mdx
+++ b/website/src/content/docs/actors/communicating-between-actors.mdx
@@ -14,6 +14,10 @@ We recommend reading the [clients documentation](/docs/clients) first. This guid
 
 The server-side actor client allows actors to call other actors within the same registry. Access it via `c.client()` in your actor context:
 
+<Note>
+If two actors call each other and their return types are inferred from the other actor's response, you may hit circular type errors (`TS2322`, `TS2722`, or `c.state` becoming `unknown`). Fix this by writing explicit return types on those actions.
+</Note>
+
 ```typescript
 import { actor, setup } from "rivetkit";
 

--- a/website/src/metadata/skill-base-rivetkit.md
+++ b/website/src/metadata/skill-base-rivetkit.md
@@ -109,10 +109,16 @@ The RivetKit OpenAPI specification is available in the skill directory at `opena
 
 - The Rivet domain is rivet.dev, not rivet.gg
 
+## TypeScript Caveat: Actor Client Inference
+
+- In multi-file TypeScript projects, bidirectional actor calls can create a circular type dependency when both actors use `c.client<typeof registry>()`.
+- Symptoms usually include `c.state` becoming `unknown`, actor methods becoming possibly `undefined`, or `TS2322` / `TS2722` errors after the first cross-actor call.
+- If an action returns the result of another actor call, prefer an explicit return type annotation on that action instead of relying on inference through `c.client<typeof registry>()`.
+- If explicit return types are not enough, use a narrower client or registry type for only the actors that action needs.
+- As a last resort, pass `unknown` for the registry type and be explicit that this gives up type safety at that call site.
+
 <!-- CONTENT -->
 
 ## Reference Map
 
 <!-- REFERENCE_INDEX -->
-
-


### PR DESCRIPTION
## Summary

Simplify and clarify documentation about circular type dependencies that occur when two actors call each other and infer return types from each other's responses. Added explicit TypeScript error codes (`TS2322`, `TS2722`) and symptoms to help developers identify and resolve the issue.

## Changes

- Simplified the main documentation note in `communicating-between-actors.mdx` with the core problem and fix
- Added detailed TypeScript caveat section to `skill-base-rivetkit.md` documenting symptoms and fallback solutions

## Testing

Reviewed existing documentation and verified TypeScript error codes are accurate.