### PR TITLE
feat(sandbox): handle destroyed sandbox, add pause/resume, keep-alive

### DIFF
--- a/frontend/apps/inspector/src/routeTree.gen.ts
+++ b/frontend/apps/inspector/src/routeTree.gen.ts
@@ -8,76 +8,76 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as ContextRouteImport } from "./routes/_context";
-import { Route as ContextIndexRouteImport } from "./routes/_context/index";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as ContextRouteImport } from './routes/_context'
+import { Route as ContextIndexRouteImport } from './routes/_context/index'
 
 const ContextRoute = ContextRouteImport.update({
-	id: "/_context",
-	getParentRoute: () => rootRouteImport,
-} as any);
+  id: '/_context',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ContextIndexRoute = ContextIndexRouteImport.update({
-	id: "/",
-	path: "/",
-	getParentRoute: () => ContextRoute,
-} as any);
+  id: '/',
+  path: '/',
+  getParentRoute: () => ContextRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
-	"/": typeof ContextIndexRoute;
+  '/': typeof ContextIndexRoute
 }
 export interface FileRoutesByTo {
-	"/": typeof ContextIndexRoute;
+  '/': typeof ContextIndexRoute
 }
 export interface FileRoutesById {
-	__root__: typeof rootRouteImport;
-	"/_context": typeof ContextRouteWithChildren;
-	"/_context/": typeof ContextIndexRoute;
+  __root__: typeof rootRouteImport
+  '/_context': typeof ContextRouteWithChildren
+  '/_context/': typeof ContextIndexRoute
 }
 export interface FileRouteTypes {
-	fileRoutesByFullPath: FileRoutesByFullPath;
-	fullPaths: "/";
-	fileRoutesByTo: FileRoutesByTo;
-	to: "/";
-	id: "__root__" | "/_context" | "/_context/";
-	fileRoutesById: FileRoutesById;
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths: '/'
+  fileRoutesByTo: FileRoutesByTo
+  to: '/'
+  id: '__root__' | '/_context' | '/_context/'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-	ContextRoute: typeof ContextRouteWithChildren;
+  ContextRoute: typeof ContextRouteWithChildren
 }
 
-declare module "@tanstack/react-router" {
-	interface FileRoutesByPath {
-		"/_context": {
-			id: "/_context";
-			path: "";
-			fullPath: "";
-			preLoaderRoute: typeof ContextRouteImport;
-			parentRoute: typeof rootRouteImport;
-		};
-		"/_context/": {
-			id: "/_context/";
-			path: "/";
-			fullPath: "/";
-			preLoaderRoute: typeof ContextIndexRouteImport;
-			parentRoute: typeof ContextRoute;
-		};
-	}
+declare module '@tanstack/react-router' {
+  interface FileRoutesByPath {
+    '/_context': {
+      id: '/_context'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof ContextRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_context/': {
+      id: '/_context/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof ContextIndexRouteImport
+      parentRoute: typeof ContextRoute
+    }
+  }
 }
 
 interface ContextRouteChildren {
-	ContextIndexRoute: typeof ContextIndexRoute;
+  ContextIndexRoute: typeof ContextIndexRoute
 }
 
 const ContextRouteChildren: ContextRouteChildren = {
-	ContextIndexRoute: ContextIndexRoute,
-};
+  ContextIndexRoute: ContextIndexRoute,
+}
 
 const ContextRouteWithChildren =
-	ContextRoute._addFileChildren(ContextRouteChildren);
+  ContextRoute._addFileChildren(ContextRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
-	ContextRoute: ContextRouteWithChildren,
-};
+  ContextRoute: ContextRouteWithChildren,
+}
 export const routeTree = rootRouteImport
-	._addFileChildren(rootRouteChildren)
-	._addFileTypes<FileRouteTypes>();
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4317,8 +4317,8 @@ importers:
         specifier: ^9.5.0
         version: 9.9.5
       sandbox-agent:
-        specifier: ^0.4.0-rc.1
-        version: 0.4.0-rc.1(@daytonaio/sdk@0.150.0(ws@8.19.0))(@e2b/code-interpreter@2.3.3)(dockerode@4.0.9)(get-port@7.1.0)(zod@4.1.13)
+        specifier: ^0.4.1-rc.1
+        version: 0.4.1-rc.1(@daytonaio/sdk@0.150.0(ws@8.19.0))(@e2b/code-interpreter@2.3.3)(dockerode@4.0.9)(get-port@7.1.0)(zod@4.1.13)
       tar:
         specifier: ^7.5.0
         version: 7.5.7
@@ -9514,36 +9514,36 @@ packages:
   '@rushstack/ts-command-line@5.1.2':
     resolution: {integrity: sha512-jn0EnSefYrkZDrBGd6KGuecL84LI06DgzL4hVQ46AUijNBt2nRU/ST4HhrfII/w91siCd1J/Okvxq/BS75Me/A==}
 
-  '@sandbox-agent/cli-darwin-arm64@0.4.0-rc.1':
-    resolution: {integrity: sha512-PxY17+HFrtZxRlY/Z0se+K1L55cjSHWkPFueJRLvIiL91WHWvZcTW0gTqOBq0iP9p+YuWJRj6gdHf8KTT8fouw==}
+  '@sandbox-agent/cli-darwin-arm64@0.4.1-rc.1':
+    resolution: {integrity: sha512-OYc7Kq2b/vIFaB7ptrU+IyKa9wF8Kzc5+v+QOXcgqUVeXVjgX1tpoX9xcJIRqWytzPCZNYaHkOBrYj4+9T/bvQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@sandbox-agent/cli-darwin-x64@0.4.0-rc.1':
-    resolution: {integrity: sha512-hbRZatEAJZfc+D2oYxHFEj/unj845VIx+/oc6T/P0wkV/sll7x+YcpWeOkivsHQUmYuIOlGPjKae/aeyy3AjpA==}
+  '@sandbox-agent/cli-darwin-x64@0.4.1-rc.1':
+    resolution: {integrity: sha512-vW4+IkUiQXbjW/KJ9gzlTaMK6hERoH9iuwuSTjrNQqDKBc0P6ZpoivJxRsCbEARrVpd1tTXsO7TyPzsL63povQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@sandbox-agent/cli-linux-arm64@0.4.0-rc.1':
-    resolution: {integrity: sha512-G760gGU07MMW6fidU+XBhHVx7emFf+VgaMxmuzgI9gNF6ocjvd9oax97E7r8hwombiB4AOs/OZlg28TnehJKdg==}
+  '@sandbox-agent/cli-linux-arm64@0.4.1-rc.1':
+    resolution: {integrity: sha512-9hZt3vWn410fbe/KH/q9/koW/IxXTkEeG0od6ZjHZjbabSKhUX3vUjlIPkEmpc1WqTzJVrxcXdX21lb7Np/zdw==}
     cpu: [arm64]
     os: [linux]
 
-  '@sandbox-agent/cli-linux-x64@0.4.0-rc.1':
-    resolution: {integrity: sha512-8ArZtxTd6YX9qxPQSLlzfyf7XLI665UopRM9Oh9htEtpycOWLrJ8XWS0r1XXW8Qr/Pstee39yZ0Riqm9D4Y8Wg==}
+  '@sandbox-agent/cli-linux-x64@0.4.1-rc.1':
+    resolution: {integrity: sha512-B3+oJSmM2Ns0my65qs3LQqNSck0K53c+P2t0VYcKa8t7jZfL1Z8RLr/fjMKq4uS86mDN0lxmMErZ1ENUdeaJOg==}
     cpu: [x64]
     os: [linux]
 
-  '@sandbox-agent/cli-shared@0.4.0-rc.1':
-    resolution: {integrity: sha512-DPNXLNX8BYDqGlqxU+Ua1SMZomAy9vCHNxp8QwA1a5lS8YUuLb5RRSTj9R2WEUQ+mpmJMWAiFmhhfzU4O8OJ6A==}
+  '@sandbox-agent/cli-shared@0.4.1-rc.1':
+    resolution: {integrity: sha512-06JKYpLQF02gwCK7QnAB+OzGvdgJaPwPZ88MVZmdNllm2fwLhqGTntQTUezubS/0q1BUcxEZ5o4y1xTrKL4FyA==}
 
-  '@sandbox-agent/cli-win32-x64@0.4.0-rc.1':
-    resolution: {integrity: sha512-3nF5R79Q77gtYZuRRnj1k1K99X5QmT2IUqH4qCb7wMk0zdXzgY1aL4H/8I9HcQySgIVV7Y+E9V93ZZJPoasLCA==}
+  '@sandbox-agent/cli-win32-x64@0.4.1-rc.1':
+    resolution: {integrity: sha512-rf2LzXpvQM4dT/FL4ZCAyH4BwwQzQfEnTOGeLbGpXixDlyavzolgXHCGsEcdETF669Okur+qZSr+LHgaHL5rbg==}
     cpu: [x64]
     os: [win32]
 
-  '@sandbox-agent/cli@0.4.0-rc.1':
-    resolution: {integrity: sha512-ei3bbTefxXSFRnDna6ZJU3/FJIoA1TqvyD+v50KfOlylWkOyq4pAjk6PVMISRpVyImpowpxRaBtk1c4s+e+F9g==}
+  '@sandbox-agent/cli@0.4.1-rc.1':
+    resolution: {integrity: sha512-ZHqB30lmpyzZYQtqCrkMteqdhOOZL8hu136MBScRxRk1tuYq8nRVLoJJJLlDYX5pZODFvGGBOYtI4+DR8u/G+Q==}
     hasBin: true
 
   '@scure/base@1.2.6':
@@ -11064,8 +11064,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acp-http-client@0.4.0-rc.1:
-    resolution: {integrity: sha512-U9n3Vfqko3BQJIH5aSfPaHkiSxG0/i+esYTKHBk0CB0J5Bx7oNMjtboAgxz2U3wb6wO9THM2scZy7KM5syTECA==}
+  acp-http-client@0.4.1-rc.1:
+    resolution: {integrity: sha512-YaRio4z+g6tjZdDijC3+BdKPU/fKY7eDHex05KVnxhMQ8JDHTdVy1a1iu02z4cccAyQHlmk/ImfB2HjAO+wT6w==}
 
   actor-core@0.6.3:
     resolution: {integrity: sha512-cdYf0GX3m3jvlubbdujOcnPn93r1fP9F0mEBso72ofMTI0+EeGMS34BNrmaGmk5Pb3iD45KQl3u5ZY5Mzv4DNg==}
@@ -16371,8 +16371,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  sandbox-agent@0.4.0-rc.1:
-    resolution: {integrity: sha512-FgmDbC6CaX3ax6R6Hv1EnlBQdjA8tDoxsUuqbQQ6u4+6I34VJOH1K40YtLWYRlLC/rTcoboyG2WiWS/qaWUjew==}
+  sandbox-agent@0.4.1-rc.1:
+    resolution: {integrity: sha512-jv0MLKoiS6rsRfRnUlPrA6Ac7DinDaJR2CUJz+x4iWWber43LEl9I7u4rDY3QCcOV9tnPIL0hdF02Un/o8CR2Q==}
     peerDependencies:
       '@cloudflare/sandbox': '>=0.1.0'
       '@daytonaio/sdk': '>=0.12.0'
@@ -23917,32 +23917,32 @@ snapshots:
       - '@types/node'
     optional: true
 
-  '@sandbox-agent/cli-darwin-arm64@0.4.0-rc.1':
+  '@sandbox-agent/cli-darwin-arm64@0.4.1-rc.1':
     optional: true
 
-  '@sandbox-agent/cli-darwin-x64@0.4.0-rc.1':
+  '@sandbox-agent/cli-darwin-x64@0.4.1-rc.1':
     optional: true
 
-  '@sandbox-agent/cli-linux-arm64@0.4.0-rc.1':
+  '@sandbox-agent/cli-linux-arm64@0.4.1-rc.1':
     optional: true
 
-  '@sandbox-agent/cli-linux-x64@0.4.0-rc.1':
+  '@sandbox-agent/cli-linux-x64@0.4.1-rc.1':
     optional: true
 
-  '@sandbox-agent/cli-shared@0.4.0-rc.1': {}
+  '@sandbox-agent/cli-shared@0.4.1-rc.1': {}
 
-  '@sandbox-agent/cli-win32-x64@0.4.0-rc.1':
+  '@sandbox-agent/cli-win32-x64@0.4.1-rc.1':
     optional: true
 
-  '@sandbox-agent/cli@0.4.0-rc.1':
+  '@sandbox-agent/cli@0.4.1-rc.1':
     dependencies:
-      '@sandbox-agent/cli-shared': 0.4.0-rc.1
+      '@sandbox-agent/cli-shared': 0.4.1-rc.1
     optionalDependencies:
-      '@sandbox-agent/cli-darwin-arm64': 0.4.0-rc.1
-      '@sandbox-agent/cli-darwin-x64': 0.4.0-rc.1
-      '@sandbox-agent/cli-linux-arm64': 0.4.0-rc.1
-      '@sandbox-agent/cli-linux-x64': 0.4.0-rc.1
-      '@sandbox-agent/cli-win32-x64': 0.4.0-rc.1
+      '@sandbox-agent/cli-darwin-arm64': 0.4.1-rc.1
+      '@sandbox-agent/cli-darwin-x64': 0.4.1-rc.1
+      '@sandbox-agent/cli-linux-arm64': 0.4.1-rc.1
+      '@sandbox-agent/cli-linux-x64': 0.4.1-rc.1
+      '@sandbox-agent/cli-win32-x64': 0.4.1-rc.1
     optional: true
 
   '@scure/base@1.2.6': {}
@@ -25891,7 +25891,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  acp-http-client@0.4.0-rc.1(zod@4.1.13):
+  acp-http-client@0.4.1-rc.1(zod@4.1.13):
     dependencies:
       '@agentclientprotocol/sdk': 0.16.1(zod@4.1.13)
     transitivePeerDependencies:
@@ -32311,14 +32311,14 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sandbox-agent@0.4.0-rc.1(@daytonaio/sdk@0.150.0(ws@8.19.0))(@e2b/code-interpreter@2.3.3)(dockerode@4.0.9)(get-port@7.1.0)(zod@4.1.13):
+  sandbox-agent@0.4.1-rc.1(@daytonaio/sdk@0.150.0(ws@8.19.0))(@e2b/code-interpreter@2.3.3)(dockerode@4.0.9)(get-port@7.1.0)(zod@4.1.13):
     dependencies:
-      '@sandbox-agent/cli-shared': 0.4.0-rc.1
-      acp-http-client: 0.4.0-rc.1(zod@4.1.13)
+      '@sandbox-agent/cli-shared': 0.4.1-rc.1
+      acp-http-client: 0.4.1-rc.1(zod@4.1.13)
     optionalDependencies:
       '@daytonaio/sdk': 0.150.0(ws@8.19.0)
       '@e2b/code-interpreter': 2.3.3
-      '@sandbox-agent/cli': 0.4.0-rc.1
+      '@sandbox-agent/cli': 0.4.1-rc.1
       dockerode: 4.0.9
       get-port: 7.1.0
     transitivePeerDependencies:

--- a/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/registry.ts
+++ b/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/registry.ts
@@ -64,6 +64,7 @@ import {
 } from "./run";
 import { scheduled } from "./scheduled";
 import { dockerSandboxActor } from "./sandbox";
+import { e2bSandboxActor } from "./sandbox-e2b";
 import {
 	sleep,
 	sleepWithLongRpc,
@@ -113,6 +114,8 @@ export const registry = setup({
 		scheduled,
 		// From sandbox.ts
 		dockerSandboxActor,
+		// From sandbox-e2b.ts
+		e2bSandboxActor,
 		// From sleep.ts
 		sleep,
 		sleepWithLongRpc,

--- a/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/sandbox-e2b.ts
+++ b/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/sandbox-e2b.ts
@@ -1,0 +1,6 @@
+import { sandboxActor } from "rivetkit/sandbox";
+import { e2b } from "rivetkit/sandbox/e2b";
+
+export const e2bSandboxActor = sandboxActor({
+	provider: e2b(),
+});

--- a/rivetkit-typescript/packages/rivetkit/package.json
+++ b/rivetkit-typescript/packages/rivetkit/package.json
@@ -327,7 +327,7 @@
 		"nanoevents": "^9.1.0",
 		"p-retry": "^6.2.1",
 		"pino": "^9.5.0",
-		"sandbox-agent": "^0.4.0-rc.1",
+		"sandbox-agent": "^0.4.1-rc.1",
 		"tar": "^7.5.0",
 		"uuid": "^12.0.0",
 		"vbare": "^0.0.4",

--- a/rivetkit-typescript/packages/rivetkit/src/driver-test-suite/tests/actor-sandbox.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/driver-test-suite/tests/actor-sandbox.ts
@@ -2,11 +2,15 @@ import { describe, expect, test, vi } from "vitest";
 import type { DriverTestConfig } from "../mod";
 import { setupDriverTest } from "../utils";
 
-export function runActorSandboxTests(driverTestConfig: DriverTestConfig) {
-	describe.skipIf(driverTestConfig.skip?.sandbox)("Actor Sandbox Tests", () => {
+function sandboxTestSuite(
+	driverTestConfig: DriverTestConfig,
+	actorName: string,
+	label: string,
+) {
+	describe.skipIf(driverTestConfig.skip?.sandbox)(`Actor Sandbox Tests (${label})`, () => {
 		test("supports sandbox actions through the actor runtime", async (c) => {
 			const { client } = await setupDriverTest(c, driverTestConfig);
-			const sandbox = client.dockerSandboxActor.getOrCreate([
+			const sandbox = (client as any)[actorName].getOrCreate([
 				`sandbox-${crypto.randomUUID()}`,
 			]);
 			const decoder = new TextDecoder();
@@ -74,4 +78,67 @@ export function runActorSandboxTests(driverTestConfig: DriverTestConfig) {
 			);
 		}, 180_000);
 	});
+}
+
+export function runActorSandboxTests(driverTestConfig: DriverTestConfig) {
+	sandboxTestSuite(driverTestConfig, "dockerSandboxActor", "Docker");
+
+	// E2B tests only run when E2B_API_KEY is available.
+	const hasE2b = !!process.env.E2B_API_KEY;
+	describe.skipIf(!hasE2b || driverTestConfig.skip?.sandbox)(
+		"Actor Sandbox Tests (E2B)",
+		() => {
+			test("creates sandbox and passes health check", async (c) => {
+				const { client } = await setupDriverTest(c, driverTestConfig);
+				const sandbox = (client as any).e2bSandboxActor.getOrCreate([
+					`sandbox-e2b-${crypto.randomUUID()}`,
+				]);
+
+				const health = await vi.waitFor(
+					async () => {
+						return await sandbox.getHealth();
+					},
+					{
+						timeout: 120_000,
+						interval: 500,
+					},
+				);
+				expect(typeof health.status).toBe("string");
+			}, 180_000);
+
+			test("supports file system operations", async (c) => {
+				const { client } = await setupDriverTest(c, driverTestConfig);
+				const sandbox = (client as any).e2bSandboxActor.getOrCreate([
+					`sandbox-e2b-${crypto.randomUUID()}`,
+				]);
+				const decoder = new TextDecoder();
+
+				await vi.waitFor(
+					async () => {
+						return await sandbox.getHealth();
+					},
+					{
+						timeout: 120_000,
+						interval: 500,
+					},
+				);
+
+				await sandbox.mkdirFs({ path: "/root/tmp" });
+				await sandbox.writeFsFile(
+					{ path: "/root/tmp/hello.txt" },
+					"e2b sandbox actor driver test",
+				);
+				expect(
+					decoder.decode(
+						await sandbox.readFsFile({ path: "/root/tmp/hello.txt" }),
+					),
+				).toBe("e2b sandbox actor driver test");
+
+				const stat = await sandbox.statFs({ path: "/root/tmp/hello.txt" });
+				expect(stat.entryType).toBe("file");
+
+				await sandbox.deleteFsEntry({ path: "/root/tmp", recursive: true });
+			}, 180_000);
+		},
+	);
 }

--- a/rivetkit-typescript/packages/rivetkit/src/sandbox/actor/index.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/sandbox/actor/index.ts
@@ -55,7 +55,7 @@ import type { DatabaseProvider } from "@/actor/database";
 import { actor } from "@/actor/mod";
 import type { RawAccess } from "@/db/config";
 import { db } from "@/db/mod";
-import { SandboxAgent, type SandboxProvider } from "sandbox-agent";
+import { SandboxAgent, SandboxDestroyedError, type SandboxProvider } from "sandbox-agent";
 import {
 	type SandboxActorConfig,
 	type SandboxActorConfigInput,
@@ -100,6 +100,11 @@ type SandboxProxyActionDefinitions<TConnParams> = {
 async function teardownAgentRuntime(
 	vars: SandboxActorVars,
 ): Promise<void> {
+	if (vars.keepAliveInterval) {
+		clearInterval(vars.keepAliveInterval);
+		vars.keepAliveInterval = null;
+	}
+
 	for (const subscription of vars.unsubscribeBySessionId.values()) {
 		subscription.event?.();
 		subscription.permission?.();
@@ -152,14 +157,10 @@ async function resolveProvider<TConnParams>(
  * wake), it reconnects to the existing sandbox. Short-circuits if the
  * agent client is already connected.
  *
- * Steps:
- * 1. Resolve the provider (static or via createProvider callback)
- * 2. Call `SandboxAgent.start()` which handles:
- *    - Creating the sandbox if no sandboxId is provided
- *    - Calling `ensureServer()` if the provider implements it
- *    - Connecting to the sandbox-agent server
- * 3. Persist the sandbox ID from the started client
- * 4. Re-subscribe to all persisted session IDs
+ * If the provider throws `SandboxDestroyedError` (e.g. the E2B sandbox
+ * expired), the behavior depends on `options.onSandboxExpired`:
+ * - "destroy" (default): marks the sandbox as destroyed and rejects.
+ * - "recreate": provisions a fresh sandbox transparently.
  */
 async function ensureAgent<TConnParams>(
 	c: SandboxActionContext<TConnParams>,
@@ -171,12 +172,68 @@ async function ensureAgent<TConnParams>(
 	}
 
 	const provider = await resolveProvider(c, config);
+	const persist = new SqliteSessionPersistDriver(c.db, persistRawEvents);
 
-	c.vars.sandboxAgentClient = await SandboxAgent.start({
-		sandbox: provider,
-		sandboxId: c.state.sandboxId ?? undefined,
-		persist: new SqliteSessionPersistDriver(c.db, persistRawEvents),
-	});
+	try {
+		c.vars.sandboxAgentClient = await SandboxAgent.start({
+			sandbox: provider,
+			sandboxId: c.state.sandboxId ?? undefined,
+			persist,
+		});
+	} catch (error) {
+		if (!(error instanceof SandboxDestroyedError)) {
+			throw error;
+		}
+
+		const options = config.options as SandboxActorOptionsRuntime;
+
+		if (config.onSandboxExpired) {
+			config.onSandboxExpired(c, error);
+		}
+
+		if (options.onSandboxExpired === "recreate") {
+			c.log.warn({
+				msg: "sandbox expired, provisioning a new one",
+				oldSandboxId: c.state.sandboxId,
+			});
+
+			// Clear old sandbox state and provision fresh.
+			c.state.sandboxId = null;
+			c.vars.sandboxAgentClient = await SandboxAgent.start({
+				sandbox: provider,
+				persist,
+			});
+
+			if (c.vars.sandboxAgentClient.sandboxId) {
+				c.state.sandboxId = c.vars.sandboxAgentClient.sandboxId;
+			}
+
+			c.broadcast("sandboxRecreated", {
+				sandboxId: c.state.sandboxId,
+			});
+
+			// Sessions from the old sandbox are gone.
+			c.state.subscribedSessionIds = [];
+			return c.vars.sandboxAgentClient;
+		}
+
+		// Default: "destroy" mode.
+		c.log.warn({
+			msg: "sandbox expired, marking as destroyed",
+			sandboxId: c.state.sandboxId,
+		});
+		c.state.sandboxDestroyed = true;
+		c.state.sandboxId = null;
+		clearAllActiveSessions(c);
+
+		c.broadcast("sandboxDestroyed", {
+			reason: "expired",
+		});
+
+		throw new Error(
+			"sandbox has been destroyed (expired); only read-only actions (listSessions, getSession, getEvents) are available",
+		);
+	}
 
 	// Persist the sandbox ID so future wake cycles reconnect to the same sandbox.
 	if (!c.state.sandboxId && c.vars.sandboxAgentClient.sandboxId) {
@@ -188,7 +245,49 @@ async function ensureAgent<TConnParams>(
 		subscribeToSession(c, config, sessionId);
 	}
 
+	// Start keep-alive if configured and sessions are active.
+	syncKeepAlive(c, config);
+
 	return c.vars.sandboxAgentClient;
+}
+
+// --- Sandbox keep-alive ---
+
+/**
+ * Starts or stops the periodic sandbox keep-alive based on whether any
+ * sessions are subscribed and keepAliveIntervalMs is configured. While
+ * active, calls `provider.reconnect(sandboxId)` on the configured interval
+ * to extend the sandbox timeout.
+ */
+function syncKeepAlive<TConnParams>(
+	c: SandboxActionContext<TConnParams>,
+	config: SandboxActorConfig<TConnParams>,
+): void {
+	const options = config.options as SandboxActorOptionsRuntime;
+	const intervalMs = options.keepAliveIntervalMs;
+	const hasActiveSessions = c.state.subscribedSessionIds.length > 0;
+
+	if (intervalMs > 0 && hasActiveSessions && !c.vars.keepAliveInterval && c.state.sandboxId) {
+		const sandboxId = c.state.sandboxId;
+		c.vars.keepAliveInterval = setInterval(async () => {
+			const provider = c.vars.provider;
+			if (!provider?.reconnect || !c.state.sandboxId) {
+				return;
+			}
+			try {
+				await provider.reconnect(c.state.sandboxId);
+			} catch (error) {
+				c.log.warn({
+					msg: "sandbox keep-alive reconnect failed",
+					sandboxId,
+					error,
+				});
+			}
+		}, intervalMs);
+	} else if ((!hasActiveSessions || intervalMs <= 0) && c.vars.keepAliveInterval) {
+		clearInterval(c.vars.keepAliveInterval);
+		c.vars.keepAliveInterval = null;
+	}
 }
 
 // --- Read-only fallback actions ---
@@ -307,9 +406,14 @@ function buildProxyActions<TConnParams>(
 
 			// Post-action side effects: manage session subscriptions based
 			// on what the action returned.
-			if (actionName === "dispose") {
+			if (actionName === "dispose" || actionName === "pauseSandbox") {
 				await teardownAgentRuntime(c.vars);
 				clearAllActiveSessions(c);
+			} else if (actionName === "killSandbox") {
+				await teardownAgentRuntime(c.vars);
+				clearAllActiveSessions(c);
+				c.state.sandboxDestroyed = true;
+				c.state.sandboxId = null;
 			} else if (
 				actionName === "destroySession" &&
 				isSessionLike(result)
@@ -319,12 +423,14 @@ function buildProxyActions<TConnParams>(
 				sub?.permission?.();
 				c.vars.unsubscribeBySessionId.delete(result.id);
 				removeSubscribedSession(c, result.id);
+				syncKeepAlive(c, config);
 			} else if (
 				SESSION_RETURNING_ACTIONS.has(actionName) &&
 				isSessionLike(result)
 			) {
 				addSubscribedSession(c, result.id);
 				subscribeToSession(c, config, result.id);
+				syncKeepAlive(c, config);
 			} else if (
 				actionName === "listSessions" &&
 				result &&
@@ -339,6 +445,7 @@ function buildProxyActions<TConnParams>(
 						}
 					}
 				}
+				syncKeepAlive(c, config);
 			}
 
 			return result;
@@ -385,6 +492,7 @@ export function sandboxActor<TConnParams = undefined>(
 			activeHooks: new Set<Promise<void>>(),
 			warningTimeoutBySessionId: new Map(),
 			staleTimeoutBySessionId: new Map(),
+			keepAliveInterval: null,
 		}),
 		db: db({
 			onMigrate: migrateSandboxTables,
@@ -438,6 +546,49 @@ export function sandboxActor<TConnParams = undefined>(
 				if (parsedConfig.destroyActor) {
 					c.destroy();
 				}
+			},
+			// Pauses the sandbox environment. Tears down the live connection
+			// but does not mark it as destroyed, so a subsequent action call
+			// will reconnect via the provider's reconnect() hook.
+			pause: async (c: SandboxActionContext<TConnParams>) => {
+				if (c.state.sandboxDestroyed) {
+					throw new Error("sandbox has been destroyed");
+				}
+				clearAllActiveSessions(c);
+				await teardownAgentRuntime(c.vars);
+
+				if (c.state.sandboxId) {
+					const provider = await resolveProvider(c, parsedConfig);
+					if (provider.pause) {
+						await provider.pause(c.state.sandboxId);
+					} else {
+						c.log.warn({
+							msg: "provider does not support pause, connection torn down but sandbox still running",
+						});
+					}
+				}
+			},
+			// Resumes a paused sandbox by reconnecting to it.
+			resume: async (c: SandboxActionContext<TConnParams>) => {
+				if (c.state.sandboxDestroyed) {
+					throw new Error("sandbox has been destroyed");
+				}
+				if (!c.state.sandboxId) {
+					throw new Error("no sandbox to resume");
+				}
+
+				// Reconnect via the provider if supported.
+				const provider = await resolveProvider(c, parsedConfig);
+				if (provider.reconnect) {
+					await provider.reconnect(c.state.sandboxId);
+				}
+
+				// Re-establish the agent connection.
+				await ensureAgent(
+					c,
+					parsedConfig,
+					parsedConfig.persistRawEvents ?? false,
+				);
 			},
 			getSandboxUrl: async (c: SandboxActionContext<TConnParams>) => {
 				if (c.state.sandboxDestroyed) {

--- a/rivetkit-typescript/packages/rivetkit/src/sandbox/config.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/sandbox/config.ts
@@ -22,6 +22,9 @@ const SandboxProviderSchema = z.object({
 	name: z.string(),
 	create: zFunction<SandboxProvider["create"]>(),
 	destroy: zFunction<SandboxProvider["destroy"]>(),
+	reconnect: zFunction<NonNullable<SandboxProvider["reconnect"]>>().optional(),
+	pause: zFunction<NonNullable<SandboxProvider["pause"]>>().optional(),
+	kill: zFunction<NonNullable<SandboxProvider["kill"]>>().optional(),
 	getUrl: zFunction<NonNullable<SandboxProvider["getUrl"]>>().optional(),
 	getFetch: zFunction<NonNullable<SandboxProvider["getFetch"]>>().optional(),
 	ensureServer: zFunction<NonNullable<SandboxProvider["ensureServer"]>>().optional(),
@@ -35,6 +38,16 @@ export const SandboxActorOptionsSchema = z
 		// Clear active-turn state after this timeout so a missing terminal event
 		// cannot keep the actor awake forever.
 		staleAfterMs: z.number().positive().default(5 * 60_000),
+		// What to do when the provider reports the sandbox has been destroyed or
+		// expired (e.g. E2B sandbox timeout). "destroy" marks the sandbox as
+		// destroyed and rejects subsequent calls. "recreate" provisions a new
+		// sandbox transparently.
+		onSandboxExpired: z.enum(["destroy", "recreate"]).default("destroy"),
+		// Interval at which the actor extends the sandbox timeout while clients
+		// are connected. Set to 0 to disable keep-alive. The extension duration
+		// is equal to the interval so the sandbox stays alive as long as sessions
+		// are active.
+		keepAliveIntervalMs: z.number().nonnegative().default(0),
 	})
 	.strict()
 	.prefault(() => ({}))
@@ -61,6 +74,7 @@ export const SandboxActorConfigSchema = z
 		onBeforeConnect: zFunction().optional(),
 		onSessionEvent: zFunction().optional(),
 		onPermissionRequest: zFunction().optional(),
+		onSandboxExpired: zFunction().optional(),
 	})
 	.strict()
 	.refine(
@@ -104,6 +118,10 @@ interface SandboxActorConfigCallbacks<TConnParams> {
 		sessionId: string,
 		request: Parameters<PermissionRequestListener>[0],
 	) => void | Promise<void>;
+	onSandboxExpired?: (
+		c: SandboxActorContext<TConnParams>,
+		error: Error,
+	) => void | Promise<void>;
 }
 
 type SandboxActorProviderConfig<TConnParams> =
@@ -126,6 +144,7 @@ export type SandboxActorConfig<TConnParams = undefined> = Omit<
 	| "onBeforeConnect"
 	| "onSessionEvent"
 	| "onPermissionRequest"
+	| "onSandboxExpired"
 > &
 	SandboxActorConfigCallbacks<TConnParams> &
 	SandboxActorProviderConfig<TConnParams>;
@@ -138,6 +157,7 @@ export type SandboxActorConfigInput<TConnParams = undefined> = Omit<
 	| "onBeforeConnect"
 	| "onSessionEvent"
 	| "onPermissionRequest"
+	| "onSandboxExpired"
 > &
 	SandboxActorConfigCallbacks<TConnParams> &
 	SandboxActorProviderConfig<TConnParams>;

--- a/rivetkit-typescript/packages/rivetkit/src/sandbox/index.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/sandbox/index.ts
@@ -20,6 +20,9 @@ export {
 	SANDBOX_AGENT_ACTION_METHODS,
 	SANDBOX_AGENT_HOOK_METHODS,
 } from "./types";
+export {
+	SandboxDestroyedError,
+} from "sandbox-agent";
 export type {
 	PermissionReply,
 	ProcessLogFollowQuery,

--- a/rivetkit-typescript/packages/rivetkit/src/sandbox/types.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/sandbox/types.ts
@@ -32,6 +32,8 @@ export const SANDBOX_AGENT_ACTION_METHODS = [
 	"resumeSession",
 	"resumeOrCreateSession",
 	"destroySandbox",
+	"pauseSandbox",
+	"killSandbox",
 	"destroySession",
 	"setSessionMode",
 	"setSessionConfigOption",
@@ -119,6 +121,8 @@ export interface SandboxActorVars {
 	activeHooks: Set<Promise<void>>;
 	warningTimeoutBySessionId: Map<string, ReturnType<typeof setTimeout>>;
 	staleTimeoutBySessionId: Map<string, ReturnType<typeof setTimeout>>;
+	/** Interval handle for periodic sandbox keep-alive while sessions are active. */
+	keepAliveInterval: ReturnType<typeof setInterval> | null;
 }
 
 /** @deprecated Use `SandboxActorVars` instead. */


### PR DESCRIPTION
# Description

Upgrades `sandbox-agent` to `0.4.1-rc.1` and adds resilience features to the sandbox actor:

- **Handle `SandboxDestroyedError`**: When the provider reports the sandbox has expired (e.g. E2B timeout), `ensureAgent()` now catches `SandboxDestroyedError` and either marks the sandbox as destroyed (`onSandboxExpired: "destroy"`) or transparently provisions a new one (`onSandboxExpired: "recreate"`). Broadcasts events to connected clients in both cases.
- **Pause/resume actions**: New `pause` and `resume` actor actions delegate to the provider's `pause()` and `reconnect()` hooks for user-initiated sandbox lifecycle control.
- **Keep-alive while sessions active**: Configurable `keepAliveIntervalMs` option periodically calls `provider.reconnect()` while sessions are subscribed, preventing sandbox timeout during active use.
- **New SDK methods**: Proxies `pauseSandbox` and `killSandbox` from the updated sandbox-agent SDK.
- **Config additions**: `onSandboxExpired` callback, `onSandboxExpired` option ("destroy"/"recreate"), `keepAliveIntervalMs` option.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Type checking passes with no new errors in sandbox source files
- Full `build:publish` build succeeds

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings