### PR TITLE
fix(websocket): add close reasons and suppress noisy warnings

### DIFF
--- a/engine/sdks/typescript/runner/src/mod.ts
+++ b/engine/sdks/typescript/runner/src/mod.ts
@@ -587,7 +587,7 @@ export class Runner {
 						msg: "error during websocket shutdown:",
 						error,
 					});
-					pegboardWebSocket.close();
+					pegboardWebSocket.close(1011, "pegboard.shutdown_error");
 				}
 			}
 		} else {
@@ -733,7 +733,7 @@ export class Runner {
 			this.log?.error(
 				"found duplicate pegboardWebSocket, closing previous",
 			);
-			this.#pegboardWebSocket.close(1000, "duplicate_websocket");
+			this.#pegboardWebSocket.close(1000, "pegboard.duplicate_websocket");
 		}
 
 		const ws = new WS(this.pegboardUrl, protocols) as any as WebSocket;

--- a/engine/sdks/typescript/runner/src/utils.ts
+++ b/engine/sdks/typescript/runner/src/utils.ts
@@ -57,7 +57,9 @@ export function parseWebSocketCloseReason(
 	const [group, error] = mainPart.split(".");
 
 	if (!group || !error) {
-		logger()?.warn({ msg: "failed to parse close reason", reason });
+		if (reason) {
+			logger()?.warn({ msg: "failed to parse close reason", reason });
+		}
 		return undefined;
 	}
 

--- a/rivetkit-swift/Sources/RivetKitClient/ActorConnection.swift
+++ b/rivetkit-swift/Sources/RivetKitClient/ActorConnection.swift
@@ -765,7 +765,7 @@ public actor ActorConnection {
                 } else {
                     errorToThrow = ActorError(group: group, code: code, message: "Connection closed: \(reason)", metadata: nil)
                 }
-            } else {
+            } else if !reason.isEmpty {
                 logger.warning("failed to parse close reason reason=\(reason, privacy: .public)")
             }
         }

--- a/rivetkit-typescript/packages/rivetkit/src/client/utils.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/client/utils.ts
@@ -42,7 +42,9 @@ export function parseWebSocketCloseReason(
 	const [group, code] = mainPart.split(".");
 
 	if (!group || !code) {
-		logger().warn({ msg: "failed to parse close reason", reason });
+		if (reason) {
+			logger().warn({ msg: "failed to parse close reason", reason });
+		}
 		return undefined;
 	}
 

--- a/rivetkit-typescript/packages/rivetkit/src/remote-manager-driver/ws-proxy.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/remote-manager-driver/ws-proxy.ts
@@ -164,9 +164,9 @@ export async function createWebSocketProxy(
 
 			if (state.targetWs) {
 				if (state.targetWs.readyState === WebSocket.OPEN) {
-					state.targetWs.close(1011, "Client WebSocket error");
+					state.targetWs.close(1011, "ws.client_error");
 				} else if (state.targetWs.readyState === WebSocket.CONNECTING) {
-					state.targetWs.close();
+					state.targetWs.close(1011, "ws.client_error");
 				}
 			}
 		},

--- a/rivetkit-typescript/packages/rivetkit/src/sandbox/client.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/sandbox/client.ts
@@ -382,12 +382,12 @@ class DirectTerminalSession implements TerminalSession {
 				this.closeSignalSent = true;
 				this.sendFrame({ type: "close" });
 			}
-			this.socket.close();
+			this.socket.close(1000, "sandbox.client_closed");
 			return;
 		}
 
 		if (this.socket.readyState !== 3) {
-			this.socket.close();
+			this.socket.close(1000, "sandbox.client_closed");
 		}
 	}
 


### PR DESCRIPTION
# Description

This PR fixes WebSocket close handling to provide complete close reason information and reduces noisy logging for normal disconnect scenarios.

When WebSocket connections close, the close reason was either missing entirely or would trigger warnings even on normal disconnects (network drops, browser closes). This fix ensures all closes include proper reason codes for debugging while only warning on actually malformed reasons.

## Changes

- Add close reason codes to all bare `.close()` calls using the `group.code` format
- Suppress "failed to parse close reason" warnings when reason is empty (normal case for network disconnects)
- Standardize close reason formats across codebase (pegboard.*, ws.*, sandbox.*)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The changes suppress logging on normal WebSocket disconnects. Close reasons now follow the standard format for proper error tracking and debugging through the logging system.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings