### PR TITLE
fix(website): update agentOS registry links

### DIFF
--- a/website/src/content/docs/agent-os/software.mdx
+++ b/website/src/content/docs/agent-os/software.mdx
@@ -51,4 +51,4 @@ Browse all available software packages on the [Registry](/agent-os/registry).
 
 ## Publishing Custom Packages
 
-See the [agent-os-registry contributing guide](https://github.com/rivet-dev/agent-os-registry/blob/main/CONTRIBUTING.md) for how to add new software packages to the registry.
+See the [agent-os-registry contributing guide](https://github.com/rivet-dev/agent-os/blob/main/registry/CONTRIBUTING.md) for how to add new software packages to the registry.

--- a/website/src/pages/agent-os/registry/index.astro
+++ b/website/src/pages/agent-os/registry/index.astro
@@ -21,7 +21,7 @@ import { registry } from '@/data/registry';
 				</p>
 				<div class="mt-8 flex items-center justify-center gap-3">
 					<a
-						href="https://github.com/rivet-dev/agent-os-registry/blob/main/CONTRIBUTING.md"
+						href="https://github.com/rivet-dev/agent-os/blob/main/registry/CONTRIBUTING.md"
 						target="_blank"
 						rel="noopener noreferrer"
 						class="inline-flex items-center gap-2 rounded-lg border border-zinc-200 px-5 py-2.5 text-sm font-medium text-zinc-600 no-underline transition-all duration-200 hover:border-zinc-300 hover:text-zinc-900"
@@ -30,7 +30,7 @@ import { registry } from '@/data/registry';
 						<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 7h10v10"/><path d="M7 17 17 7"/></svg>
 					</a>
 					<a
-						href="https://github.com/rivet-dev/agent-os-registry/issues"
+						href="https://github.com/rivet-dev/agent-os/issues"
 						target="_blank"
 						rel="noopener noreferrer"
 						class="inline-flex items-center gap-2 rounded-lg border border-zinc-200 px-5 py-2.5 text-sm font-medium text-zinc-600 no-underline transition-all duration-200 hover:border-zinc-300 hover:text-zinc-900"


### PR DESCRIPTION
## Summary
- Update "Publish a Package" and "Request an Extension" links from `agent-os-registry` repo to `agent-os` repo
- Update contributing guide link in software docs page

## Test plan
- [ ] Verify links on `/agent-os/registry/` page point to correct URLs
- [ ] Verify contributing guide link in `/docs/agent-os/software/` is correct