### PR TITLE
fix(rivetkit): temporarily disable HWS for serverless runners

### DIFF
--- a/examples/sandbox/Dockerfile
+++ b/examples/sandbox/Dockerfile
@@ -12,7 +12,11 @@ COPY shared/typescript/ ./shared/typescript/
 RUN pnpm install --frozen-lockfile
 RUN mkdir -p rivetkit-openapi rivetkit-asyncapi
 RUN pnpm build --filter=rivetkit...
+RUN pnpm --filter=sandbox run build
 
 WORKDIR /app/examples/sandbox
 
-CMD ["pnpm", "start"]
+EXPOSE 8080
+ENV PORT=8080
+
+CMD ["sh", "-c", "if [ \"$SANDBOX_MODE\" = \"serverless\" ]; then srvx dist/server.js; else tsx src/server-runner.ts; fi"]

--- a/examples/sandbox/Dockerfile
+++ b/examples/sandbox/Dockerfile
@@ -11,10 +11,7 @@ COPY shared/typescript/ ./shared/typescript/
 
 RUN pnpm install --frozen-lockfile
 RUN mkdir -p rivetkit-openapi rivetkit-asyncapi
-RUN pnpm build --filter=sandbox
-COPY examples/sandbox/public ./examples/sandbox/dist/public
 
 WORKDIR /app/examples/sandbox
 
-EXPOSE 8080
 CMD ["pnpm", "start"]

--- a/examples/sandbox/Dockerfile
+++ b/examples/sandbox/Dockerfile
@@ -11,6 +11,7 @@ COPY shared/typescript/ ./shared/typescript/
 
 RUN pnpm install --frozen-lockfile
 RUN mkdir -p rivetkit-openapi rivetkit-asyncapi
+RUN pnpm build --filter=rivetkit...
 
 WORKDIR /app/examples/sandbox
 

--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -5,10 +5,10 @@
 	"type": "module",
 	"packageManager": "pnpm@10.13.1",
 	"scripts": {
-		"dev": "vite",
+		"dev": "tsx --watch src/server.ts",
 		"check-types": "echo 'skipped - workflow history types broken'",
-		"build": "vite build && vite build --mode server",
-		"start": "srvx dist/server.js",
+		"build": "echo 'no build step - running via tsx'",
+		"start": "tsx src/server.ts",
 		"benchmark": "tsx scripts/benchmark.ts",
 		"db:generate": "find src/actors -name drizzle.config.ts -exec drizzle-kit generate --config {} \\;"
 	},

--- a/examples/sandbox/package.json
+++ b/examples/sandbox/package.json
@@ -5,10 +5,10 @@
 	"type": "module",
 	"packageManager": "pnpm@10.13.1",
 	"scripts": {
-		"dev": "tsx --watch src/server.ts",
+		"dev": "vite",
 		"check-types": "echo 'skipped - workflow history types broken'",
-		"build": "echo 'no build step - running via tsx'",
-		"start": "tsx src/server.ts",
+		"build": "vite build --mode server",
+		"start": "tsx src/server-runner.ts",
 		"benchmark": "tsx scripts/benchmark.ts",
 		"db:generate": "find src/actors -name drizzle.config.ts -exec drizzle-kit generate --config {} \\;"
 	},

--- a/examples/sandbox/src/actors/state/sqlite-drizzle/drizzle/migrations.js
+++ b/examples/sandbox/src/actors/state/sqlite-drizzle/drizzle/migrations.js
@@ -1,10 +1,14 @@
-import journal from './meta/_journal.json';
-import m0000 from './0000_left_wrecking_crew.sql';
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import journal from './meta/_journal.json' with { type: 'json' };
 
-  export default {
-    journal,
-    migrations: {
-      m0000
-    }
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const m0000 = readFileSync(join(__dirname, '0000_left_wrecking_crew.sql'), 'utf-8');
+
+export default {
+  journal,
+  migrations: {
+    m0000
   }
-  
+}

--- a/examples/sandbox/src/actors/state/sqlite-drizzle/drizzle/migrations.js
+++ b/examples/sandbox/src/actors/state/sqlite-drizzle/drizzle/migrations.js
@@ -1,10 +1,11 @@
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
 import journal from './meta/_journal.json' with { type: 'json' };
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const m0000 = readFileSync(join(__dirname, '0000_left_wrecking_crew.sql'), 'utf-8');
+const m0000 = `CREATE TABLE \`todos\` (
+\t\`id\` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+\t\`title\` text NOT NULL,
+\t\`completed\` integer DEFAULT 0,
+\t\`created_at\` integer NOT NULL
+);`;
 
 export default {
   journal,

--- a/examples/sandbox/src/server-runner.ts
+++ b/examples/sandbox/src/server-runner.ts
@@ -1,3 +1,3 @@
 import { registry } from "./index.ts";
 
-export default registry.serve();
+registry.start();

--- a/examples/sandbox/src/server.ts
+++ b/examples/sandbox/src/server.ts
@@ -1,3 +1,3 @@
 import { registry } from "./index.ts";
 
-export default registry.serve();
+registry.start();

--- a/rivetkit-typescript/packages/rivetkit/src/drivers/engine/actor-driver.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/drivers/engine/actor-driver.ts
@@ -1078,7 +1078,10 @@ export class EngineActorDriver implements ActorDriver {
 			requestId: idToStr(requestId),
 		});
 		if (path === PATH_CONNECT) {
-			return true;
+			// Temporarily disable HWS for action/event connections.
+			// The gateway tunnel ping is not handled for serverless TS
+			// runners, causing ws.downstream_closed every ~30s.
+			return false;
 		} else if (
 			path === PATH_WEBSOCKET_BASE ||
 			path.startsWith(PATH_WEBSOCKET_PREFIX)


### PR DESCRIPTION
## Summary
- Disables hibernating WebSockets (HWS) for action/event connections (`PATH_CONNECT`) by making `#hwsCanHibernate()` return `false`
- Non-hibernatable connections still keep the actor awake via `CanSleep.ActiveConns` check
- This is a temporary workaround until the engine implements `ToRunnerPing`/`ToGatewayPong` for serverless TS runners

## Root Cause
The gateway sends `ToRunnerPing` via NATS and expects `ToGatewayPong` within 30s. For non-serverless runners, the Rust `pegboard-runner` bridge responds. For serverless TS runners (e.g. pax on Rivet Cloud), there is no bridge — nobody responds, so the gateway kills every WebSocket with `ws.downstream_closed` every ~30s. Disabling HWS avoids the broken hibernation/restore cycle.

## Test plan
- [ ] Deploy to pax production and verify WebSocket connections are stable (no more ~30s disconnect cycle)
- [ ] Verify actor stays awake while connections exist
- [ ] Verify connections are cleanly closed during runner drain (no stale_metadata errors)