### PR TITLE
Fix agentOS RAM typo: 22 KB → 22 MB

### DIFF
--- a/website/src/components/marketing/sections/ProductSplitSection.tsx
+++ b/website/src/components/marketing/sections/ProductSplitSection.tsx
@@ -40,7 +40,7 @@ const actorFeatures = [
 const agentOSFeatures = [
 	{
 		icon: Clock,
-		title: '~6ms coldstart, 22 KB RAM',
+		title: '~6ms coldstart, 22 MB RAM',
 		description: 'Near-zero cold start with minimal overhead.',
 	},
 	{


### PR DESCRIPTION
## Summary
- Fix typo in ProductSplitSection: agentOS RAM listed as 22 KB instead of 22 MB

## Test plan
- [ ] Verify homepage shows "22 MB RAM"