### PR TITLE
fix(cf): fix Cloudflare Workers setTimeout regression

### DIFF
--- a/rivetkit-typescript/CLAUDE.md
+++ b/rivetkit-typescript/CLAUDE.md
@@ -54,6 +54,10 @@ cd rivetkit-typescript/packages/rivetkit
 
 The script installs each drizzle-orm version, runs the drizzle driver tests, and reports pass/fail per version. It restores the original package.json and lockfile on exit. Update the `DEFAULT_VERSIONS` array in the script and `SUPPORTED_DRIZZLE_RANGE` in `packages/rivetkit/src/db/drizzle/mod.ts` when adding support for new drizzle releases.
 
+## Cloudflare Workers Compatibility
+
+Cloudflare Workers forbid `setTimeout`, `fetch`, `connect`, and other async I/O in global scope (outside a request handler). The `Registry` constructor runs in global scope, so it must never call these APIs unconditionally. Any deferred work (e.g., prestarting the runtime) must be gated behind a synchronous config check before scheduling a timer. See `packages/rivetkit/src/registry/index.ts` for the pattern: the outer `if` guards `setTimeout`, and the inner `if` re-checks after the tick to pick up late config mutations.
+
 ## Workflow Context Actor Access Guards
 
 In `ActorWorkflowContext` (`packages/rivetkit/src/workflow/context.ts`), all side-effectful `#runCtx` access must be guarded by `#ensureActorAccess` so that side effects only run inside workflow steps and are not replayed outside of them. Read-only properties (e.g., `actorId`, `log`) do not need guards. When adding new methods or properties to the workflow context that delegate to `#runCtx`, apply the guard if the operation has side effects.

--- a/rivetkit-typescript/packages/rivetkit/src/registry/index.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/index.ts
@@ -36,17 +36,19 @@ export class Registry<A extends RegistryActors> {
 		// Start the local manager or engine before /api/rivet is hit so clients can
 		// reach the public endpoint preemptively. This waits one tick because some
 		// integrations mutate registry config immediately after setup() returns.
-		setTimeout(() => {
-			const parsedConfig = this.parseConfig();
+		if (config.serverless?.spawnEngine || config.serveManager) {
+			setTimeout(() => {
+				const parsedConfig = this.parseConfig();
 
-			if (
-				parsedConfig.serverless.spawnEngine ||
-				parsedConfig.serveManager
-			) {
-				// biome-ignore lint/nursery/noFloatingPromises: fire-and-forget auto-prepare
-				this.#ensureRuntime();
-			}
-		}, 0);
+				if (
+					parsedConfig.serverless.spawnEngine ||
+					parsedConfig.serveManager
+				) {
+					// biome-ignore lint/nursery/noFloatingPromises: fire-and-forget auto-prepare
+					this.#ensureRuntime();
+				}
+			}, 0);
+		}
 	}
 
 	/** Creates runtime if not already created. Idempotent. */

--- a/rivetkit-typescript/packages/rivetkit/tests/registry-constructor.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/registry-constructor.test.ts
@@ -1,0 +1,72 @@
+import { actor, setup } from "@/mod";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { Runtime } from "../runtime";
+
+const testActor = actor({
+	state: {},
+	actions: {},
+});
+
+function createMockRuntime() {
+	return {
+		startRunner: vi.fn(),
+		startServerless: vi.fn(),
+		handleServerlessRequest: vi.fn(),
+	} as any;
+}
+
+describe("Registry constructor", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	test("does not schedule prestart when it is not explicitly enabled", async () => {
+		const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+		const runtimeCreateSpy = vi
+			.spyOn(Runtime, "create")
+			.mockResolvedValue(createMockRuntime());
+		const initialTimeoutCalls = setTimeoutSpy.mock.calls.length;
+
+		setup({
+			use: {
+				test: testActor,
+			},
+		});
+
+		expect(setTimeoutSpy.mock.calls).toHaveLength(initialTimeoutCalls);
+
+		await vi.runAllTimersAsync();
+		expect(runtimeCreateSpy).not.toHaveBeenCalled();
+	});
+
+	test("reads config mutations made before the prestart tick", async () => {
+		const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+		const initialTimeoutCalls = setTimeoutSpy.mock.calls.length;
+		let managerPort: number | undefined;
+
+		vi.spyOn(Runtime, "create").mockImplementation(async (registry) => {
+			managerPort = registry.parseConfig().managerPort;
+
+			return createMockRuntime();
+		});
+
+		const registry = setup({
+			use: {
+				test: testActor,
+			},
+			serveManager: true,
+		});
+
+		registry.config.managerPort = 7777;
+
+		expect(setTimeoutSpy.mock.calls).toHaveLength(initialTimeoutCalls + 1);
+
+		await vi.runAllTimersAsync();
+		expect(managerPort).toBe(7777);
+	});
+});


### PR DESCRIPTION
## Summary

- Fixes the `setTimeout` regression in the `Registry` constructor that broke Cloudflare Workers deployments (error 10021: "Disallowed operation called within global scope")
- Moves the `setTimeout` call back inside the synchronous config guard so it only fires when `spawnEngine` or `serveManager` is set
- Adds tests covering both the no-timer and late-mutation cases
- Adds Cloudflare Workers compatibility constraint to `rivetkit-typescript/CLAUDE.md`

Closes #4514

## Test plan

- [x] `wrangler dev` starts without global scope error
- [x] Basic `counter` actor works end-to-end (increment, getCount)
- [x] Unit tests pass for constructor behavior (`registry-constructor.test.ts`)