### PR TITLE
Rework landing page for Actors + agentOS split

### DIFF
--- a/website/src/components/Footer.jsx
+++ b/website/src/components/Footer.jsx
@@ -36,6 +36,7 @@ const footer = {
 		{ name: "Status Page", href: "https://rivet.betteruptime.com/" },
 	],
 	resources: [
+		{ name: "Cookbooks", href: "/cookbook" },
 		{ name: "Blog", href: "/blog" },
 		{
 			name: "Rivet vs Cloudflare Workers",
@@ -142,7 +143,7 @@ function SmallPrint() {
 				<div className="col-span-1 min-[440px]:col-span-2 md:col-span-4 lg:col-span-1 space-y-6">
 					<img className="h-8 w-8" src={imgLogo.src} alt="Rivet" />
 					<p className="text-sm text-zinc-500">
-						The primitive for stateful workloads
+						Infrastructure for software that thinks
 					</p>
 					<div className="flex gap-4">
 						{footer.social.map((item) => (

--- a/website/src/components/marketing/components/AnimatedCTATitle.tsx
+++ b/website/src/components/marketing/components/AnimatedCTATitle.tsx
@@ -11,7 +11,7 @@ export function AnimatedCTATitle() {
       transition={{ duration: 0.5 }}
       className='text-2xl font-normal tracking-tight text-white md:text-4xl'
     >
-      The primitive for stateful workloads.
+      Infrastructure for software that thinks.
     </motion.h2>
   );
 }

--- a/website/src/components/marketing/sections/ObservabilitySection.tsx
+++ b/website/src/components/marketing/sections/ObservabilitySection.tsx
@@ -8,7 +8,7 @@ export const ObservabilitySection = () => {
   const features = [
     {
       title: 'SQLite Viewer',
-      description: 'Browse and query your actor\'s SQLite database in real-time',
+      description: 'Browse and query SQLite databases in real-time across actors and agent sessions',
       icon: <Database className='h-4 w-4' />
     },
     {
@@ -18,13 +18,13 @@ export const ObservabilitySection = () => {
     },
     {
       title: 'Event Monitoring',
-      description: 'See all events happening in your actor in real-time and track every state change and action as it happens',
+      description: 'Track every state change, action, and agent event as it happens in real-time',
       icon: <Activity className='h-4 w-4' />
     },
     {
       title: 'REPL',
       description:
-        'Debug your actor in real-time by calling actions, subscribing to events, and interacting directly with your code',
+        'Debug actors and agent sessions by calling actions, subscribing to events, and interacting directly with your code',
       icon: <Terminal className='h-4 w-4' />
     },
   ];
@@ -69,8 +69,7 @@ export const ObservabilitySection = () => {
               transition={{ duration: 0.5, delay: 0.1 }}
               className='mb-6 max-w-xl text-base leading-relaxed text-zinc-500'
             >
-              Powerful debugging and monitoring tools that work seamlessly from local development to production
-              at scale.
+              Debugging and monitoring for actors and agents, from local development to production at scale.
             </motion.p>
             {/* Feature List */}
             <div className='grid gap-px sm:grid-cols-2'>

--- a/website/src/components/marketing/sections/ProductSplitSection.tsx
+++ b/website/src/components/marketing/sections/ProductSplitSection.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { Database, Globe, Infinity, Layers, Wifi, GitBranch, ListOrdered, Clock, Shield, FolderOpen, Code, ArrowRight } from 'lucide-react';
+import { motion } from 'framer-motion';
+import agentosLogoUrl from '@/images/products/agentos-logo.svg';
+
+const actorFeatures = [
+	{
+		icon: Database,
+		title: 'In-memory state',
+		description: 'Co-located with compute for instant reads and writes.',
+	},
+	{
+		icon: Infinity,
+		title: 'Runs indefinitely, sleeps when idle',
+		description: 'Long-lived when active, hibernates when idle.',
+	},
+	{
+		icon: Layers,
+		title: 'Scales infinitely, scales to zero',
+		description: 'Supports bursty workloads and is cost-efficient.',
+	},
+	{
+		icon: Globe,
+		title: 'Global edge network',
+		description: 'Deploy close to your users without complexity.',
+	},
+	{
+		icon: Wifi,
+		title: 'WebSockets',
+		description: 'Real-time bidirectional streaming built in.',
+	},
+	{
+		icon: GitBranch,
+		title: 'Workflows, Queues, Scheduling',
+		description: 'Multi-step operations, durable queues, and timers.',
+	},
+];
+
+const agentOSFeatures = [
+	{
+		icon: Clock,
+		title: '~6ms coldstart, 22 KB RAM',
+		description: 'Near-zero cold start with minimal overhead.',
+	},
+	{
+		icon: Layers,
+		title: '32x cheaper than sandboxes',
+		description: 'V8 isolates + WASM instead of full VMs.',
+	},
+	{
+		icon: Code,
+		title: 'Embed in your backend',
+		description: 'Your APIs. Your toolchains. No complex agent auth.',
+	},
+	{
+		icon: FolderOpen,
+		title: 'Mount anything as a file system',
+		description: 'S3, SQLite, Google Drive, or the host file system.',
+	},
+	{
+		icon: Shield,
+		title: 'Granular security',
+		description: 'V8 isolates + WebAssembly. Configurable policies.',
+	},
+	{
+		icon: Globe,
+		title: 'Your laptop, your infra, or on-prem',
+		description: 'Rivet Cloud, Railway, Vercel, Kubernetes, or on-prem.',
+	},
+];
+
+const RivetActorIcon = ({ className }: { className?: string }) => (
+	<svg width="24" height="24" viewBox="0 0 176 173" className={className}>
+		<g transform="translate(-32928.8,-28118.2)">
+			<g transform="matrix(0.941176,0,0,0.925134,2119.4,2323.67)">
+				<g clipPath="url(#_clip1)">
+					<g transform="matrix(1.0625,0,0,1.08092,32936.6,27881.1)">
+						<path d="M164.529,52.792L164.529,120.844C164.529,145.347 144.635,165.241 120.132,165.241L52.08,165.241C27.577,165.241 7.683,145.347 7.683,120.844L7.683,52.792C7.683,28.289 27.577,8.395 52.08,8.395L120.132,8.395C144.635,8.395 164.529,28.289 164.529,52.792Z" style={{ fill: 'none', stroke: 'currentColor', strokeWidth: '15.18px' }} />
+					</g>
+					<g transform="matrix(1.0625,0,0,1.08092,32737,27881.7)">
+						<path d="M164.529,52.792L164.529,120.844C164.529,145.347 144.635,165.241 120.132,165.241L52.08,165.241C27.577,165.241 7.683,145.347 7.683,120.844L7.683,52.792C7.683,28.289 27.577,8.395 52.08,8.395L120.132,8.395C144.635,8.395 164.529,28.289 164.529,52.792Z" style={{ fill: 'none', stroke: 'currentColor', strokeWidth: '15.18px' }} />
+					</g>
+				</g>
+			</g>
+		</g>
+		<g transform="translate(-32928.8,-28118.2)">
+			<g transform="matrix(0.941176,0,0,0.925134,2119.4,2323.67)">
+				<g clipPath="url(#_clip1)">
+					<g transform="matrix(1.0625,0,0,1.08092,-2251.86,-2261.21)">
+						<g transform="translate(32930.7,27886.2)">
+							<path d="M104.323,87.121C104.584,85.628 105.665,84.411 107.117,83.977C108.568,83.542 110.14,83.965 111.178,85.069C118.49,92.847 131.296,106.469 138.034,113.637C138.984,114.647 139.343,116.076 138.983,117.415C138.623,118.754 137.595,119.811 136.267,120.208C127.471,122.841 111.466,127.633 102.67,130.266C101.342,130.664 99.903,130.345 98.867,129.425C97.83,128.504 97.344,127.112 97.582,125.747C99.274,116.055 102.488,97.637 104.323,87.121Z" style={{ fill: 'currentColor' }} />
+						</g>
+						<g transform="translate(32930.7,27886.2)">
+							<path d="M69.264,88.242L79.739,106.385C82.629,111.392 80.912,117.803 75.905,120.694L57.762,131.168C52.755,134.059 46.344,132.341 43.453,127.335L32.979,109.192C30.088,104.185 31.806,97.774 36.813,94.883L54.956,84.408C59.962,81.518 66.374,83.236 69.264,88.242Z" style={{ fill: 'currentColor' }} />
+						</g>
+						<g transform="translate(32930.7,27886.2)">
+							<path d="M86.541,79.464C98.111,79.464 107.49,70.084 107.49,58.514C107.49,46.944 98.111,37.565 86.541,37.565C74.971,37.565 65.591,46.944 65.591,58.514C65.591,70.084 74.971,79.464 86.541,79.464Z" style={{ fill: 'currentColor' }} />
+						</g>
+					</g>
+				</g>
+			</g>
+		</g>
+	</svg>
+);
+
+interface ProductCardProps {
+	icon: React.ReactNode;
+	title: string;
+	tagline: string;
+	docsHref: string;
+	detailsHref: string;
+	features: { icon: typeof Database; title: string; description: string }[];
+	delay: number;
+}
+
+const ProductCard = ({ icon, title, tagline, docsHref, detailsHref, features, delay }: ProductCardProps) => (
+	<motion.div
+		initial={{ opacity: 0, y: 20 }}
+		whileInView={{ opacity: 1, y: 0 }}
+		viewport={{ once: true }}
+		transition={{ duration: 0.5, delay }}
+		className='flex flex-col rounded-xl border border-white/10 bg-white/[0.03] p-6 md:p-8'
+	>
+		<div className='mb-4 flex items-center gap-3'>
+			{icon}
+			<h3 className='text-xl font-normal text-white'>{title}</h3>
+		</div>
+
+		<p className='mb-6 text-sm leading-relaxed text-zinc-400'>
+			{tagline}
+		</p>
+
+		<div className='mb-8 flex flex-wrap gap-3'>
+			<a
+				href={docsHref}
+				className='inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200'
+			>
+				Documentation
+			</a>
+			<a
+				href={detailsHref}
+				className='inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md border border-white/10 px-4 py-2 text-sm text-zinc-300 transition-colors hover:border-white/20 hover:text-white'
+			>
+				Details
+				<ArrowRight className='h-3.5 w-3.5' />
+			</a>
+		</div>
+
+		<div className='grid grid-cols-2 gap-x-6 gap-y-5'>
+			{features.map((feature) => {
+				const Icon = feature.icon;
+				return (
+					<div key={feature.title} className='flex flex-col gap-1.5'>
+						<div className='flex items-center gap-2'>
+							<Icon className='h-3.5 w-3.5 text-zinc-500' />
+							<span className='text-sm font-medium text-white'>{feature.title}</span>
+						</div>
+						<p className='text-xs leading-relaxed text-zinc-500'>{feature.description}</p>
+					</div>
+				);
+			})}
+		</div>
+	</motion.div>
+);
+
+export const ProductSplitSection = () => (
+	<section className='relative border-t border-white/10 px-6 py-16 lg:py-24'>
+		<div className='mx-auto w-full max-w-7xl'>
+			<div className='grid grid-cols-1 gap-6 lg:grid-cols-2'>
+				<ProductCard
+					icon={<RivetActorIcon className='text-white' />}
+					title='Actors'
+					tagline='The primitive for stateful workloads.'
+					docsHref='/docs'
+					detailsHref='/actors'
+					features={actorFeatures}
+					delay={0}
+				/>
+				<ProductCard
+					icon={<img src={agentosLogoUrl.src} alt='agentOS' className='h-6 w-6' />}
+					title='agentOS'
+					tagline='A lightweight open-source operating system for agents. Built on WASM & V8.'
+					docsHref='/docs/agent-os'
+					detailsHref='/agent-os'
+					features={agentOSFeatures}
+					delay={0.1}
+				/>
+			</div>
+		</div>
+	</section>
+);

--- a/website/src/components/marketing/sections/RedesignedCTA.tsx
+++ b/website/src/components/marketing/sections/RedesignedCTA.tsx
@@ -26,7 +26,7 @@ export const RedesignedCTA = () => (
         className='flex flex-col items-center justify-center gap-3 sm:flex-row'
       >
         <a
-          href='/docs'
+          href='/docs/actors'
           className='inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200'
         >
           Start Building

--- a/website/src/components/marketing/sections/RedesignedHero.tsx
+++ b/website/src/components/marketing/sections/RedesignedHero.tsx
@@ -272,8 +272,8 @@ export const RedesignedHero = ({ latestChangelogTitle, thinkingImages }: Redesig
               transition={{ duration: 0.5 }}
               className='mb-4 text-4xl font-normal leading-[1.1] tracking-tight text-white md:text-6xl'
             >
-              The primitive for <br />
-              stateful workloads.
+              Infrastructure for <br />
+              software that thinks.
             </motion.h1>
 
             <motion.p

--- a/website/src/components/v2/Header.tsx
+++ b/website/src/components/v2/Header.tsx
@@ -76,7 +76,7 @@ function ProductsDropdown({
 	const products = [
 		{
 			label: "Actors",
-			href: "/docs/actors",
+			href: "/actors",
 			logo: actorsLogoUrl,
 			description: "Build stateful backends",
 		},
@@ -445,14 +445,6 @@ export function Header({
 								>
 									Documentation
 								</TextNavItem>
-								{!isLightTheme && (
-									<TextNavItem
-										href="/cookbook"
-										ariaCurrent={active === "cookbook" ? "page" : undefined}
-									>
-										Cookbooks
-									</TextNavItem>
-								)}
 								{isLightTheme && (
 									<>
 										<TextNavItem href="/agent-os/use-cases">
@@ -552,12 +544,6 @@ export function Header({
 						Documentation
 					</TextNavItem>
 					<TextNavItem
-						href="/cookbook"
-						ariaCurrent={active === "cookbook" ? "page" : undefined}
-					>
-						Cookbooks
-					</TextNavItem>
-					<TextNavItem
 						href="/cloud"
 						ariaCurrent={active === "pricing" ? "page" : undefined}
 					>
@@ -608,12 +594,11 @@ function DocsMobileNavigation({
 		: [
 			{ href: "/docs", label: "Documentation" },
 			{ href: "/cloud", label: "Pricing" },
-			{ href: "/cookbook", label: "Cookbooks" },
 		];
 
 	const products = [
 		{ label: "agentOS", href: "/agent-os", logo: agentosLogoUrl },
-		{ label: "Actors", href: "/docs/actors", logo: actorsLogoUrl },
+		{ label: "Actors", href: "/actors", logo: actorsLogoUrl },
 		{
 			label: "Sandbox Agent SDK",
 			href: "https://sandboxagent.dev/",

--- a/website/src/pages/actors.astro
+++ b/website/src/pages/actors.astro
@@ -1,0 +1,48 @@
+---
+import MarketingLayout from '@/layouts/MarketingLayout.astro';
+import { BuiltInFeatures } from '@/components/marketing/sections/BuiltInFeatures';
+import { ProblemSection } from '@/components/marketing/sections/ProblemSection';
+import { BenchmarksSection } from '@/components/marketing/sections/BenchmarksSection';
+import { ObservabilitySection } from '@/components/marketing/sections/ObservabilitySection';
+import { RedesignedCTA } from '@/components/marketing/sections/RedesignedCTA';
+import { ScrollObserver } from '@/components/ScrollObserver';
+---
+
+<MarketingLayout
+	title="Rivet Actors - The Primitive for Stateful Workloads"
+	description="In-memory state, WebSockets, workflows, queues, scheduling, and more. One primitive that adapts to agents, collaboration, and durable execution."
+	canonicalUrl="https://rivet.dev/actors"
+	keywords={["actors", "stateful", "workflows", "websockets", "real-time", "backend infrastructure", "serverless", "open source", "self-hosted", "AI infrastructure", "long-running processes", "state management"]}
+>
+	<ScrollObserver client:load>
+		<div class="min-h-screen bg-black font-sans text-zinc-300 selection:bg-[#FF4500]/30 selection:text-orange-200">
+			<main>
+				<!-- Hero -->
+				<section class="relative flex flex-col justify-center px-6 pt-32 pb-16 md:pt-40 md:pb-24 text-center">
+					<div class="mx-auto w-full max-w-3xl">
+						<h1 class="mb-4 text-4xl font-normal leading-[1.1] tracking-tight text-white md:text-6xl">
+							The primitive for<br />stateful workloads.
+						</h1>
+						<p class="mb-8 text-lg text-zinc-400 md:text-xl">
+							One Actor per agent, per session, per user. State, storage, and networking included.
+						</p>
+						<div class="flex flex-col items-center gap-3 sm:flex-row sm:justify-center">
+							<a href="/docs" class="selection-dark inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md bg-white px-4 py-2 text-sm font-medium text-black transition-colors hover:bg-zinc-200">
+								Start Building
+							</a>
+							<a href="/docs/actors/quickstart" class="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md border border-white/20 px-4 py-2 text-sm text-zinc-300 transition-colors hover:border-white/30 hover:text-white">
+								Quickstart Guide
+							</a>
+						</div>
+					</div>
+				</section>
+
+				<BuiltInFeatures client:visible />
+				<ProblemSection client:visible />
+				<BenchmarksSection client:visible />
+				<ObservabilitySection client:visible />
+				<RedesignedCTA client:visible />
+			</main>
+		</div>
+	</ScrollObserver>
+</MarketingLayout>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -3,15 +3,10 @@ import { getCollection } from 'astro:content';
 import { getImage } from 'astro:assets';
 import MarketingLayout from '@/layouts/MarketingLayout.astro';
 import { RedesignedHero } from '@/components/marketing/sections/RedesignedHero';
-import { BuiltInFeatures } from '@/components/marketing/sections/BuiltInFeatures';
-import { ProblemSection } from '@/components/marketing/sections/ProblemSection';
-import { BenchmarksSection } from '@/components/marketing/sections/BenchmarksSection';
-import { CodeWalkthrough } from '@/components/marketing/sections/CodeWalkthrough';
-import { DynamicActorsSection } from '@/components/marketing/sections/DynamicActorsSection';
-import { HostingSection } from '@/components/marketing/sections/HostingSection';
-import { AgentOSSection } from '@/components/marketing/sections/AgentOSSection';
-import { IntegrationsSection } from '@/components/marketing/sections/IntegrationsSection';
+import { ProductSplitSection } from '@/components/marketing/sections/ProductSplitSection';
 import { ObservabilitySection } from '@/components/marketing/sections/ObservabilitySection';
+import { IntegrationsSection } from '@/components/marketing/sections/IntegrationsSection';
+import { HostingSection } from '@/components/marketing/sections/HostingSection';
 import { RedesignedCTA } from '@/components/marketing/sections/RedesignedCTA';
 import { ScrollObserver } from '@/components/ScrollObserver';
 
@@ -86,8 +81,8 @@ const latestChangelogTitle = latest?.data.title ?? '';
 ---
 
 <MarketingLayout
-	title="Rivet - The Primitive for Stateful Workloads"
-	description="Rivet Actors are built for AI agents, collaborative apps, and durable execution."
+	title="Rivet - Infrastructure for Software That Thinks"
+	description="Composable stateful compute for AI agents, collaborative apps, and durable execution. Actors and agentOS."
 	canonicalUrl="https://rivet.dev"
 	keywords={["actors", "stateful", "workflows", "websockets", "real-time", "backend infrastructure", "serverless", "open source", "self-hosted", "AI infrastructure", "long-running processes", "state management"]}
 >
@@ -95,14 +90,9 @@ const latestChangelogTitle = latest?.data.title ?? '';
 		<div class="min-h-screen bg-black font-sans text-zinc-300 selection:bg-[#FF4500]/30 selection:text-orange-200">
 			<main>
 				<RedesignedHero latestChangelogTitle={latestChangelogTitle} thinkingImages={thinkingImages} client:load />
-				<BuiltInFeatures client:visible />
-				<ProblemSection client:visible />
-				<!-- <DynamicActorsSection client:visible /> -->
-				<!-- <BenchmarksSection client:visible /> -->
-				<!-- <CodeWalkthrough client:visible /> -->
-				<AgentOSSection client:visible />
-				<IntegrationsSection client:visible />
+				<ProductSplitSection client:visible />
 				<ObservabilitySection client:visible />
+				<IntegrationsSection client:visible />
 				<HostingSection client:visible />
 				<RedesignedCTA client:visible />
 			</main>


### PR DESCRIPTION
## Summary
- Restructure the homepage to position Rivet as a platform with two products: Actors and agentOS
- New hero messaging: "Infrastructure for software that thinks"
- Side-by-side product cards (Actors / agentOS) with feature grids and CTAs
- New dedicated `/actors` product page with features, use cases, benchmarks, and observability
- Observability section updated to cover both actors and agents
- Cookbooks moved from nav to footer under Resources
- Updated CTA, footer tagline, and product dropdown links to `/actors`

## Test plan
- [ ] Verify homepage renders correctly with new hero + product cards + observability + integrations + hosting + CTA
- [ ] Verify `/actors` page loads with hero, features, use cases, benchmarks, observability, and CTA
- [ ] Verify product dropdown links to `/actors` (desktop + mobile)
- [ ] Verify Cookbooks removed from nav, present in footer under Resources
- [ ] Verify footer tagline updated
- [ ] Verify CTA links and messaging