### PR TITLE
Add @rivetkit/world-workflow package for Vercel Workflow SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
 		"@rivetkit/engine-api-full": "workspace:*",
 		"@rivetkit/rivetkit-native": "workspace:*",
 		"@rivetkit/engine-cli": "workspace:*",
+		"@rivetkit/world-workflow": "workspace:*",
 		"@types/react": "^19",
 		"@types/react-dom": "^19",
 		"@clerk/shared": "3.27.1"

--- a/rivetkit-typescript/packages/world-workflow/README.md
+++ b/rivetkit-typescript/packages/world-workflow/README.md
@@ -1,0 +1,54 @@
+# @rivetkit/world-workflow
+
+Vercel Workflow SDK [World](https://useworkflow.dev/docs/deploying/building-a-world)
+implementation backed by [Rivet Actors](https://rivet.dev/docs/actors).
+
+This package replaces traditional Postgres + queue infrastructure with three
+Rivet actors:
+
+- `workflowRun` — one per workflow run. Owns the append-only event log,
+  materialized run/step/hook state, and per-run streams.
+- `coordinator` — singleton. Indexes runs for cross-run queries and enforces
+  global hook token uniqueness.
+- `queueRunner` — one per `__wkf_workflow_*` / `__wkf_step_*` queue. Wraps a
+  Rivet durable queue with retry and idempotency handling.
+
+## Status
+
+Early scaffold. The package compiles as a standalone workspace member and
+provides working implementations for the Storage, Queue, and most of the
+Streamer surface. Known gaps:
+
+- `readFromStream` live streaming is not yet wired to the `streamAppended`
+  actor event. Use `getStreamChunks` to drain chunks in a loop.
+- `hooks.get(hookId)` does not have a global index; callers must use
+  `hooks.getByToken`.
+- `events.listByCorrelationId` returns an empty result pending a
+  coordinator-level correlation index.
+
+The goal is to pass the 84 E2E tests in the Workflow SDK test suite; each gap
+above is a concrete follow-up.
+
+## Usage
+
+```ts
+import { createRivetWorld, registry } from "@rivetkit/world-workflow";
+
+// Start the registry (e.g. as part of your server entry point)
+registry.start();
+
+// Build a World the Workflow SDK can target
+export const world = createRivetWorld({
+	endpoint: process.env.RIVET_ENDPOINT,
+});
+```
+
+Then set `WORKFLOW_TARGET_WORLD=@rivetkit/world-workflow` to activate it.
+
+## Development
+
+```bash
+pnpm -F @rivetkit/world-workflow build
+pnpm -F @rivetkit/world-workflow check-types
+pnpm -F @rivetkit/world-workflow test
+```

--- a/rivetkit-typescript/packages/world-workflow/package.json
+++ b/rivetkit-typescript/packages/world-workflow/package.json
@@ -1,0 +1,64 @@
+{
+	"name": "@rivetkit/world-workflow",
+	"version": "0.1.0",
+	"description": "Vercel Workflow SDK World implementation backed by Rivet Actors",
+	"license": "Apache-2.0",
+	"keywords": [
+		"workflow",
+		"vercel",
+		"rivet",
+		"world",
+		"durable"
+	],
+	"files": [
+		"dist",
+		"src",
+		"package.json",
+		"README.md"
+	],
+	"type": "module",
+	"exports": {
+		".": {
+			"import": {
+				"types": "./dist/tsup/index.d.ts",
+				"default": "./dist/tsup/index.js"
+			},
+			"require": {
+				"types": "./dist/tsup/index.d.cts",
+				"default": "./dist/tsup/index.cjs"
+			}
+		},
+		"./registry": {
+			"import": {
+				"types": "./dist/tsup/registry.d.ts",
+				"default": "./dist/tsup/registry.js"
+			},
+			"require": {
+				"types": "./dist/tsup/registry.d.cts",
+				"default": "./dist/tsup/registry.cjs"
+			}
+		}
+	},
+	"engines": {
+		"node": ">=20.0.0"
+	},
+	"scripts": {
+		"build": "tsup src/index.ts src/registry.ts",
+		"check-types": "tsc --noEmit",
+		"lint": "biome check .",
+		"lint:fix": "biome check --write .",
+		"test": "vitest run",
+		"test:watch": "vitest"
+	},
+	"dependencies": {
+		"rivetkit": "workspace:*",
+		"uuid": "^12.0.0"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.3",
+		"@types/node": "^22.13.1",
+		"tsup": "^8.4.0",
+		"typescript": "^5.7.3",
+		"vitest": "^3.1.1"
+	}
+}

--- a/rivetkit-typescript/packages/world-workflow/src/actors/coordinator.ts
+++ b/rivetkit-typescript/packages/world-workflow/src/actors/coordinator.ts
@@ -12,7 +12,9 @@
  */
 
 import { actor } from "rivetkit";
-import type { HookStatus, WorkflowRunStatus } from "../types";
+import type { WorkflowRunStatus } from "../types";
+
+type HookStatus = "pending" | "disposed";
 
 interface CoordinatorRunRow {
 	id: string;
@@ -35,12 +37,14 @@ interface CoordinatorHookRow {
 interface CoordinatorState {
 	runs: Record<string, CoordinatorRunRow>;
 	hookTokens: Record<string, CoordinatorHookRow>;
+	hookIds: Record<string, { runId: string; token: string }>;
 }
 
 export const coordinatorActor = actor({
 	state: {
 		runs: {},
 		hookTokens: {},
+		hookIds: {},
 	} as CoordinatorState,
 	actions: {
 		registerRun: (c, row: CoordinatorRunRow) => {
@@ -127,11 +131,22 @@ export const coordinatorActor = actor({
 				return { ok: false, reason: "conflict" };
 			}
 			c.state.hookTokens[row.token] = row;
+			c.state.hookIds[row.hookId] = {
+				runId: row.runId,
+				token: row.token,
+			};
 			return { ok: true };
 		},
 
 		lookupHookToken: (c, token: string) => {
 			return c.state.hookTokens[token] ?? null;
+		},
+
+		lookupHookId: (
+			c,
+			hookId: string,
+		): { runId: string; token: string } | null => {
+			return c.state.hookIds[hookId] ?? null;
 		},
 
 		updateHookStatus: (

--- a/rivetkit-typescript/packages/world-workflow/src/actors/coordinator.ts
+++ b/rivetkit-typescript/packages/world-workflow/src/actors/coordinator.ts
@@ -1,0 +1,159 @@
+/**
+ * Coordinator actor.
+ *
+ * Singleton, keyed `["coordinator"]`. Serves as a cross-run index for:
+ *
+ * - `runs.list()` paginated queries
+ * - `hooks.getByToken()` global token lookup
+ *
+ * The coordinator is an *index*, not a source of truth. The authoritative
+ * state for each run lives in its `workflowRunActor`. Writes to the
+ * coordinator are best-effort and eventually consistent.
+ */
+
+import { actor } from "rivetkit";
+import type { HookStatus, WorkflowRunStatus } from "../types";
+
+interface CoordinatorRunRow {
+	id: string;
+	workflowName: string;
+	status: WorkflowRunStatus;
+	createdAt: number;
+	updatedAt: number;
+	deploymentId?: string;
+	parentRunId?: string;
+}
+
+interface CoordinatorHookRow {
+	hookId: string;
+	runId: string;
+	token: string;
+	status: HookStatus;
+	createdAt: number;
+}
+
+interface CoordinatorState {
+	runs: Record<string, CoordinatorRunRow>;
+	hookTokens: Record<string, CoordinatorHookRow>;
+}
+
+export const coordinatorActor = actor({
+	state: {
+		runs: {},
+		hookTokens: {},
+	} as CoordinatorState,
+	actions: {
+		registerRun: (c, row: CoordinatorRunRow) => {
+			c.state.runs[row.id] = row;
+		},
+
+		updateRunStatus: (
+			c,
+			runId: string,
+			status: WorkflowRunStatus,
+			updatedAt: number,
+		) => {
+			const row = c.state.runs[runId];
+			if (!row) return;
+			row.status = status;
+			row.updatedAt = updatedAt;
+		},
+
+		getRun: (c, runId: string) => {
+			return c.state.runs[runId] ?? null;
+		},
+
+		listRuns: (
+			c,
+			opts?: {
+				cursor?: string;
+				limit?: number;
+				workflowName?: string;
+				status?: WorkflowRunStatus;
+				deploymentId?: string;
+				parentRunId?: string;
+				createdAfter?: number;
+				createdBefore?: number;
+			},
+		) => {
+			const limit = opts?.limit ?? 50;
+			let items = Object.values(c.state.runs);
+			if (opts?.workflowName) {
+				items = items.filter(
+					(r) => r.workflowName === opts.workflowName,
+				);
+			}
+			if (opts?.status) {
+				items = items.filter((r) => r.status === opts.status);
+			}
+			if (opts?.deploymentId) {
+				items = items.filter(
+					(r) => r.deploymentId === opts.deploymentId,
+				);
+			}
+			if (opts?.parentRunId) {
+				items = items.filter(
+					(r) => r.parentRunId === opts.parentRunId,
+				);
+			}
+			if (opts?.createdAfter !== undefined) {
+				const after = opts.createdAfter;
+				items = items.filter((r) => r.createdAt >= after);
+			}
+			if (opts?.createdBefore !== undefined) {
+				const before = opts.createdBefore;
+				items = items.filter((r) => r.createdAt < before);
+			}
+			items.sort((a, b) => b.createdAt - a.createdAt);
+
+			const startIdx = opts?.cursor
+				? Number.parseInt(opts.cursor, 10)
+				: 0;
+			const slice = items.slice(startIdx, startIdx + limit);
+			const nextIdx = startIdx + slice.length;
+			return {
+				data: slice,
+				cursor: nextIdx < items.length ? String(nextIdx) : null,
+				hasMore: nextIdx < items.length,
+			};
+		},
+
+		registerHookToken: (
+			c,
+			row: CoordinatorHookRow,
+		): { ok: true } | { ok: false; reason: "conflict" } => {
+			const existing = c.state.hookTokens[row.token];
+			if (existing && existing.status !== "disposed") {
+				return { ok: false, reason: "conflict" };
+			}
+			c.state.hookTokens[row.token] = row;
+			return { ok: true };
+		},
+
+		lookupHookToken: (c, token: string) => {
+			return c.state.hookTokens[token] ?? null;
+		},
+
+		updateHookStatus: (
+			c,
+			token: string,
+			status: HookStatus,
+		): void => {
+			const row = c.state.hookTokens[token];
+			if (!row) return;
+			row.status = status;
+			if (status === "disposed") {
+				// Free the token slot for future reuse.
+				delete c.state.hookTokens[token];
+			}
+		},
+
+		disposeHookTokensForRun: (c, runId: string) => {
+			for (const [token, row] of Object.entries(c.state.hookTokens)) {
+				if (row.runId === runId) {
+					delete c.state.hookTokens[token];
+				}
+			}
+		},
+	},
+});

--- a/rivetkit-typescript/packages/world-workflow/src/actors/queue.ts
+++ b/rivetkit-typescript/packages/world-workflow/src/actors/queue.ts
@@ -21,7 +21,14 @@
 
 import { actor } from "rivetkit";
 import { v4 as uuidv4 } from "uuid";
-import type { QueueRetryPolicy, ValidQueueName } from "../types";
+import type { ValidQueueName } from "../types";
+
+interface QueueRetryPolicy {
+	maxAttempts?: number;
+	initialBackoffMs?: number;
+	maxBackoffMs?: number;
+	backoffMultiplier?: number;
+}
 
 interface PendingMessage {
 	id: string;

--- a/rivetkit-typescript/packages/world-workflow/src/actors/queue.ts
+++ b/rivetkit-typescript/packages/world-workflow/src/actors/queue.ts
@@ -1,0 +1,154 @@
+/**
+ * Queue actor.
+ *
+ * One actor per `ValidQueueName` (e.g. `__wkf_workflow_0`). Messages are
+ * persisted in actor state so they survive restarts and hibernation. A
+ * follow-up can switch the pending list to an actor-owned durable queue
+ * (`queue<T>()`) if we want concurrent consumers.
+ *
+ * Responsibilities:
+ *
+ * - Accept `queue()` calls and enqueue messages with idempotency and retry
+ *   tracking.
+ * - Dispatch messages to a handler registered at runtime via an HTTP
+ *   endpoint. The handler is owned by user code; the queue actor only calls
+ *   back into it.
+ * - Apply retry backoff on failed messages up to the configured policy.
+ *
+ * Handler dispatch is driven by the `processNext` action which the host
+ * `createQueueHandler` HTTP wrapper invokes to pull one message at a time.
+ */
+
+import { actor } from "rivetkit";
+import { v4 as uuidv4 } from "uuid";
+import type { QueueRetryPolicy, ValidQueueName } from "../types";
+
+interface PendingMessage {
+	id: string;
+	queueName: ValidQueueName;
+	payload: unknown;
+	attempt: number;
+	createdAt: number;
+	deliverAfter: number;
+	idempotencyKey?: string;
+	retryPolicy?: QueueRetryPolicy;
+}
+
+interface QueueActorState {
+	queueName?: ValidQueueName;
+	pending: PendingMessage[];
+	idempotencyKeys: Record<string, string>;
+	inFlight: Record<string, PendingMessage>;
+}
+
+function computeBackoffMs(attempt: number, policy?: QueueRetryPolicy): number {
+	const initial = policy?.initialBackoffMs ?? 1_000;
+	const max = policy?.maxBackoffMs ?? 60_000;
+	const multiplier = policy?.backoffMultiplier ?? 2;
+	return Math.min(max, initial * multiplier ** Math.max(attempt - 1, 0));
+}
+
+export const queueActor = actor({
+	state: {
+		pending: [],
+		idempotencyKeys: {},
+		inFlight: {},
+	} as QueueActorState,
+	actions: {
+		/**
+		 * Enqueue a message. Returns its stable message id.
+		 */
+		enqueue: (
+			c,
+			queueName: ValidQueueName,
+			payload: unknown,
+			opts?: {
+				idempotencyKey?: string;
+				delay?: number;
+				retryPolicy?: QueueRetryPolicy;
+			},
+		): { messageId: string } => {
+			c.state.queueName ??= queueName;
+
+			if (opts?.idempotencyKey) {
+				const existing = c.state.idempotencyKeys[opts.idempotencyKey];
+				if (existing) {
+					return { messageId: existing };
+				}
+			}
+
+			const now = Date.now();
+			const msg: PendingMessage = {
+				id: uuidv4(),
+				queueName,
+				payload,
+				attempt: 0,
+				createdAt: now,
+				deliverAfter: now + (opts?.delay ?? 0),
+				idempotencyKey: opts?.idempotencyKey,
+				retryPolicy: opts?.retryPolicy,
+			};
+
+			c.state.pending.push(msg);
+			if (opts?.idempotencyKey) {
+				c.state.idempotencyKeys[opts.idempotencyKey] = msg.id;
+			}
+			return { messageId: msg.id };
+		},
+
+		/**
+		 * Pull the next deliverable message. Returns null if none are ready.
+		 * The caller is expected to process the message then call `ack` or
+		 * `nack`. This powers the HTTP `createQueueHandler` dispatcher loop.
+		 */
+		claimNext: (c): PendingMessage | null => {
+			const now = Date.now();
+			const idx = c.state.pending.findIndex(
+				(m) => m.deliverAfter <= now,
+			);
+			if (idx === -1) return null;
+			const [msg] = c.state.pending.splice(idx, 1);
+			msg.attempt += 1;
+			c.state.inFlight[msg.id] = msg;
+			return msg;
+		},
+
+		/** Mark a message as successfully processed. */
+		ack: (c, messageId: string) => {
+			const msg = c.state.inFlight[messageId];
+			if (!msg) return;
+			delete c.state.inFlight[messageId];
+			if (msg.idempotencyKey) {
+				// Keep idempotency mapping for dedup window. In practice this
+				// should age out; we keep it indefinitely for now.
+			}
+		},
+
+		/** Mark a message as failed and schedule a retry (or drop). */
+		nack: (c, messageId: string, err?: unknown) => {
+			const msg = c.state.inFlight[messageId];
+			if (!msg) return;
+			delete c.state.inFlight[messageId];
+			const maxAttempts = msg.retryPolicy?.maxAttempts ?? 5;
+			if (msg.attempt >= maxAttempts) {
+				c.log.warn({
+					msg: "queue message exceeded max attempts",
+					messageId,
+					queueName: msg.queueName,
+					attempt: msg.attempt,
+					err: err ?? null,
+				});
+				return;
+			}
+			msg.deliverAfter =
+				Date.now() + computeBackoffMs(msg.attempt, msg.retryPolicy);
+			c.state.pending.push(msg);
+		},
+
+		stats: (c) => ({
+			queueName: c.state.queueName,
+			pending: c.state.pending.length,
+			inFlight: Object.keys(c.state.inFlight).length,
+		}),
+	},
+});

--- a/rivetkit-typescript/packages/world-workflow/src/actors/shared.ts
+++ b/rivetkit-typescript/packages/world-workflow/src/actors/shared.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared helpers for serializing state across actor boundaries.
+ *
+ * Rivet actors persist JSON-serializable state. We base64-encode binary data
+ * (stream chunks, encryption keys) so `Uint8Array` survives persistence.
+ */
+
+export function encodeBinary(data: string | Uint8Array): string {
+	if (typeof data === "string") {
+		return Buffer.from(data, "utf8").toString("base64");
+	}
+	return Buffer.from(data).toString("base64");
+}
+
+export function decodeBinary(encoded: string): Uint8Array {
+	return new Uint8Array(Buffer.from(encoded, "base64"));
+}
+
+export function nowMs(): number {
+	return Date.now();
+}
+
+export function toDate(value: number | string | Date | undefined): Date {
+	if (value === undefined) return new Date();
+	if (value instanceof Date) return value;
+	return new Date(value);
+}
+
+export function serializeDates<T>(obj: T): T {
+	if (obj === null || obj === undefined) return obj;
+	if (obj instanceof Date) return obj.toISOString() as unknown as T;
+	if (Array.isArray(obj)) {
+		return obj.map((item) => serializeDates(item)) as unknown as T;
+	}
+	if (typeof obj === "object") {
+		const result: Record<string, unknown> = {};
+		for (const [key, value] of Object.entries(obj as object)) {
+			result[key] = serializeDates(value);
+		}
+		return result as unknown as T;
+	}
+	return obj;
+}
+
+export function deserializeDates<T>(obj: T, dateFields: string[] = []): T {
+	if (obj === null || obj === undefined) return obj;
+	if (Array.isArray(obj)) {
+		return obj.map((item) => deserializeDates(item, dateFields)) as unknown as T;
+	}
+	if (typeof obj === "object") {
+		const result: Record<string, unknown> = {};
+		for (const [key, value] of Object.entries(obj as object)) {
+			if (
+				dateFields.includes(key) &&
+				(typeof value === "string" || typeof value === "number")
+			) {
+				result[key] = new Date(value as string | number);
+			} else if (typeof value === "object") {
+				result[key] = deserializeDates(value, dateFields);
+			} else {
+				result[key] = value;
+			}
+		}
+		return result as unknown as T;
+	}
+	return obj;
+}
+
+export const RUN_DATE_FIELDS = [
+	"createdAt",
+	"updatedAt",
+	"startedAt",
+	"finishedAt",
+	"disposedAt",
+	"triggeredAt",
+	"requestedAt",
+];

--- a/rivetkit-typescript/packages/world-workflow/src/actors/workflow-run.ts
+++ b/rivetkit-typescript/packages/world-workflow/src/actors/workflow-run.ts
@@ -8,8 +8,7 @@
  * - Named streams keyed by stream name
  *
  * All mutations go through `createEvent` so the event log remains the source
- * of truth. This is the Postgres-World reference pattern, mapped onto Rivet
- * actor state.
+ * of truth.
  */
 
 import { actor, event } from "rivetkit";
@@ -20,10 +19,11 @@ import type {
 	EventResult,
 	EventType,
 	Hook,
-	HookStatus,
 	RunCreatedEventRequest,
 	Step,
 	StepStatus,
+	Wait,
+	WaitStatus,
 	WorkflowRun,
 	WorkflowRunStatus,
 } from "../types";
@@ -34,27 +34,26 @@ import { encodeBinary, nowMs } from "./shared";
 // ---------------------------------------------------------------------------
 
 interface PersistedRun {
-	id: string;
+	runId: string;
 	workflowName: string;
 	status: WorkflowRunStatus;
+	deploymentId: string;
 	input?: unknown;
 	output?: unknown;
 	error?: unknown;
+	executionContext?: Record<string, unknown>;
+	specVersion?: number;
 	createdAt: number;
 	updatedAt: number;
 	startedAt?: number;
-	finishedAt?: number;
-	deploymentId?: string;
-	parentRunId?: string;
-	parentStepId?: string;
-	traceCarrier?: Record<string, string>;
-	metadata?: Record<string, unknown>;
+	completedAt?: number;
+	expiredAt?: number;
 }
 
 interface PersistedStep {
-	id: string;
+	stepId: string;
 	runId: string;
-	name: string;
+	stepName: string;
 	status: StepStatus;
 	input?: unknown;
 	output?: unknown;
@@ -62,33 +61,44 @@ interface PersistedStep {
 	createdAt: number;
 	updatedAt: number;
 	startedAt?: number;
-	finishedAt?: number;
+	completedAt?: number;
+	retryAfter?: number;
 	attempt: number;
-	parentStepId?: string;
+	specVersion?: number;
 }
 
 interface PersistedHook {
-	id: string;
+	hookId: string;
 	runId: string;
 	token: string;
-	name: string;
-	status: HookStatus;
+	ownerId: string;
+	projectId: string;
+	environment: string;
+	metadata?: unknown;
+	createdAt: number;
+	specVersion?: number;
+	isWebhook?: boolean;
+}
+
+interface PersistedWait {
+	waitId: string;
+	runId: string;
+	status: WaitStatus;
+	resumeAt?: number;
+	completedAt?: number;
 	createdAt: number;
 	updatedAt: number;
-	disposedAt?: number;
-	triggeredAt?: number;
-	metadata?: Record<string, unknown>;
+	specVersion?: number;
 }
 
 interface PersistedEvent {
-	id: string;
-	type: EventType;
+	eventId: string;
+	eventType: EventType;
 	runId: string;
-	stepId?: string;
-	hookId?: string;
 	correlationId?: string;
-	data?: unknown;
+	eventData?: unknown;
 	createdAt: number;
+	specVersion?: number;
 }
 
 interface PersistedStreamChunk {
@@ -108,6 +118,7 @@ interface WorkflowRunState {
 	run?: PersistedRun;
 	steps: Record<string, PersistedStep>;
 	hooks: Record<string, PersistedHook>;
+	waits: Record<string, PersistedWait>;
 	events: PersistedEvent[];
 	idempotencyKeys: Record<string, string>;
 	streams: Record<string, PersistedStream>;
@@ -133,29 +144,28 @@ function isTerminalRunStatus(status: WorkflowRunStatus): boolean {
 
 function runToPublic(run: PersistedRun): WorkflowRun {
 	return {
-		id: run.id,
+		runId: run.runId,
 		workflowName: run.workflowName,
 		status: run.status,
+		deploymentId: run.deploymentId,
 		input: run.input,
 		output: run.output,
 		error: run.error as WorkflowRun["error"],
+		executionContext: run.executionContext,
+		specVersion: run.specVersion,
 		createdAt: new Date(run.createdAt),
 		updatedAt: new Date(run.updatedAt),
 		startedAt: run.startedAt ? new Date(run.startedAt) : undefined,
-		finishedAt: run.finishedAt ? new Date(run.finishedAt) : undefined,
-		deploymentId: run.deploymentId,
-		parentRunId: run.parentRunId,
-		parentStepId: run.parentStepId,
-		traceCarrier: run.traceCarrier,
-		metadata: run.metadata,
+		completedAt: run.completedAt ? new Date(run.completedAt) : undefined,
+		expiredAt: run.expiredAt ? new Date(run.expiredAt) : undefined,
 	};
 }
 
 function stepToPublic(step: PersistedStep): Step {
 	return {
-		id: step.id,
+		stepId: step.stepId,
 		runId: step.runId,
-		name: step.name,
+		stepName: step.stepName,
 		status: step.status,
 		input: step.input,
 		output: step.output,
@@ -163,37 +173,54 @@ function stepToPublic(step: PersistedStep): Step {
 		createdAt: new Date(step.createdAt),
 		updatedAt: new Date(step.updatedAt),
 		startedAt: step.startedAt ? new Date(step.startedAt) : undefined,
-		finishedAt: step.finishedAt ? new Date(step.finishedAt) : undefined,
+		completedAt: step.completedAt
+			? new Date(step.completedAt)
+			: undefined,
+		retryAfter: step.retryAfter ? new Date(step.retryAfter) : undefined,
 		attempt: step.attempt,
-		parentStepId: step.parentStepId,
+		specVersion: step.specVersion,
 	};
 }
 
 function hookToPublic(hook: PersistedHook): Hook {
 	return {
-		id: hook.id,
+		hookId: hook.hookId,
 		runId: hook.runId,
 		token: hook.token,
-		name: hook.name,
-		status: hook.status,
-		createdAt: new Date(hook.createdAt),
-		updatedAt: new Date(hook.updatedAt),
-		disposedAt: hook.disposedAt ? new Date(hook.disposedAt) : undefined,
-		triggeredAt: hook.triggeredAt ? new Date(hook.triggeredAt) : undefined,
+		ownerId: hook.ownerId,
+		projectId: hook.projectId,
+		environment: hook.environment,
 		metadata: hook.metadata,
+		createdAt: new Date(hook.createdAt),
+		specVersion: hook.specVersion,
+		isWebhook: hook.isWebhook,
+	};
+}
+
+function waitToPublic(wait: PersistedWait): Wait {
+	return {
+		waitId: wait.waitId,
+		runId: wait.runId,
+		status: wait.status,
+		resumeAt: wait.resumeAt ? new Date(wait.resumeAt) : undefined,
+		completedAt: wait.completedAt
+			? new Date(wait.completedAt)
+			: undefined,
+		createdAt: new Date(wait.createdAt),
+		updatedAt: new Date(wait.updatedAt),
+		specVersion: wait.specVersion,
 	};
 }
 
 function eventToPublic(e: PersistedEvent): WorldEvent {
 	return {
-		id: e.id,
-		type: e.type,
+		eventId: e.eventId,
+		eventType: e.eventType,
 		runId: e.runId,
-		stepId: e.stepId,
-		hookId: e.hookId,
 		correlationId: e.correlationId,
-		data: e.data,
+		eventData: e.eventData,
 		createdAt: new Date(e.createdAt),
+		specVersion: e.specVersion,
 	};
 }
 
@@ -211,172 +238,207 @@ function materializeEvent(args: MaterializeArgs): void {
 	const { state, event: ev, data } = args;
 	const now = ev.createdAt;
 
-	if (data.type === "run_created") {
-		if (state.run) {
-			// Idempotency: treat as no-op so replays do not clobber state.
-			return;
-		}
+	if (data.eventType === "run_created") {
+		if (state.run) return;
+		const ed = data.eventData as {
+			deploymentId: string;
+			workflowName: string;
+			input?: unknown;
+			executionContext?: Record<string, unknown>;
+		};
 		state.run = {
-			id: ev.runId,
-			workflowName: data.workflowName,
+			runId: ev.runId,
+			workflowName: ed.workflowName,
+			deploymentId: ed.deploymentId,
 			status: "pending",
-			input: data.input,
+			input: ed.input,
+			executionContext: ed.executionContext,
+			specVersion: ev.specVersion,
 			createdAt: now,
 			updatedAt: now,
-			deploymentId: data.deploymentId,
-			parentRunId: data.parentRunId,
-			parentStepId: data.parentStepId,
-			traceCarrier: data.traceCarrier,
-			metadata: data.metadata,
 		};
 		return;
 	}
 
-	if (!state.run) {
-		// Ignore events that arrive before run_created. This keeps the actor
-		// defensive; the coordinator should prevent this in practice.
-		return;
-	}
+	if (!state.run) return;
 
-	switch (data.type) {
-		case "run_started":
+	switch (data.eventType) {
+		case "run_started": {
 			state.run.status = "running";
 			state.run.startedAt ??= now;
 			state.run.updatedAt = now;
+			if (data.eventData) {
+				const ed = data.eventData as {
+					deploymentId?: string;
+					input?: unknown;
+					executionContext?: Record<string, unknown>;
+				};
+				if (ed.deploymentId) state.run.deploymentId = ed.deploymentId;
+				if (ed.input !== undefined) state.run.input = ed.input;
+				if (ed.executionContext)
+					state.run.executionContext = ed.executionContext;
+			}
 			break;
+		}
 		case "run_completed":
 			state.run.status = "completed";
-			state.run.finishedAt = now;
+			state.run.completedAt = now;
 			state.run.updatedAt = now;
-			if (data.data !== undefined) {
-				state.run.output = data.data;
+			if (data.eventData) {
+				const ed = data.eventData as { output?: unknown };
+				if (ed.output !== undefined) state.run.output = ed.output;
 			}
 			break;
 		case "run_failed":
 			state.run.status = "failed";
-			state.run.finishedAt = now;
+			state.run.completedAt = now;
 			state.run.updatedAt = now;
-			state.run.error = data.data;
+			if (data.eventData) {
+				state.run.error = data.eventData;
+			}
 			break;
 		case "run_cancelled":
 			state.run.status = "cancelled";
-			state.run.finishedAt = now;
+			state.run.completedAt = now;
 			state.run.updatedAt = now;
-			break;
-		case "run_updated":
-			state.run.updatedAt = now;
-			if (typeof data.data === "object" && data.data !== null) {
-				Object.assign(state.run, data.data);
-			}
 			break;
 		case "step_created": {
-			const stepId = data.stepId;
-			if (!stepId) break;
-			const stepData = (data.data ?? {}) as Partial<PersistedStep>;
-			state.steps[stepId] = {
-				id: stepId,
+			const corrId = data.correlationId;
+			if (!corrId) break;
+			const ed = (data.eventData ?? {}) as {
+				stepName?: string;
+				input?: unknown;
+			};
+			state.steps[corrId] = {
+				stepId: corrId,
 				runId: ev.runId,
-				name: stepData.name ?? "step",
+				stepName: ed.stepName ?? "step",
 				status: "pending",
-				input: stepData.input,
+				input: ed.input,
 				createdAt: now,
 				updatedAt: now,
 				attempt: 0,
-				parentStepId: stepData.parentStepId,
+				specVersion: ev.specVersion,
 			};
 			break;
 		}
 		case "step_started": {
-			const step = data.stepId ? state.steps[data.stepId] : undefined;
+			const step = data.correlationId
+				? state.steps[data.correlationId]
+				: undefined;
 			if (!step) break;
 			step.status = "running";
 			step.startedAt ??= now;
 			step.updatedAt = now;
-			step.attempt += 1;
+			if (data.eventData) {
+				const ed = data.eventData as { attempt?: number };
+				if (ed.attempt !== undefined) step.attempt = ed.attempt;
+			} else {
+				step.attempt += 1;
+			}
 			break;
 		}
 		case "step_completed": {
-			const step = data.stepId ? state.steps[data.stepId] : undefined;
+			const step = data.correlationId
+				? state.steps[data.correlationId]
+				: undefined;
 			if (!step) break;
 			step.status = "completed";
-			step.finishedAt = now;
+			step.completedAt = now;
 			step.updatedAt = now;
-			step.output = data.data;
+			if (data.eventData) {
+				const ed = data.eventData as { result?: unknown };
+				step.output = ed.result;
+			}
 			break;
 		}
 		case "step_failed": {
-			const step = data.stepId ? state.steps[data.stepId] : undefined;
+			const step = data.correlationId
+				? state.steps[data.correlationId]
+				: undefined;
 			if (!step) break;
 			step.status = "failed";
-			step.finishedAt = now;
+			step.completedAt = now;
 			step.updatedAt = now;
-			step.error = data.data;
-			break;
-		}
-		case "step_cancelled": {
-			const step = data.stepId ? state.steps[data.stepId] : undefined;
-			if (!step) break;
-			step.status = "cancelled";
-			step.finishedAt = now;
-			step.updatedAt = now;
+			step.error = data.eventData;
 			break;
 		}
 		case "step_retrying": {
-			const step = data.stepId ? state.steps[data.stepId] : undefined;
+			const step = data.correlationId
+				? state.steps[data.correlationId]
+				: undefined;
 			if (!step) break;
 			step.status = "pending";
 			step.updatedAt = now;
+			step.error = data.eventData;
+			if (data.eventData) {
+				const ed = data.eventData as { retryAfter?: string | number };
+				if (ed.retryAfter)
+					step.retryAfter = new Date(ed.retryAfter).getTime();
+			}
 			break;
 		}
 		case "hook_created": {
-			const hookId = data.hookId;
-			if (!hookId) break;
-			const hookData = (data.data ?? {}) as Partial<PersistedHook>;
-			state.hooks[hookId] = {
-				id: hookId,
+			const corrId = data.correlationId;
+			if (!corrId) break;
+			const ed = (data.eventData ?? {}) as {
+				token?: string;
+				metadata?: unknown;
+				isWebhook?: boolean;
+			};
+			state.hooks[corrId] = {
+				hookId: corrId,
 				runId: ev.runId,
-				token: hookData.token ?? hookId,
-				name: hookData.name ?? "hook",
-				status: "pending",
+				token: ed.token ?? corrId,
+				ownerId: "",
+				projectId: "",
+				environment: "",
+				metadata: ed.metadata,
 				createdAt: now,
-				updatedAt: now,
-				metadata: hookData.metadata,
+				specVersion: ev.specVersion,
+				isWebhook: ed.isWebhook,
 			};
 			break;
 		}
-		case "hook_triggered": {
-			const hook = data.hookId ? state.hooks[data.hookId] : undefined;
-			if (!hook) break;
-			hook.status = "triggered";
-			hook.triggeredAt = now;
-			hook.updatedAt = now;
-			break;
-		}
-		case "hook_disposed": {
-			const hook = data.hookId ? state.hooks[data.hookId] : undefined;
-			if (!hook) break;
-			hook.status = "disposed";
-			hook.disposedAt = now;
-			hook.updatedAt = now;
-			break;
-		}
+		case "hook_received":
+		case "hook_disposed":
 		case "hook_conflict":
-		case "stream_chunk":
-		case "stream_closed":
-			// No materialization needed. Streams are mutated directly; hook
-			// conflicts are surfaced through the event itself.
 			break;
+		case "wait_created": {
+			const corrId = data.correlationId;
+			if (!corrId) break;
+			const ed = (data.eventData ?? {}) as {
+				resumeAt?: string | number;
+			};
+			state.waits[corrId] = {
+				waitId: corrId,
+				runId: ev.runId,
+				status: "waiting",
+				resumeAt: ed.resumeAt
+					? new Date(ed.resumeAt).getTime()
+					: undefined,
+				createdAt: now,
+				updatedAt: now,
+				specVersion: ev.specVersion,
+			};
+			break;
+		}
+		case "wait_completed": {
+			const wait = data.correlationId
+				? state.waits[data.correlationId]
+				: undefined;
+			if (!wait) break;
+			wait.status = "completed";
+			wait.completedAt = now;
+			wait.updatedAt = now;
+			break;
+		}
 	}
 
 	// Auto-dispose hooks when the run enters a terminal status.
 	if (state.run && isTerminalRunStatus(state.run.status)) {
-		for (const hook of Object.values(state.hooks)) {
-			if (hook.status === "pending") {
-				hook.status = "disposed";
-				hook.disposedAt = now;
-				hook.updatedAt = now;
-			}
-		}
+		// Hook disposal is tracked via hook_disposed events; we do not
+		// delete them from state here so they remain queryable.
 	}
 }
 
@@ -389,6 +451,7 @@ export const workflowRunActor = actor({
 		initialized: false,
 		steps: {},
 		hooks: {},
+		waits: {},
 		events: [],
 		idempotencyKeys: {},
 		streams: {},
@@ -401,7 +464,6 @@ export const workflowRunActor = actor({
 		}>(),
 	},
 	actions: {
-		/** Initialize the run identity. Called implicitly by `createEvent`. */
 		ensureRun: (c, runId: string) => {
 			if (!c.state.initialized) {
 				c.state.initialized = true;
@@ -409,18 +471,17 @@ export const workflowRunActor = actor({
 			return runId;
 		},
 
-		/** Append an event. Atomically updates materialized state. */
 		createEvent: (
 			c,
 			runId: string,
 			data: RunCreatedEventRequest | CreateEventRequest,
-			opts?: { idempotencyKey?: string },
+			opts?: { requestId?: string },
 		): EventResult => {
-			if (opts?.idempotencyKey) {
-				const existingId = c.state.idempotencyKeys[opts.idempotencyKey];
+			if (opts?.requestId) {
+				const existingId = c.state.idempotencyKeys[opts.requestId];
 				if (existingId) {
 					const existing = c.state.events.find(
-						(e) => e.id === existingId,
+						(e) => e.eventId === existingId,
 					);
 					if (existing) {
 						return {
@@ -434,28 +495,43 @@ export const workflowRunActor = actor({
 			}
 
 			const ev: PersistedEvent = {
-				id: uuidv4(),
-				type: data.type,
+				eventId: uuidv4(),
+				eventType: data.eventType,
 				runId,
-				stepId: "stepId" in data ? data.stepId : undefined,
-				hookId: "hookId" in data ? data.hookId : undefined,
 				correlationId:
 					"correlationId" in data ? data.correlationId : undefined,
-				data: "data" in data ? data.data : undefined,
+				eventData: data.eventData,
 				createdAt: nowMs(),
 			};
 
 			materializeEvent({ state: c.state, event: ev, data });
 			c.state.events.push(ev);
 
-			if (opts?.idempotencyKey) {
-				c.state.idempotencyKeys[opts.idempotencyKey] = ev.id;
+			if (opts?.requestId) {
+				c.state.idempotencyKeys[opts.requestId] = ev.eventId;
 			}
+
+			const corrId =
+				"correlationId" in data ? data.correlationId : undefined;
 
 			return {
 				event: eventToPublic(ev),
 				run: c.state.run ? runToPublic(c.state.run) : undefined,
+				step: corrId && c.state.steps[corrId]
+					? stepToPublic(c.state.steps[corrId])
+					: undefined,
+				hook: corrId && c.state.hooks[corrId]
+					? hookToPublic(c.state.hooks[corrId])
+					: undefined,
+				wait: corrId && c.state.waits[corrId]
+					? waitToPublic(c.state.waits[corrId])
+					: undefined,
 			};
+		},
+
+		getEvent: (c, eventId: string): WorldEvent | null => {
+			const ev = c.state.events.find((e) => e.eventId === eventId);
+			return ev ? eventToPublic(ev) : null;
 		},
 
 		getRun: (c): WorkflowRun | null => {
@@ -469,16 +545,22 @@ export const workflowRunActor = actor({
 
 		listSteps: (
 			c,
-			opts?: { status?: StepStatus; cursor?: string; limit?: number },
+			opts?: {
+				cursor?: string;
+				limit?: number;
+				sortOrder?: "asc" | "desc";
+			},
 		) => {
 			const limit = opts?.limit ?? 50;
 			let items = Object.values(c.state.steps);
-			if (opts?.status) {
-				items = items.filter((s) => s.status === opts.status);
-			}
-			items.sort((a, b) => a.createdAt - b.createdAt);
+			const desc = opts?.sortOrder !== "asc";
+			items.sort((a, b) =>
+				desc ? b.createdAt - a.createdAt : a.createdAt - b.createdAt,
+			);
 
-			const startIdx = opts?.cursor ? Number.parseInt(opts.cursor, 10) : 0;
+			const startIdx = opts?.cursor
+				? Number.parseInt(opts.cursor, 10)
+				: 0;
 			const slice = items.slice(startIdx, startIdx + limit);
 			const nextIdx = startIdx + slice.length;
 			return {
@@ -491,27 +573,20 @@ export const workflowRunActor = actor({
 		listEvents: (
 			c,
 			opts?: {
-				types?: EventType[];
-				stepId?: string;
-				hookId?: string;
 				cursor?: string;
 				limit?: number;
+				sortOrder?: "asc" | "desc";
 			},
 		) => {
 			const limit = opts?.limit ?? 100;
-			let items = c.state.events;
-			if (opts?.types && opts.types.length > 0) {
-				const set = new Set(opts.types);
-				items = items.filter((e) => set.has(e.type));
-			}
-			if (opts?.stepId) {
-				items = items.filter((e) => e.stepId === opts.stepId);
-			}
-			if (opts?.hookId) {
-				items = items.filter((e) => e.hookId === opts.hookId);
+			let items = [...c.state.events];
+			if (opts?.sortOrder === "desc") {
+				items.reverse();
 			}
 
-			const startIdx = opts?.cursor ? Number.parseInt(opts.cursor, 10) : 0;
+			const startIdx = opts?.cursor
+				? Number.parseInt(opts.cursor, 10)
+				: 0;
 			const slice = items.slice(startIdx, startIdx + limit);
 			const nextIdx = startIdx + slice.length;
 			return {
@@ -524,13 +599,22 @@ export const workflowRunActor = actor({
 		listEventsByCorrelationId: (
 			c,
 			correlationId: string,
-			opts?: { cursor?: string; limit?: number },
+			opts?: {
+				cursor?: string;
+				limit?: number;
+				sortOrder?: "asc" | "desc";
+			},
 		) => {
 			const limit = opts?.limit ?? 100;
-			const items = c.state.events.filter(
+			let items = c.state.events.filter(
 				(e) => e.correlationId === correlationId,
 			);
-			const startIdx = opts?.cursor ? Number.parseInt(opts.cursor, 10) : 0;
+			if (opts?.sortOrder === "desc") {
+				items = [...items].reverse();
+			}
+			const startIdx = opts?.cursor
+				? Number.parseInt(opts.cursor, 10)
+				: 0;
 			const slice = items.slice(startIdx, startIdx + limit);
 			const nextIdx = startIdx + slice.length;
 			return {
@@ -547,15 +631,21 @@ export const workflowRunActor = actor({
 
 		listHooks: (
 			c,
-			opts?: { status?: HookStatus; cursor?: string; limit?: number },
+			opts?: {
+				cursor?: string;
+				limit?: number;
+				sortOrder?: "asc" | "desc";
+			},
 		) => {
 			const limit = opts?.limit ?? 50;
 			let items = Object.values(c.state.hooks);
-			if (opts?.status) {
-				items = items.filter((h) => h.status === opts.status);
-			}
-			items.sort((a, b) => a.createdAt - b.createdAt);
-			const startIdx = opts?.cursor ? Number.parseInt(opts.cursor, 10) : 0;
+			const desc = opts?.sortOrder !== "asc";
+			items.sort((a, b) =>
+				desc ? b.createdAt - a.createdAt : a.createdAt - b.createdAt,
+			);
+			const startIdx = opts?.cursor
+				? Number.parseInt(opts.cursor, 10)
+				: 0;
 			const slice = items.slice(startIdx, startIdx + limit);
 			const nextIdx = startIdx + slice.length;
 			return {

--- a/rivetkit-typescript/packages/world-workflow/src/actors/workflow-run.ts
+++ b/rivetkit-typescript/packages/world-workflow/src/actors/workflow-run.ts
@@ -1,0 +1,672 @@
+/**
+ * WorkflowRun actor.
+ *
+ * One actor per workflow run, keyed by `[runId]`. Owns:
+ *
+ * - Append-only event log for this run
+ * - Materialized run, steps, and hooks state
+ * - Named streams keyed by stream name
+ *
+ * All mutations go through `createEvent` so the event log remains the source
+ * of truth. This is the Postgres-World reference pattern, mapped onto Rivet
+ * actor state.
+ */
+
+import { actor, event } from "rivetkit";
+import { v4 as uuidv4 } from "uuid";
+import type {
+	CreateEventRequest,
+	Event as WorldEvent,
+	EventResult,
+	EventType,
+	Hook,
+	HookStatus,
+	RunCreatedEventRequest,
+	Step,
+	StepStatus,
+	WorkflowRun,
+	WorkflowRunStatus,
+} from "../types";
+import { encodeBinary, nowMs } from "./shared";
+
+// ---------------------------------------------------------------------------
+// Persisted state shape
+// ---------------------------------------------------------------------------
+
+interface PersistedRun {
+	id: string;
+	workflowName: string;
+	status: WorkflowRunStatus;
+	input?: unknown;
+	output?: unknown;
+	error?: unknown;
+	createdAt: number;
+	updatedAt: number;
+	startedAt?: number;
+	finishedAt?: number;
+	deploymentId?: string;
+	parentRunId?: string;
+	parentStepId?: string;
+	traceCarrier?: Record<string, string>;
+	metadata?: Record<string, unknown>;
+}
+
+interface PersistedStep {
+	id: string;
+	runId: string;
+	name: string;
+	status: StepStatus;
+	input?: unknown;
+	output?: unknown;
+	error?: unknown;
+	createdAt: number;
+	updatedAt: number;
+	startedAt?: number;
+	finishedAt?: number;
+	attempt: number;
+	parentStepId?: string;
+}
+
+interface PersistedHook {
+	id: string;
+	runId: string;
+	token: string;
+	name: string;
+	status: HookStatus;
+	createdAt: number;
+	updatedAt: number;
+	disposedAt?: number;
+	triggeredAt?: number;
+	metadata?: Record<string, unknown>;
+}
+
+interface PersistedEvent {
+	id: string;
+	type: EventType;
+	runId: string;
+	stepId?: string;
+	hookId?: string;
+	correlationId?: string;
+	data?: unknown;
+	createdAt: number;
+}
+
+interface PersistedStreamChunk {
+	index: number;
+	data: string;
+}
+
+interface PersistedStream {
+	name: string;
+	chunks: PersistedStreamChunk[];
+	tailIndex: number;
+	done: boolean;
+}
+
+interface WorkflowRunState {
+	initialized: boolean;
+	run?: PersistedRun;
+	steps: Record<string, PersistedStep>;
+	hooks: Record<string, PersistedHook>;
+	events: PersistedEvent[];
+	idempotencyKeys: Record<string, string>;
+	streams: Record<string, PersistedStream>;
+}
+
+// ---------------------------------------------------------------------------
+// Terminal state helper
+// ---------------------------------------------------------------------------
+
+const TERMINAL_RUN_STATUSES: readonly WorkflowRunStatus[] = [
+	"completed",
+	"failed",
+	"cancelled",
+];
+
+function isTerminalRunStatus(status: WorkflowRunStatus): boolean {
+	return TERMINAL_RUN_STATUSES.includes(status);
+}
+
+// ---------------------------------------------------------------------------
+// Mapping helpers
+// ---------------------------------------------------------------------------
+
+function runToPublic(run: PersistedRun): WorkflowRun {
+	return {
+		id: run.id,
+		workflowName: run.workflowName,
+		status: run.status,
+		input: run.input,
+		output: run.output,
+		error: run.error as WorkflowRun["error"],
+		createdAt: new Date(run.createdAt),
+		updatedAt: new Date(run.updatedAt),
+		startedAt: run.startedAt ? new Date(run.startedAt) : undefined,
+		finishedAt: run.finishedAt ? new Date(run.finishedAt) : undefined,
+		deploymentId: run.deploymentId,
+		parentRunId: run.parentRunId,
+		parentStepId: run.parentStepId,
+		traceCarrier: run.traceCarrier,
+		metadata: run.metadata,
+	};
+}
+
+function stepToPublic(step: PersistedStep): Step {
+	return {
+		id: step.id,
+		runId: step.runId,
+		name: step.name,
+		status: step.status,
+		input: step.input,
+		output: step.output,
+		error: step.error as Step["error"],
+		createdAt: new Date(step.createdAt),
+		updatedAt: new Date(step.updatedAt),
+		startedAt: step.startedAt ? new Date(step.startedAt) : undefined,
+		finishedAt: step.finishedAt ? new Date(step.finishedAt) : undefined,
+		attempt: step.attempt,
+		parentStepId: step.parentStepId,
+	};
+}
+
+function hookToPublic(hook: PersistedHook): Hook {
+	return {
+		id: hook.id,
+		runId: hook.runId,
+		token: hook.token,
+		name: hook.name,
+		status: hook.status,
+		createdAt: new Date(hook.createdAt),
+		updatedAt: new Date(hook.updatedAt),
+		disposedAt: hook.disposedAt ? new Date(hook.disposedAt) : undefined,
+		triggeredAt: hook.triggeredAt ? new Date(hook.triggeredAt) : undefined,
+		metadata: hook.metadata,
+	};
+}
+
+function eventToPublic(e: PersistedEvent): WorldEvent {
+	return {
+		id: e.id,
+		type: e.type,
+		runId: e.runId,
+		stepId: e.stepId,
+		hookId: e.hookId,
+		correlationId: e.correlationId,
+		data: e.data,
+		createdAt: new Date(e.createdAt),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Event materialization
+// ---------------------------------------------------------------------------
+
+interface MaterializeArgs {
+	state: WorkflowRunState;
+	event: PersistedEvent;
+	data: CreateEventRequest | RunCreatedEventRequest;
+}
+
+function materializeEvent(args: MaterializeArgs): void {
+	const { state, event: ev, data } = args;
+	const now = ev.createdAt;
+
+	if (data.type === "run_created") {
+		if (state.run) {
+			// Idempotency: treat as no-op so replays do not clobber state.
+			return;
+		}
+		state.run = {
+			id: ev.runId,
+			workflowName: data.workflowName,
+			status: "pending",
+			input: data.input,
+			createdAt: now,
+			updatedAt: now,
+			deploymentId: data.deploymentId,
+			parentRunId: data.parentRunId,
+			parentStepId: data.parentStepId,
+			traceCarrier: data.traceCarrier,
+			metadata: data.metadata,
+		};
+		return;
+	}
+
+	if (!state.run) {
+		// Ignore events that arrive before run_created. This keeps the actor
+		// defensive; the coordinator should prevent this in practice.
+		return;
+	}
+
+	switch (data.type) {
+		case "run_started":
+			state.run.status = "running";
+			state.run.startedAt ??= now;
+			state.run.updatedAt = now;
+			break;
+		case "run_completed":
+			state.run.status = "completed";
+			state.run.finishedAt = now;
+			state.run.updatedAt = now;
+			if (data.data !== undefined) {
+				state.run.output = data.data;
+			}
+			break;
+		case "run_failed":
+			state.run.status = "failed";
+			state.run.finishedAt = now;
+			state.run.updatedAt = now;
+			state.run.error = data.data;
+			break;
+		case "run_cancelled":
+			state.run.status = "cancelled";
+			state.run.finishedAt = now;
+			state.run.updatedAt = now;
+			break;
+		case "run_updated":
+			state.run.updatedAt = now;
+			if (typeof data.data === "object" && data.data !== null) {
+				Object.assign(state.run, data.data);
+			}
+			break;
+		case "step_created": {
+			const stepId = data.stepId;
+			if (!stepId) break;
+			const stepData = (data.data ?? {}) as Partial<PersistedStep>;
+			state.steps[stepId] = {
+				id: stepId,
+				runId: ev.runId,
+				name: stepData.name ?? "step",
+				status: "pending",
+				input: stepData.input,
+				createdAt: now,
+				updatedAt: now,
+				attempt: 0,
+				parentStepId: stepData.parentStepId,
+			};
+			break;
+		}
+		case "step_started": {
+			const step = data.stepId ? state.steps[data.stepId] : undefined;
+			if (!step) break;
+			step.status = "running";
+			step.startedAt ??= now;
+			step.updatedAt = now;
+			step.attempt += 1;
+			break;
+		}
+		case "step_completed": {
+			const step = data.stepId ? state.steps[data.stepId] : undefined;
+			if (!step) break;
+			step.status = "completed";
+			step.finishedAt = now;
+			step.updatedAt = now;
+			step.output = data.data;
+			break;
+		}
+		case "step_failed": {
+			const step = data.stepId ? state.steps[data.stepId] : undefined;
+			if (!step) break;
+			step.status = "failed";
+			step.finishedAt = now;
+			step.updatedAt = now;
+			step.error = data.data;
+			break;
+		}
+		case "step_cancelled": {
+			const step = data.stepId ? state.steps[data.stepId] : undefined;
+			if (!step) break;
+			step.status = "cancelled";
+			step.finishedAt = now;
+			step.updatedAt = now;
+			break;
+		}
+		case "step_retrying": {
+			const step = data.stepId ? state.steps[data.stepId] : undefined;
+			if (!step) break;
+			step.status = "pending";
+			step.updatedAt = now;
+			break;
+		}
+		case "hook_created": {
+			const hookId = data.hookId;
+			if (!hookId) break;
+			const hookData = (data.data ?? {}) as Partial<PersistedHook>;
+			state.hooks[hookId] = {
+				id: hookId,
+				runId: ev.runId,
+				token: hookData.token ?? hookId,
+				name: hookData.name ?? "hook",
+				status: "pending",
+				createdAt: now,
+				updatedAt: now,
+				metadata: hookData.metadata,
+			};
+			break;
+		}
+		case "hook_triggered": {
+			const hook = data.hookId ? state.hooks[data.hookId] : undefined;
+			if (!hook) break;
+			hook.status = "triggered";
+			hook.triggeredAt = now;
+			hook.updatedAt = now;
+			break;
+		}
+		case "hook_disposed": {
+			const hook = data.hookId ? state.hooks[data.hookId] : undefined;
+			if (!hook) break;
+			hook.status = "disposed";
+			hook.disposedAt = now;
+			hook.updatedAt = now;
+			break;
+		}
+		case "hook_conflict":
+		case "stream_chunk":
+		case "stream_closed":
+			// No materialization needed. Streams are mutated directly; hook
+			// conflicts are surfaced through the event itself.
+			break;
+	}
+
+	// Auto-dispose hooks when the run enters a terminal status.
+	if (state.run && isTerminalRunStatus(state.run.status)) {
+		for (const hook of Object.values(state.hooks)) {
+			if (hook.status === "pending") {
+				hook.status = "disposed";
+				hook.disposedAt = now;
+				hook.updatedAt = now;
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Actor definition
+// ---------------------------------------------------------------------------
+
+export const workflowRunActor = actor({
+	state: {
+		initialized: false,
+		steps: {},
+		hooks: {},
+		events: [],
+		idempotencyKeys: {},
+		streams: {},
+	} as WorkflowRunState,
+	events: {
+		streamAppended: event<{
+			streamName: string;
+			chunks: PersistedStreamChunk[];
+			done: boolean;
+		}>(),
+	},
+	actions: {
+		/** Initialize the run identity. Called implicitly by `createEvent`. */
+		ensureRun: (c, runId: string) => {
+			if (!c.state.initialized) {
+				c.state.initialized = true;
+			}
+			return runId;
+		},
+
+		/** Append an event. Atomically updates materialized state. */
+		createEvent: (
+			c,
+			runId: string,
+			data: RunCreatedEventRequest | CreateEventRequest,
+			opts?: { idempotencyKey?: string },
+		): EventResult => {
+			if (opts?.idempotencyKey) {
+				const existingId = c.state.idempotencyKeys[opts.idempotencyKey];
+				if (existingId) {
+					const existing = c.state.events.find(
+						(e) => e.id === existingId,
+					);
+					if (existing) {
+						return {
+							event: eventToPublic(existing),
+							run: c.state.run
+								? runToPublic(c.state.run)
+								: undefined,
+						};
+					}
+				}
+			}
+
+			const ev: PersistedEvent = {
+				id: uuidv4(),
+				type: data.type,
+				runId,
+				stepId: "stepId" in data ? data.stepId : undefined,
+				hookId: "hookId" in data ? data.hookId : undefined,
+				correlationId:
+					"correlationId" in data ? data.correlationId : undefined,
+				data: "data" in data ? data.data : undefined,
+				createdAt: nowMs(),
+			};
+
+			materializeEvent({ state: c.state, event: ev, data });
+			c.state.events.push(ev);
+
+			if (opts?.idempotencyKey) {
+				c.state.idempotencyKeys[opts.idempotencyKey] = ev.id;
+			}
+
+			return {
+				event: eventToPublic(ev),
+				run: c.state.run ? runToPublic(c.state.run) : undefined,
+			};
+		},
+
+		getRun: (c): WorkflowRun | null => {
+			return c.state.run ? runToPublic(c.state.run) : null;
+		},
+
+		getStep: (c, stepId: string): Step | null => {
+			const step = c.state.steps[stepId];
+			return step ? stepToPublic(step) : null;
+		},
+
+		listSteps: (
+			c,
+			opts?: { status?: StepStatus; cursor?: string; limit?: number },
+		) => {
+			const limit = opts?.limit ?? 50;
+			let items = Object.values(c.state.steps);
+			if (opts?.status) {
+				items = items.filter((s) => s.status === opts.status);
+			}
+			items.sort((a, b) => a.createdAt - b.createdAt);
+
+			const startIdx = opts?.cursor ? Number.parseInt(opts.cursor, 10) : 0;
+			const slice = items.slice(startIdx, startIdx + limit);
+			const nextIdx = startIdx + slice.length;
+			return {
+				data: slice.map(stepToPublic),
+				cursor: nextIdx < items.length ? String(nextIdx) : null,
+				hasMore: nextIdx < items.length,
+			};
+		},
+
+		listEvents: (
+			c,
+			opts?: {
+				types?: EventType[];
+				stepId?: string;
+				hookId?: string;
+				cursor?: string;
+				limit?: number;
+			},
+		) => {
+			const limit = opts?.limit ?? 100;
+			let items = c.state.events;
+			if (opts?.types && opts.types.length > 0) {
+				const set = new Set(opts.types);
+				items = items.filter((e) => set.has(e.type));
+			}
+			if (opts?.stepId) {
+				items = items.filter((e) => e.stepId === opts.stepId);
+			}
+			if (opts?.hookId) {
+				items = items.filter((e) => e.hookId === opts.hookId);
+			}
+
+			const startIdx = opts?.cursor ? Number.parseInt(opts.cursor, 10) : 0;
+			const slice = items.slice(startIdx, startIdx + limit);
+			const nextIdx = startIdx + slice.length;
+			return {
+				data: slice.map(eventToPublic),
+				cursor: nextIdx < items.length ? String(nextIdx) : null,
+				hasMore: nextIdx < items.length,
+			};
+		},
+
+		listEventsByCorrelationId: (
+			c,
+			correlationId: string,
+			opts?: { cursor?: string; limit?: number },
+		) => {
+			const limit = opts?.limit ?? 100;
+			const items = c.state.events.filter(
+				(e) => e.correlationId === correlationId,
+			);
+			const startIdx = opts?.cursor ? Number.parseInt(opts.cursor, 10) : 0;
+			const slice = items.slice(startIdx, startIdx + limit);
+			const nextIdx = startIdx + slice.length;
+			return {
+				data: slice.map(eventToPublic),
+				cursor: nextIdx < items.length ? String(nextIdx) : null,
+				hasMore: nextIdx < items.length,
+			};
+		},
+
+		getHook: (c, hookId: string): Hook | null => {
+			const hook = c.state.hooks[hookId];
+			return hook ? hookToPublic(hook) : null;
+		},
+
+		listHooks: (
+			c,
+			opts?: { status?: HookStatus; cursor?: string; limit?: number },
+		) => {
+			const limit = opts?.limit ?? 50;
+			let items = Object.values(c.state.hooks);
+			if (opts?.status) {
+				items = items.filter((h) => h.status === opts.status);
+			}
+			items.sort((a, b) => a.createdAt - b.createdAt);
+			const startIdx = opts?.cursor ? Number.parseInt(opts.cursor, 10) : 0;
+			const slice = items.slice(startIdx, startIdx + limit);
+			const nextIdx = startIdx + slice.length;
+			return {
+				data: slice.map(hookToPublic),
+				cursor: nextIdx < items.length ? String(nextIdx) : null,
+				hasMore: nextIdx < items.length,
+			};
+		},
+
+		// ------------------------------------------------------------------
+		// Stream operations
+		// ------------------------------------------------------------------
+
+		writeStream: (
+			c,
+			streamName: string,
+			chunks: (string | Uint8Array)[],
+		) => {
+			let stream = c.state.streams[streamName];
+			if (!stream) {
+				stream = {
+					name: streamName,
+					chunks: [],
+					tailIndex: -1,
+					done: false,
+				};
+				c.state.streams[streamName] = stream;
+			}
+			if (stream.done) {
+				throw new Error(`stream ${streamName} is closed`);
+			}
+			const appended: PersistedStreamChunk[] = [];
+			for (const chunk of chunks) {
+				stream.tailIndex += 1;
+				const encoded: PersistedStreamChunk = {
+					index: stream.tailIndex,
+					data: encodeBinary(chunk),
+				};
+				stream.chunks.push(encoded);
+				appended.push(encoded);
+			}
+			c.broadcast("streamAppended", {
+				streamName,
+				chunks: appended,
+				done: false,
+			});
+		},
+
+		closeStream: (c, streamName: string) => {
+			const stream = c.state.streams[streamName];
+			if (!stream) {
+				c.state.streams[streamName] = {
+					name: streamName,
+					chunks: [],
+					tailIndex: -1,
+					done: true,
+				};
+				c.broadcast("streamAppended", {
+					streamName,
+					chunks: [],
+					done: true,
+				});
+				return;
+			}
+			stream.done = true;
+			c.broadcast("streamAppended", {
+				streamName,
+				chunks: [],
+				done: true,
+			});
+		},
+
+		getStreamInfo: (c, streamName: string) => {
+			const stream = c.state.streams[streamName];
+			if (!stream) {
+				return { tailIndex: -1, done: false };
+			}
+			return { tailIndex: stream.tailIndex, done: stream.done };
+		},
+
+		getStreamChunks: (
+			c,
+			streamName: string,
+			opts?: { limit?: number; cursor?: string },
+		) => {
+			const stream = c.state.streams[streamName];
+			if (!stream) {
+				return {
+					data: [] as PersistedStreamChunk[],
+					cursor: null as string | null,
+					hasMore: false,
+					done: false,
+				};
+			}
+			const limit = opts?.limit ?? 100;
+			const startIdx = opts?.cursor
+				? Number.parseInt(opts.cursor, 10)
+				: 0;
+			const slice = stream.chunks.slice(startIdx, startIdx + limit);
+			const nextIdx = startIdx + slice.length;
+			const hasMore = nextIdx < stream.chunks.length;
+			return {
+				data: slice,
+				cursor: hasMore ? String(nextIdx) : null,
+				hasMore,
+				done: stream.done && !hasMore,
+			};
+		},
+
+		listStreams: (c): string[] => {
+			return Object.keys(c.state.streams);
+		},
+	},
+});

--- a/rivetkit-typescript/packages/world-workflow/src/index.ts
+++ b/rivetkit-typescript/packages/world-workflow/src/index.ts
@@ -1,0 +1,23 @@
+/**
+ * `@rivetkit/world-workflow` — Vercel Workflow SDK World implementation
+ * backed by Rivet Actors.
+ *
+ * Usage:
+ *
+ * ```ts
+ * import { createRivetWorld } from "@rivetkit/world-workflow";
+ * import { registry } from "@rivetkit/world-workflow/registry";
+ *
+ * // Somewhere in your server entry point, start the registry:
+ * registry.start();
+ *
+ * // And build a World the Workflow SDK can use:
+ * export const world = createRivetWorld({
+ *   endpoint: process.env.RIVET_ENDPOINT,
+ * });
+ * ```
+ */
+
+export { createRivetWorld } from "./world";
+export type { RivetWorldConfig } from "./world";
+export * from "./types";

--- a/rivetkit-typescript/packages/world-workflow/src/registry.ts
+++ b/rivetkit-typescript/packages/world-workflow/src/registry.ts
@@ -1,0 +1,25 @@
+/**
+ * RivetKit registry containing the three actors that back the Rivet World.
+ *
+ * Host code that wants to run a Rivet World must boot this registry via the
+ * normal RivetKit entrypoints (`registry.start()`, `registry.serve()`, or
+ * `registry.handler(req)`). `createRivetWorld` returns a World instance that
+ * talks to this registry over a RivetKit client.
+ */
+
+import { setup } from "rivetkit";
+import { coordinatorActor } from "./actors/coordinator";
+import { queueActor } from "./actors/queue";
+import { workflowRunActor } from "./actors/workflow-run";
+
+export const registry = setup({
+	use: {
+		workflowRun: workflowRunActor,
+		coordinator: coordinatorActor,
+		queueRunner: queueActor,
+	},
+});
+
+export type WorldRegistry = typeof registry;
+
+export { workflowRunActor, coordinatorActor, queueActor };

--- a/rivetkit-typescript/packages/world-workflow/src/types.ts
+++ b/rivetkit-typescript/packages/world-workflow/src/types.ts
@@ -1,0 +1,399 @@
+/**
+ * Vercel Workflow SDK `World` types.
+ *
+ * These mirror the public contract from `@workflow/world`. We redeclare them
+ * locally so this package does not hard-depend on the SDK. The shapes are
+ * derived from https://useworkflow.dev/docs/deploying/building-a-world and
+ * the Postgres and Local reference worlds.
+ *
+ * When the upstream types drift, update this file to keep parity.
+ */
+
+// ---------------------------------------------------------------------------
+// Primitive types
+// ---------------------------------------------------------------------------
+
+export type MessageId = string;
+
+/** Queue name, always prefixed with `__wkf_workflow_` or `__wkf_step_`. */
+export type ValidQueueName = `__wkf_workflow_${string}` | `__wkf_step_${string}`;
+
+/** Queue prefix used when registering a handler. */
+export type QueuePrefix = "__wkf_workflow_" | "__wkf_step_";
+
+export interface PaginatedResponse<T> {
+	data: T[];
+	cursor: string | null;
+	hasMore: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Run / Step / Hook state
+// ---------------------------------------------------------------------------
+
+export type WorkflowRunStatus =
+	| "pending"
+	| "running"
+	| "completed"
+	| "failed"
+	| "cancelled";
+
+export type StepStatus =
+	| "pending"
+	| "running"
+	| "completed"
+	| "failed"
+	| "cancelled";
+
+export type HookStatus = "pending" | "triggered" | "disposed";
+
+export interface WorkflowRun {
+	id: string;
+	workflowName: string;
+	status: WorkflowRunStatus;
+	input?: unknown;
+	output?: unknown;
+	error?: WorkflowRunError;
+	createdAt: Date;
+	updatedAt: Date;
+	startedAt?: Date;
+	finishedAt?: Date;
+	deploymentId?: string;
+	parentRunId?: string;
+	parentStepId?: string;
+	traceCarrier?: Record<string, string>;
+	metadata?: Record<string, unknown>;
+}
+
+export interface WorkflowRunError {
+	message: string;
+	stack?: string;
+	name?: string;
+	cause?: unknown;
+}
+
+export interface Step {
+	id: string;
+	runId: string;
+	name: string;
+	status: StepStatus;
+	input?: unknown;
+	output?: unknown;
+	error?: WorkflowRunError;
+	createdAt: Date;
+	updatedAt: Date;
+	startedAt?: Date;
+	finishedAt?: Date;
+	attempt: number;
+	parentStepId?: string;
+}
+
+export interface Hook {
+	id: string;
+	runId: string;
+	token: string;
+	name: string;
+	status: HookStatus;
+	createdAt: Date;
+	updatedAt: Date;
+	disposedAt?: Date;
+	triggeredAt?: Date;
+	metadata?: Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Events (append-only log)
+// ---------------------------------------------------------------------------
+
+export type EventType =
+	| "run_created"
+	| "run_started"
+	| "run_completed"
+	| "run_failed"
+	| "run_cancelled"
+	| "run_updated"
+	| "step_created"
+	| "step_started"
+	| "step_completed"
+	| "step_failed"
+	| "step_cancelled"
+	| "step_retrying"
+	| "hook_created"
+	| "hook_triggered"
+	| "hook_disposed"
+	| "hook_conflict"
+	| "stream_chunk"
+	| "stream_closed";
+
+export interface Event {
+	id: string;
+	type: EventType;
+	runId: string;
+	stepId?: string;
+	hookId?: string;
+	correlationId?: string;
+	data: unknown;
+	createdAt: Date;
+}
+
+export interface EventResult {
+	event: Event;
+	/** Present when an event results in a newly created run. */
+	run?: WorkflowRun;
+}
+
+export interface RunCreatedEventRequest {
+	type: "run_created";
+	workflowName: string;
+	input?: unknown;
+	deploymentId?: string;
+	parentRunId?: string;
+	parentStepId?: string;
+	traceCarrier?: Record<string, string>;
+	metadata?: Record<string, unknown>;
+}
+
+export interface CreateEventRequest {
+	type: Exclude<EventType, "run_created">;
+	stepId?: string;
+	hookId?: string;
+	correlationId?: string;
+	data?: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Query parameters
+// ---------------------------------------------------------------------------
+
+export interface GetWorkflowRunParams {
+	includeEvents?: boolean;
+}
+
+export interface ListWorkflowRunsParams {
+	cursor?: string;
+	limit?: number;
+	workflowName?: string;
+	status?: WorkflowRunStatus;
+	deploymentId?: string;
+	parentRunId?: string;
+	createdAfter?: Date;
+	createdBefore?: Date;
+}
+
+export interface GetStepParams {
+	includeEvents?: boolean;
+}
+
+export interface ListWorkflowRunStepsParams {
+	runId: string;
+	cursor?: string;
+	limit?: number;
+	status?: StepStatus;
+}
+
+export interface ListEventsParams {
+	runId: string;
+	cursor?: string;
+	limit?: number;
+	types?: EventType[];
+	stepId?: string;
+	hookId?: string;
+}
+
+export interface ListEventsByCorrelationIdParams {
+	correlationId: string;
+	cursor?: string;
+	limit?: number;
+}
+
+export interface CreateEventParams {
+	idempotencyKey?: string;
+}
+
+export interface GetHookParams {
+	includeEvents?: boolean;
+}
+
+export interface ListHooksParams {
+	runId: string;
+	cursor?: string;
+	limit?: number;
+	status?: HookStatus;
+}
+
+// ---------------------------------------------------------------------------
+// Queue payloads
+// ---------------------------------------------------------------------------
+
+export interface WorkflowInvokePayload {
+	runId: string;
+	traceCarrier?: Record<string, string>;
+	requestedAt?: Date;
+}
+
+export interface StepInvokePayload {
+	workflowName: string;
+	workflowRunId: string;
+	workflowStartedAt: number;
+	stepId: string;
+	traceCarrier?: Record<string, string>;
+	requestedAt?: Date;
+}
+
+export type QueuePayload = WorkflowInvokePayload | StepInvokePayload;
+
+export interface QueueRetryPolicy {
+	maxAttempts?: number;
+	initialBackoffMs?: number;
+	maxBackoffMs?: number;
+	backoffMultiplier?: number;
+}
+
+export interface QueueOptions {
+	idempotencyKey?: string;
+	delay?: number;
+	retryPolicy?: QueueRetryPolicy;
+}
+
+export interface QueueMessageMeta {
+	attempt: number;
+	queueName: ValidQueueName;
+	messageId: MessageId;
+}
+
+export type QueueHandler = (
+	message: unknown,
+	meta: QueueMessageMeta,
+) => Promise<void | { timeoutSeconds: number }>;
+
+// ---------------------------------------------------------------------------
+// World interface
+// ---------------------------------------------------------------------------
+
+export interface Storage {
+	runs: {
+		get(id: string, params?: GetWorkflowRunParams): Promise<WorkflowRun>;
+		list(
+			params?: ListWorkflowRunsParams,
+		): Promise<PaginatedResponse<WorkflowRun>>;
+	};
+	steps: {
+		get(
+			runId: string | undefined,
+			stepId: string,
+			params?: GetStepParams,
+		): Promise<Step>;
+		list(
+			params: ListWorkflowRunStepsParams,
+		): Promise<PaginatedResponse<Step>>;
+	};
+	events: {
+		create(
+			runId: string | null,
+			data: RunCreatedEventRequest,
+			params?: CreateEventParams,
+		): Promise<EventResult>;
+		create(
+			runId: string,
+			data: CreateEventRequest,
+			params?: CreateEventParams,
+		): Promise<EventResult>;
+		list(params: ListEventsParams): Promise<PaginatedResponse<Event>>;
+		listByCorrelationId(
+			params: ListEventsByCorrelationIdParams,
+		): Promise<PaginatedResponse<Event>>;
+	};
+	hooks: {
+		get(hookId: string, params?: GetHookParams): Promise<Hook>;
+		getByToken(token: string, params?: GetHookParams): Promise<Hook>;
+		list(params: ListHooksParams): Promise<PaginatedResponse<Hook>>;
+	};
+}
+
+export interface Queue {
+	getDeploymentId(): Promise<string>;
+	queue(
+		queueName: ValidQueueName,
+		message: QueuePayload,
+		opts?: QueueOptions,
+	): Promise<{ messageId: MessageId }>;
+	createQueueHandler(
+		queueNamePrefix: QueuePrefix,
+		handler: QueueHandler,
+	): (req: Request) => Promise<Response>;
+}
+
+export interface StreamChunk {
+	index: number;
+	data: Uint8Array;
+}
+
+export interface StreamInfo {
+	tailIndex: number;
+	done: boolean;
+}
+
+export interface StreamChunksResult {
+	data: StreamChunk[];
+	cursor: string | null;
+	hasMore: boolean;
+	done: boolean;
+}
+
+export interface Streamer {
+	writeToStream(
+		name: string,
+		runId: string,
+		chunk: string | Uint8Array,
+	): Promise<void>;
+	writeToStreamMulti?(
+		name: string,
+		runId: string,
+		chunks: (string | Uint8Array)[],
+	): Promise<void>;
+	closeStream(name: string, runId: string): Promise<void>;
+	readFromStream(
+		name: string,
+		startIndex?: number,
+	): Promise<ReadableStream<Uint8Array>>;
+	listStreamsByRunId(runId: string): Promise<string[]>;
+	getStreamChunks(
+		name: string,
+		runId: string,
+		options?: { limit?: number; cursor?: string },
+	): Promise<StreamChunksResult>;
+	getStreamInfo(name: string, runId: string): Promise<StreamInfo>;
+}
+
+export interface World extends Storage, Queue, Streamer {
+	start?(): Promise<void>;
+	close?(): Promise<void>;
+	getEncryptionKeyForRun?(run: WorkflowRun): Promise<Uint8Array | undefined>;
+}
+
+// ---------------------------------------------------------------------------
+// Error shapes
+// ---------------------------------------------------------------------------
+
+export class WorldError extends Error {
+	code: string;
+	constructor(code: string, message: string) {
+		super(message);
+		this.name = "WorldError";
+		this.code = code;
+	}
+}
+
+export class NotFoundError extends WorldError {
+	constructor(entity: string, id: string) {
+		super("not_found", `${entity} ${id} not found`);
+		this.name = "NotFoundError";
+	}
+}
+
+export class HookConflictError extends WorldError {
+	constructor(token: string) {
+		super("hook_conflict", `hook token ${token} already registered`);
+		this.name = "HookConflictError";
+	}
+}

--- a/rivetkit-typescript/packages/world-workflow/src/types.ts
+++ b/rivetkit-typescript/packages/world-workflow/src/types.ts
@@ -1,25 +1,25 @@
 /**
  * Vercel Workflow SDK `World` types.
  *
- * These mirror the public contract from `@workflow/world`. We redeclare them
- * locally so this package does not hard-depend on the SDK. The shapes are
- * derived from https://useworkflow.dev/docs/deploying/building-a-world and
- * the Postgres and Local reference worlds.
- *
+ * These mirror the public contract from `@workflow/world` (packages/world/src/).
  * When the upstream types drift, update this file to keep parity.
+ *
+ * Source: https://github.com/vercel/workflow/tree/main/packages/world/src
  */
 
 // ---------------------------------------------------------------------------
-// Primitive types
+// Shared primitives
 // ---------------------------------------------------------------------------
 
-export type MessageId = string;
+export type SerializedData = Uint8Array | unknown;
 
-/** Queue name, always prefixed with `__wkf_workflow_` or `__wkf_step_`. */
-export type ValidQueueName = `__wkf_workflow_${string}` | `__wkf_step_${string}`;
+export type ResolveData = "none" | "all";
 
-/** Queue prefix used when registering a handler. */
-export type QueuePrefix = "__wkf_workflow_" | "__wkf_step_";
+export interface PaginationOptions {
+	limit?: number;
+	cursor?: string;
+	sortOrder?: "asc" | "desc";
+}
 
 export interface PaginatedResponse<T> {
 	data: T[];
@@ -27,8 +27,24 @@ export interface PaginatedResponse<T> {
 	hasMore: boolean;
 }
 
+export interface StructuredError {
+	message: string;
+	stack?: string;
+	code?: string;
+}
+
+export type MessageId = string;
+
+export type ValidQueueName =
+	| `__wkf_workflow_${string}`
+	| `__wkf_step_${string}`;
+
+export type QueuePrefix = "__wkf_workflow_" | "__wkf_step_";
+
+export type TraceCarrier = Record<string, string>;
+
 // ---------------------------------------------------------------------------
-// Run / Step / Hook state
+// WorkflowRun
 // ---------------------------------------------------------------------------
 
 export type WorkflowRunStatus =
@@ -38,6 +54,32 @@ export type WorkflowRunStatus =
 	| "failed"
 	| "cancelled";
 
+export interface WorkflowRun {
+	runId: string;
+	status: WorkflowRunStatus;
+	deploymentId: string;
+	workflowName: string;
+	specVersion?: number;
+	executionContext?: Record<string, unknown>;
+	input: SerializedData;
+	output?: SerializedData;
+	error?: StructuredError;
+	expiredAt?: Date;
+	startedAt?: Date;
+	completedAt?: Date;
+	createdAt: Date;
+	updatedAt: Date;
+}
+
+export type WorkflowRunWithoutData = Omit<WorkflowRun, "input" | "output"> & {
+	input: undefined;
+	output: undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Step
+// ---------------------------------------------------------------------------
+
 export type StepStatus =
 	| "pending"
 	| "running"
@@ -45,64 +87,64 @@ export type StepStatus =
 	| "failed"
 	| "cancelled";
 
-export type HookStatus = "pending" | "triggered" | "disposed";
-
-export interface WorkflowRun {
-	id: string;
-	workflowName: string;
-	status: WorkflowRunStatus;
-	input?: unknown;
-	output?: unknown;
-	error?: WorkflowRunError;
-	createdAt: Date;
-	updatedAt: Date;
-	startedAt?: Date;
-	finishedAt?: Date;
-	deploymentId?: string;
-	parentRunId?: string;
-	parentStepId?: string;
-	traceCarrier?: Record<string, string>;
-	metadata?: Record<string, unknown>;
-}
-
-export interface WorkflowRunError {
-	message: string;
-	stack?: string;
-	name?: string;
-	cause?: unknown;
-}
-
 export interface Step {
-	id: string;
 	runId: string;
-	name: string;
+	stepId: string;
+	stepName: string;
 	status: StepStatus;
-	input?: unknown;
-	output?: unknown;
-	error?: WorkflowRunError;
+	input: SerializedData;
+	output?: SerializedData;
+	error?: StructuredError;
+	attempt: number;
+	startedAt?: Date;
+	completedAt?: Date;
 	createdAt: Date;
 	updatedAt: Date;
-	startedAt?: Date;
-	finishedAt?: Date;
-	attempt: number;
-	parentStepId?: string;
+	retryAfter?: Date;
+	specVersion?: number;
 }
+
+export type StepWithoutData = Omit<Step, "input" | "output"> & {
+	input: undefined;
+	output: undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
 
 export interface Hook {
-	id: string;
 	runId: string;
+	hookId: string;
 	token: string;
-	name: string;
-	status: HookStatus;
+	ownerId: string;
+	projectId: string;
+	environment: string;
+	metadata?: SerializedData;
 	createdAt: Date;
-	updatedAt: Date;
-	disposedAt?: Date;
-	triggeredAt?: Date;
-	metadata?: Record<string, unknown>;
+	specVersion?: number;
+	isWebhook?: boolean;
 }
 
 // ---------------------------------------------------------------------------
-// Events (append-only log)
+// Wait
+// ---------------------------------------------------------------------------
+
+export type WaitStatus = "waiting" | "completed";
+
+export interface Wait {
+	waitId: string;
+	runId: string;
+	status: WaitStatus;
+	resumeAt?: Date;
+	completedAt?: Date;
+	createdAt: Date;
+	updatedAt: Date;
+	specVersion?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Events
 // ---------------------------------------------------------------------------
 
 export type EventType =
@@ -111,54 +153,55 @@ export type EventType =
 	| "run_completed"
 	| "run_failed"
 	| "run_cancelled"
-	| "run_updated"
 	| "step_created"
 	| "step_started"
 	| "step_completed"
 	| "step_failed"
-	| "step_cancelled"
 	| "step_retrying"
 	| "hook_created"
-	| "hook_triggered"
+	| "hook_received"
 	| "hook_disposed"
 	| "hook_conflict"
-	| "stream_chunk"
-	| "stream_closed";
+	| "wait_created"
+	| "wait_completed";
 
 export interface Event {
-	id: string;
-	type: EventType;
 	runId: string;
-	stepId?: string;
-	hookId?: string;
+	eventId: string;
+	eventType: EventType;
 	correlationId?: string;
-	data: unknown;
+	eventData?: unknown;
 	createdAt: Date;
+	specVersion?: number;
 }
 
 export interface EventResult {
-	event: Event;
-	/** Present when an event results in a newly created run. */
+	event?: Event;
 	run?: WorkflowRun;
+	step?: Step;
+	hook?: Hook;
+	wait?: Wait;
+	events?: Event[];
 }
 
+// ---------------------------------------------------------------------------
+// Event request types
+// ---------------------------------------------------------------------------
+
 export interface RunCreatedEventRequest {
-	type: "run_created";
-	workflowName: string;
-	input?: unknown;
-	deploymentId?: string;
-	parentRunId?: string;
-	parentStepId?: string;
-	traceCarrier?: Record<string, string>;
-	metadata?: Record<string, unknown>;
+	eventType: "run_created";
+	eventData: {
+		deploymentId: string;
+		workflowName: string;
+		input: SerializedData;
+		executionContext?: Record<string, unknown>;
+	};
 }
 
 export interface CreateEventRequest {
-	type: Exclude<EventType, "run_created">;
-	stepId?: string;
-	hookId?: string;
+	eventType: Exclude<EventType, "run_created">;
 	correlationId?: string;
-	data?: unknown;
+	eventData?: unknown;
 }
 
 // ---------------------------------------------------------------------------
@@ -166,69 +209,84 @@ export interface CreateEventRequest {
 // ---------------------------------------------------------------------------
 
 export interface GetWorkflowRunParams {
-	includeEvents?: boolean;
+	resolveData?: ResolveData;
 }
 
 export interface ListWorkflowRunsParams {
-	cursor?: string;
-	limit?: number;
 	workflowName?: string;
 	status?: WorkflowRunStatus;
-	deploymentId?: string;
-	parentRunId?: string;
-	createdAfter?: Date;
-	createdBefore?: Date;
+	pagination?: PaginationOptions;
+	resolveData?: ResolveData;
+}
+
+export interface CreateWorkflowRunRequest {
+	deploymentId: string;
+	workflowName: string;
+	input: SerializedData;
+	executionContext?: SerializedData;
+	specVersion?: number;
 }
 
 export interface GetStepParams {
-	includeEvents?: boolean;
+	resolveData?: ResolveData;
 }
 
 export interface ListWorkflowRunStepsParams {
 	runId: string;
-	cursor?: string;
-	limit?: number;
-	status?: StepStatus;
+	pagination?: PaginationOptions;
+	resolveData?: ResolveData;
+}
+
+export interface CreateEventParams {
+	v1Compat?: boolean;
+	resolveData?: ResolveData;
+	requestId?: string;
+}
+
+export interface GetEventParams {
+	resolveData?: ResolveData;
 }
 
 export interface ListEventsParams {
 	runId: string;
-	cursor?: string;
-	limit?: number;
-	types?: EventType[];
-	stepId?: string;
-	hookId?: string;
+	pagination?: PaginationOptions;
+	resolveData?: ResolveData;
 }
 
 export interface ListEventsByCorrelationIdParams {
 	correlationId: string;
-	cursor?: string;
-	limit?: number;
-}
-
-export interface CreateEventParams {
-	idempotencyKey?: string;
+	pagination?: PaginationOptions;
+	resolveData?: ResolveData;
 }
 
 export interface GetHookParams {
-	includeEvents?: boolean;
+	resolveData?: ResolveData;
 }
 
 export interface ListHooksParams {
-	runId: string;
-	cursor?: string;
-	limit?: number;
-	status?: HookStatus;
+	runId?: string;
+	pagination?: PaginationOptions;
+	resolveData?: ResolveData;
 }
 
 // ---------------------------------------------------------------------------
 // Queue payloads
 // ---------------------------------------------------------------------------
 
+export interface RunInput {
+	input: unknown;
+	deploymentId: string;
+	workflowName: string;
+	specVersion: number;
+	executionContext?: Record<string, unknown>;
+}
+
 export interface WorkflowInvokePayload {
 	runId: string;
-	traceCarrier?: Record<string, string>;
+	traceCarrier?: TraceCarrier;
 	requestedAt?: Date;
+	serverErrorRetryCount?: number;
+	runInput?: RunInput;
 }
 
 export interface StepInvokePayload {
@@ -236,29 +294,33 @@ export interface StepInvokePayload {
 	workflowRunId: string;
 	workflowStartedAt: number;
 	stepId: string;
-	traceCarrier?: Record<string, string>;
+	traceCarrier?: TraceCarrier;
 	requestedAt?: Date;
 }
 
-export type QueuePayload = WorkflowInvokePayload | StepInvokePayload;
-
-export interface QueueRetryPolicy {
-	maxAttempts?: number;
-	initialBackoffMs?: number;
-	maxBackoffMs?: number;
-	backoffMultiplier?: number;
+export interface HealthCheckPayload {
+	__healthCheck: true;
+	correlationId: string;
 }
 
+export type QueuePayload =
+	| WorkflowInvokePayload
+	| StepInvokePayload
+	| HealthCheckPayload;
+
 export interface QueueOptions {
+	deploymentId?: string;
 	idempotencyKey?: string;
-	delay?: number;
-	retryPolicy?: QueueRetryPolicy;
+	headers?: Record<string, string>;
+	delaySeconds?: number;
+	specVersion?: number;
 }
 
 export interface QueueMessageMeta {
 	attempt: number;
 	queueName: ValidQueueName;
 	messageId: MessageId;
+	requestId?: string;
 }
 
 export type QueueHandler = (
@@ -267,25 +329,54 @@ export type QueueHandler = (
 ) => Promise<void | { timeoutSeconds: number }>;
 
 // ---------------------------------------------------------------------------
+// Stream types
+// ---------------------------------------------------------------------------
+
+export interface StreamChunk {
+	index: number;
+	data: Uint8Array;
+}
+
+export interface GetChunksOptions {
+	limit?: number;
+	cursor?: string;
+}
+
+export interface StreamInfoResponse {
+	tailIndex: number;
+	done: boolean;
+}
+
+export interface StreamChunksResponse {
+	data: StreamChunk[];
+	cursor: string | null;
+	hasMore: boolean;
+	done: boolean;
+}
+
+// ---------------------------------------------------------------------------
 // World interface
 // ---------------------------------------------------------------------------
 
 export interface Storage {
 	runs: {
-		get(id: string, params?: GetWorkflowRunParams): Promise<WorkflowRun>;
+		get(
+			id: string,
+			params?: GetWorkflowRunParams,
+		): Promise<WorkflowRun | WorkflowRunWithoutData>;
 		list(
 			params?: ListWorkflowRunsParams,
-		): Promise<PaginatedResponse<WorkflowRun>>;
+		): Promise<PaginatedResponse<WorkflowRun | WorkflowRunWithoutData>>;
 	};
 	steps: {
 		get(
-			runId: string | undefined,
+			runId: string,
 			stepId: string,
 			params?: GetStepParams,
-		): Promise<Step>;
+		): Promise<Step | StepWithoutData>;
 		list(
 			params: ListWorkflowRunStepsParams,
-		): Promise<PaginatedResponse<Step>>;
+		): Promise<PaginatedResponse<Step | StepWithoutData>>;
 	};
 	events: {
 		create(
@@ -298,6 +389,11 @@ export interface Storage {
 			data: CreateEventRequest,
 			params?: CreateEventParams,
 		): Promise<EventResult>;
+		get(
+			runId: string,
+			eventId: string,
+			params?: GetEventParams,
+		): Promise<Event>;
 		list(params: ListEventsParams): Promise<PaginatedResponse<Event>>;
 		listByCorrelationId(
 			params: ListEventsByCorrelationIdParams,
@@ -316,60 +412,67 @@ export interface Queue {
 		queueName: ValidQueueName,
 		message: QueuePayload,
 		opts?: QueueOptions,
-	): Promise<{ messageId: MessageId }>;
+	): Promise<{ messageId: MessageId | null }>;
 	createQueueHandler(
 		queueNamePrefix: QueuePrefix,
 		handler: QueueHandler,
 	): (req: Request) => Promise<Response>;
 }
 
-export interface StreamChunk {
-	index: number;
-	data: Uint8Array;
-}
-
-export interface StreamInfo {
-	tailIndex: number;
-	done: boolean;
-}
-
-export interface StreamChunksResult {
-	data: StreamChunk[];
-	cursor: string | null;
-	hasMore: boolean;
-	done: boolean;
-}
-
 export interface Streamer {
-	writeToStream(
-		name: string,
-		runId: string,
-		chunk: string | Uint8Array,
-	): Promise<void>;
-	writeToStreamMulti?(
-		name: string,
-		runId: string,
-		chunks: (string | Uint8Array)[],
-	): Promise<void>;
-	closeStream(name: string, runId: string): Promise<void>;
-	readFromStream(
-		name: string,
-		startIndex?: number,
-	): Promise<ReadableStream<Uint8Array>>;
-	listStreamsByRunId(runId: string): Promise<string[]>;
-	getStreamChunks(
-		name: string,
-		runId: string,
-		options?: { limit?: number; cursor?: string },
-	): Promise<StreamChunksResult>;
-	getStreamInfo(name: string, runId: string): Promise<StreamInfo>;
+	streamFlushIntervalMs?: number;
+	streams: {
+		write(
+			runId: string,
+			name: string,
+			chunk: string | Uint8Array,
+		): Promise<void>;
+		writeMulti?(
+			runId: string,
+			name: string,
+			chunks: (string | Uint8Array)[],
+		): Promise<void>;
+		close(runId: string, name: string): Promise<void>;
+		get(
+			runId: string,
+			name: string,
+			startIndex?: number,
+		): Promise<ReadableStream<Uint8Array>>;
+		list(runId: string): Promise<string[]>;
+		getChunks(
+			runId: string,
+			name: string,
+			options?: GetChunksOptions,
+		): Promise<StreamChunksResponse>;
+		getInfo(
+			runId: string,
+			name: string,
+		): Promise<StreamInfoResponse>;
+	};
 }
 
 export interface World extends Storage, Queue, Streamer {
+	specVersion?: number;
 	start?(): Promise<void>;
 	close?(): Promise<void>;
-	getEncryptionKeyForRun?(run: WorkflowRun): Promise<Uint8Array | undefined>;
+	resolveLatestDeploymentId?(): Promise<string>;
+	getEncryptionKeyForRun?(
+		run: WorkflowRun,
+	): Promise<Uint8Array | undefined>;
+	getEncryptionKeyForRun?(
+		runId: string,
+		context?: Record<string, unknown>,
+	): Promise<Uint8Array | undefined>;
 }
+
+// ---------------------------------------------------------------------------
+// Spec versions
+// ---------------------------------------------------------------------------
+
+export const SPEC_VERSION_LEGACY = 1;
+export const SPEC_VERSION_SUPPORTS_EVENT_SOURCING = 2;
+export const SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT = 3;
+export const SPEC_VERSION_CURRENT = SPEC_VERSION_SUPPORTS_CBOR_QUEUE_TRANSPORT;
 
 // ---------------------------------------------------------------------------
 // Error shapes

--- a/rivetkit-typescript/packages/world-workflow/src/world.ts
+++ b/rivetkit-typescript/packages/world-workflow/src/world.ts
@@ -1,0 +1,577 @@
+/**
+ * `createRivetWorld` factory.
+ *
+ * Wires the three Rivet actors into a single `World` instance that
+ * implements the Vercel Workflow SDK's `Storage`, `Queue`, and `Streamer`
+ * interfaces.
+ *
+ * A note on actor sharding: the coordinator and queue actors are singletons
+ * per name. The `workflowRun` actor is keyed by `runId`, so each run lives
+ * on its own actor and can be materialized independently.
+ */
+
+import { createClient } from "rivetkit/client";
+import { v4 as uuidv4 } from "uuid";
+import { decodeBinary } from "./actors/shared";
+import type { WorldRegistry } from "./registry";
+import {
+	type CreateEventParams,
+	type CreateEventRequest,
+	type Event as WorldEvent,
+	type EventResult,
+	HookConflictError,
+	type GetHookParams,
+	type GetStepParams,
+	type GetWorkflowRunParams,
+	type Hook,
+	type ListEventsByCorrelationIdParams,
+	type ListEventsParams,
+	type ListHooksParams,
+	type ListWorkflowRunStepsParams,
+	type ListWorkflowRunsParams,
+	NotFoundError,
+	type PaginatedResponse,
+	type QueueHandler,
+	type QueueOptions,
+	type QueuePayload,
+	type QueuePrefix,
+	type RunCreatedEventRequest,
+	type Step,
+	type StreamChunk,
+	type StreamChunksResult,
+	type StreamInfo,
+	type ValidQueueName,
+	type WorkflowRun,
+	type World,
+} from "./types";
+
+export interface RivetWorldConfig {
+	/**
+	 * RivetKit client endpoint or full config. Passed through to
+	 * `rivetkit/client` `createClient`.
+	 */
+	endpoint?: string;
+
+	/**
+	 * Stable deployment id returned by `Queue.getDeploymentId()`. If omitted
+	 * we derive one from `process.env.VERCEL_DEPLOYMENT_ID` or generate a
+	 * random id per process.
+	 */
+	deploymentId?: string;
+
+	/**
+	 * Optional key resolver for per-run encryption.
+	 */
+	getEncryptionKeyForRun?: (
+		run: WorkflowRun,
+	) => Promise<Uint8Array | undefined>;
+
+	/** Pre-built rivetkit client. Overrides `endpoint` when provided. */
+	client?: ReturnType<typeof createClient<WorldRegistry>>;
+}
+
+const COORDINATOR_KEY = ["coordinator"] as const;
+
+function resolveDeploymentId(cfg: RivetWorldConfig): string {
+	if (cfg.deploymentId) return cfg.deploymentId;
+	const envId =
+		typeof process !== "undefined"
+			? process.env.VERCEL_DEPLOYMENT_ID ??
+				process.env.WORKFLOW_DEPLOYMENT_ID
+			: undefined;
+	return envId ?? `rivet-world-${uuidv4()}`;
+}
+
+type RivetClient = ReturnType<typeof createClient<WorldRegistry>>;
+
+function runHandle(client: RivetClient, runId: string) {
+	return client.workflowRun.getOrCreate([runId]);
+}
+
+function coordinatorHandle(client: RivetClient) {
+	return client.coordinator.getOrCreate([...COORDINATOR_KEY]);
+}
+
+function queueHandle(client: RivetClient, queueName: ValidQueueName) {
+	return client.queueRunner.getOrCreate([queueName]);
+}
+
+function revivePaginated<T>(result: {
+	data: unknown[];
+	cursor: string | null;
+	hasMore: boolean;
+}): PaginatedResponse<T> {
+	return {
+		data: result.data as T[],
+		cursor: result.cursor,
+		hasMore: result.hasMore,
+	};
+}
+
+function reviveChunks(
+	raw: { index: number; data: string }[],
+): StreamChunk[] {
+	return raw.map((c) => ({ index: c.index, data: decodeBinary(c.data) }));
+}
+
+export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
+	const client: RivetClient =
+		cfg.client ?? createClient<WorldRegistry>(cfg.endpoint);
+	const deploymentId = resolveDeploymentId(cfg);
+
+	// -----------------------------------------------------------------
+	// Storage
+	// -----------------------------------------------------------------
+
+	const world: World = {
+		runs: {
+			async get(id, _params?: GetWorkflowRunParams): Promise<WorkflowRun> {
+				const run = (await runHandle(client, id).getRun()) as
+					| WorkflowRun
+					| null;
+				if (!run) throw new NotFoundError("run", id);
+				return run;
+			},
+			async list(
+				params: ListWorkflowRunsParams = {},
+			): Promise<PaginatedResponse<WorkflowRun>> {
+				const res = (await coordinatorHandle(client).listRuns({
+					cursor: params.cursor,
+					limit: params.limit,
+					workflowName: params.workflowName,
+					status: params.status,
+					deploymentId: params.deploymentId,
+					parentRunId: params.parentRunId,
+					createdAfter: params.createdAfter?.getTime(),
+					createdBefore: params.createdBefore?.getTime(),
+				})) as {
+					data: Array<{
+						id: string;
+						workflowName: string;
+						status: WorkflowRun["status"];
+						createdAt: number;
+						updatedAt: number;
+						deploymentId?: string;
+						parentRunId?: string;
+					}>;
+					cursor: string | null;
+					hasMore: boolean;
+				};
+
+				// The coordinator only stores an index row. Materialize full
+				// runs by hitting each run actor. In practice callers will
+				// paginate, so this fan-out is bounded by `limit`.
+				const data = await Promise.all(
+					res.data.map(async (row) => {
+						const run = (await runHandle(
+							client,
+							row.id,
+						).getRun()) as WorkflowRun | null;
+						if (run) return run;
+						// Fall back to the index row if the run actor is gone.
+						return {
+							id: row.id,
+							workflowName: row.workflowName,
+							status: row.status,
+							createdAt: new Date(row.createdAt),
+							updatedAt: new Date(row.updatedAt),
+							deploymentId: row.deploymentId,
+							parentRunId: row.parentRunId,
+						} satisfies WorkflowRun;
+					}),
+				);
+
+				return {
+					data,
+					cursor: res.cursor,
+					hasMore: res.hasMore,
+				};
+			},
+		},
+		steps: {
+			async get(
+				runId: string | undefined,
+				stepId: string,
+				_params?: GetStepParams,
+			): Promise<Step> {
+				if (!runId) {
+					throw new NotFoundError("step", stepId);
+				}
+				const step = (await runHandle(client, runId).getStep(
+					stepId,
+				)) as Step | null;
+				if (!step) throw new NotFoundError("step", stepId);
+				return step;
+			},
+			async list(
+				params: ListWorkflowRunStepsParams,
+			): Promise<PaginatedResponse<Step>> {
+				const res = (await runHandle(client, params.runId).listSteps({
+					status: params.status,
+					cursor: params.cursor,
+					limit: params.limit,
+				})) as unknown as {
+					data: Step[];
+					cursor: string | null;
+					hasMore: boolean;
+				};
+				return revivePaginated<Step>(res);
+			},
+		},
+		events: {
+			create: (async (
+				runId: string | null,
+				data: CreateEventRequest | RunCreatedEventRequest,
+				params?: CreateEventParams,
+			): Promise<EventResult> => {
+				if (data.type === "run_created") {
+					const id = runId ?? uuidv4();
+					const runActor = runHandle(client, id);
+					const result = (await runActor.createEvent(
+						id,
+						data,
+						params,
+					)) as EventResult;
+
+					if (result.run) {
+						const run = result.run;
+						await coordinatorHandle(client).registerRun({
+							id: run.id,
+							workflowName: run.workflowName,
+							status: run.status,
+							createdAt:
+								run.createdAt instanceof Date
+									? run.createdAt.getTime()
+									: Date.parse(
+											run.createdAt as unknown as string,
+										),
+							updatedAt:
+								run.updatedAt instanceof Date
+									? run.updatedAt.getTime()
+									: Date.parse(
+											run.updatedAt as unknown as string,
+										),
+							deploymentId: run.deploymentId ?? deploymentId,
+							parentRunId: run.parentRunId,
+						});
+					}
+					return result;
+				}
+
+				if (!runId) {
+					throw new Error(
+						`events.create requires runId for event type ${data.type}`,
+					);
+				}
+
+				const runActor = runHandle(client, runId);
+
+				// Special-case hook creation so the coordinator can enforce
+				// global token uniqueness before we commit the event.
+				if (data.type === "hook_created") {
+					const hookData = (data.data ?? {}) as {
+						token?: string;
+						name?: string;
+					};
+					if (hookData.token) {
+						const coord = coordinatorHandle(client);
+						const reg = (await coord.registerHookToken({
+							hookId: data.hookId ?? uuidv4(),
+							runId,
+							token: hookData.token,
+							status: "pending",
+							createdAt: Date.now(),
+						})) as { ok: true } | { ok: false; reason: string };
+						if (!reg.ok) {
+							// Materialize a hook_conflict event on the run so
+							// the event log reflects the rejection, then throw.
+							await runActor.createEvent(
+								runId,
+								{
+									type: "hook_conflict",
+									data: { token: hookData.token },
+								},
+								params,
+							);
+							throw new HookConflictError(hookData.token);
+						}
+					}
+				}
+
+				const result = (await runActor.createEvent(
+					runId,
+					data,
+					params,
+				)) as EventResult;
+
+				// Mirror status into coordinator when the run status moved.
+				if (result.run) {
+					const run = result.run;
+					await coordinatorHandle(client).updateRunStatus(
+						run.id,
+						run.status,
+						run.updatedAt instanceof Date
+							? run.updatedAt.getTime()
+							: Date.parse(run.updatedAt as unknown as string),
+					);
+					if (
+						run.status === "completed" ||
+						run.status === "failed" ||
+						run.status === "cancelled"
+					) {
+						await coordinatorHandle(
+							client,
+						).disposeHookTokensForRun(run.id);
+					}
+				}
+
+				return result;
+			}) as World["events"]["create"],
+			async list(
+				params: ListEventsParams,
+			): Promise<PaginatedResponse<WorldEvent>> {
+				const res = (await runHandle(client, params.runId).listEvents({
+					types: params.types,
+					stepId: params.stepId,
+					hookId: params.hookId,
+					cursor: params.cursor,
+					limit: params.limit,
+				})) as unknown as {
+					data: WorldEvent[];
+					cursor: string | null;
+					hasMore: boolean;
+				};
+				return revivePaginated<WorldEvent>(res);
+			},
+			async listByCorrelationId(
+				params: ListEventsByCorrelationIdParams,
+			): Promise<PaginatedResponse<WorldEvent>> {
+				// Correlation ids are not indexed globally. We delegate to the
+				// caller-provided run scope in practice; if unknown, the
+				// Workflow SDK passes a correlation id that matches a single
+				// run. We fall back to returning an empty result.
+				return {
+					data: [],
+					cursor: null,
+					hasMore: false,
+				};
+			},
+		},
+		hooks: {
+			async get(hookId: string, _params?: GetHookParams): Promise<Hook> {
+				// Hooks are keyed by runId; we need to resolve via the
+				// coordinator. For direct lookups by hook id, the Workflow
+				// SDK normally knows the runId already, but we support it by
+				// scanning hooks on the run if supplied via metadata prefix.
+				throw new NotFoundError("hook", hookId);
+			},
+			async getByToken(
+				token: string,
+				_params?: GetHookParams,
+			): Promise<Hook> {
+				const row = (await coordinatorHandle(client).lookupHookToken(
+					token,
+				)) as {
+					hookId: string;
+					runId: string;
+					token: string;
+					status: Hook["status"];
+					createdAt: number;
+				} | null;
+				if (!row) throw new NotFoundError("hook", token);
+				const hook = (await runHandle(client, row.runId).getHook(
+					row.hookId,
+				)) as Hook | null;
+				if (!hook) throw new NotFoundError("hook", token);
+				return hook;
+			},
+			async list(
+				params: ListHooksParams,
+			): Promise<PaginatedResponse<Hook>> {
+				const res = (await runHandle(client, params.runId).listHooks({
+					status: params.status,
+					cursor: params.cursor,
+					limit: params.limit,
+				})) as unknown as {
+					data: Hook[];
+					cursor: string | null;
+					hasMore: boolean;
+				};
+				return revivePaginated<Hook>(res);
+			},
+		},
+
+		// -----------------------------------------------------------------
+		// Queue
+		// -----------------------------------------------------------------
+
+		async getDeploymentId(): Promise<string> {
+			return deploymentId;
+		},
+
+		async queue(
+			queueName: ValidQueueName,
+			message: QueuePayload,
+			opts?: QueueOptions,
+		) {
+			const res = (await queueHandle(client, queueName).enqueue(
+				queueName,
+				message,
+				opts,
+			)) as { messageId: string };
+			return { messageId: res.messageId };
+		},
+
+		createQueueHandler(
+			queueNamePrefix: QueuePrefix,
+			handler: QueueHandler,
+		): (req: Request) => Promise<Response> {
+			return async (req: Request): Promise<Response> => {
+				let body: {
+					queueName?: ValidQueueName;
+					messageId?: string;
+				};
+				try {
+					body = await req.json();
+				} catch {
+					return new Response("invalid body", { status: 400 });
+				}
+
+				const queueName = body.queueName;
+				if (!queueName || !queueName.startsWith(queueNamePrefix)) {
+					return new Response("queue name mismatch", { status: 400 });
+				}
+
+				const q = queueHandle(client, queueName);
+				const msg = (await q.claimNext()) as {
+					id: string;
+					queueName: ValidQueueName;
+					payload: unknown;
+					attempt: number;
+				} | null;
+				if (!msg) {
+					return new Response(null, { status: 204 });
+				}
+
+				try {
+					const result = await handler(msg.payload, {
+						attempt: msg.attempt,
+						queueName: msg.queueName,
+						messageId: msg.id,
+					});
+					await q.ack(msg.id);
+					return new Response(
+						JSON.stringify({
+							ok: true,
+							messageId: msg.id,
+							timeoutSeconds:
+								result && "timeoutSeconds" in result
+									? result.timeoutSeconds
+									: undefined,
+						}),
+						{
+							status: 200,
+							headers: { "content-type": "application/json" },
+						},
+					);
+				} catch (err) {
+					await q.nack(
+						msg.id,
+						err instanceof Error ? err.message : String(err),
+					);
+					return new Response(
+						JSON.stringify({
+							ok: false,
+							messageId: msg.id,
+							error:
+								err instanceof Error
+									? err.message
+									: String(err),
+						}),
+						{
+							status: 500,
+							headers: { "content-type": "application/json" },
+						},
+					);
+				}
+			};
+		},
+
+		// -----------------------------------------------------------------
+		// Streamer
+		// -----------------------------------------------------------------
+
+		async writeToStream(
+			name: string,
+			runId: string,
+			chunk: string | Uint8Array,
+		): Promise<void> {
+			await runHandle(client, runId).writeStream(name, [chunk]);
+		},
+		async writeToStreamMulti(
+			name: string,
+			runId: string,
+			chunks: (string | Uint8Array)[],
+		): Promise<void> {
+			await runHandle(client, runId).writeStream(name, chunks);
+		},
+		async closeStream(name: string, runId: string): Promise<void> {
+			await runHandle(client, runId).closeStream(name);
+		},
+		async getStreamChunks(
+			name: string,
+			runId: string,
+			options?: { limit?: number; cursor?: string },
+		): Promise<StreamChunksResult> {
+			const res = (await runHandle(client, runId).getStreamChunks(
+				name,
+				options,
+			)) as {
+				data: { index: number; data: string }[];
+				cursor: string | null;
+				hasMore: boolean;
+				done: boolean;
+			};
+			return {
+				data: reviveChunks(res.data),
+				cursor: res.cursor,
+				hasMore: res.hasMore,
+				done: res.done,
+			};
+		},
+		async getStreamInfo(name: string, runId: string): Promise<StreamInfo> {
+			return (await runHandle(client, runId).getStreamInfo(
+				name,
+			)) as StreamInfo;
+		},
+		async listStreamsByRunId(runId: string): Promise<string[]> {
+			return (await runHandle(client, runId).listStreams()) as string[];
+		},
+		async readFromStream(
+			_name: string,
+			_startIndex = 0,
+		): Promise<ReadableStream<Uint8Array>> {
+			// Live streaming support requires subscribing to the
+			// `streamAppended` actor event over WebSocket. Until that is
+			// wired up, callers must use `getStreamChunks` to drain the
+			// stream manually.
+			throw new Error(
+				"readFromStream is not yet implemented; use getStreamChunks",
+			);
+		},
+
+		// -----------------------------------------------------------------
+		// Lifecycle
+		// -----------------------------------------------------------------
+
+		async start(): Promise<void> {
+			// No-op: the RivetKit client lazily connects on first use.
+		},
+		async close(): Promise<void> {
+			// No-op: RivetKit client does not require explicit shutdown.
+		},
+		getEncryptionKeyForRun: cfg.getEncryptionKeyForRun,
+	};
+
+	return world;
+}

--- a/rivetkit-typescript/packages/world-workflow/src/world.ts
+++ b/rivetkit-typescript/packages/world-workflow/src/world.ts
@@ -4,10 +4,6 @@
  * Wires the three Rivet actors into a single `World` instance that
  * implements the Vercel Workflow SDK's `Storage`, `Queue`, and `Streamer`
  * interfaces.
- *
- * A note on actor sharding: the coordinator and queue actors are singletons
- * per name. The `workflowRun` actor is keyed by `runId`, so each run lives
- * on its own actor and can be materialized independently.
  */
 
 import { createClient } from "rivetkit/client";
@@ -19,11 +15,13 @@ import {
 	type CreateEventRequest,
 	type Event as WorldEvent,
 	type EventResult,
-	HookConflictError,
+	type GetChunksOptions,
+	type GetEventParams,
 	type GetHookParams,
 	type GetStepParams,
 	type GetWorkflowRunParams,
 	type Hook,
+	HookConflictError,
 	type ListEventsByCorrelationIdParams,
 	type ListEventsParams,
 	type ListHooksParams,
@@ -36,37 +34,23 @@ import {
 	type QueuePayload,
 	type QueuePrefix,
 	type RunCreatedEventRequest,
+	SPEC_VERSION_CURRENT,
 	type Step,
-	type StreamChunk,
-	type StreamChunksResult,
-	type StreamInfo,
+	type StepWithoutData,
+	type StreamChunksResponse,
+	type StreamInfoResponse,
 	type ValidQueueName,
 	type WorkflowRun,
+	type WorkflowRunWithoutData,
 	type World,
 } from "./types";
 
 export interface RivetWorldConfig {
-	/**
-	 * RivetKit client endpoint or full config. Passed through to
-	 * `rivetkit/client` `createClient`.
-	 */
 	endpoint?: string;
-
-	/**
-	 * Stable deployment id returned by `Queue.getDeploymentId()`. If omitted
-	 * we derive one from `process.env.VERCEL_DEPLOYMENT_ID` or generate a
-	 * random id per process.
-	 */
 	deploymentId?: string;
-
-	/**
-	 * Optional key resolver for per-run encryption.
-	 */
 	getEncryptionKeyForRun?: (
 		run: WorkflowRun,
 	) => Promise<Uint8Array | undefined>;
-
-	/** Pre-built rivetkit client. Overrides `endpoint` when provided. */
 	client?: ReturnType<typeof createClient<WorldRegistry>>;
 }
 
@@ -110,7 +94,7 @@ function revivePaginated<T>(result: {
 
 function reviveChunks(
 	raw: { index: number; data: string }[],
-): StreamChunk[] {
+): { index: number; data: Uint8Array }[] {
 	return raw.map((c) => ({ index: c.index, data: decodeBinary(c.data) }));
 }
 
@@ -119,13 +103,59 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 		cfg.client ?? createClient<WorldRegistry>(cfg.endpoint);
 	const deploymentId = resolveDeploymentId(cfg);
 
+	const queueHandlers = new Map<QueuePrefix, QueueHandler>();
+
+	async function dispatchMessage(
+		queueName: ValidQueueName,
+	): Promise<void> {
+		const prefix = (
+			queueName.startsWith("__wkf_workflow_")
+				? "__wkf_workflow_"
+				: "__wkf_step_"
+		) as QueuePrefix;
+		const handler = queueHandlers.get(prefix);
+		if (!handler) return;
+
+		const q = queueHandle(client, queueName);
+		const msg = (await q.claimNext()) as {
+			id: string;
+			queueName: ValidQueueName;
+			payload: unknown;
+			attempt: number;
+		} | null;
+		if (!msg) return;
+
+		try {
+			await handler(msg.payload, {
+				attempt: msg.attempt,
+				queueName: msg.queueName,
+				messageId: msg.id,
+			});
+			await q.ack(msg.id);
+		} catch (err) {
+			await q.nack(
+				msg.id,
+				err instanceof Error ? err.message : String(err),
+			);
+		}
+	}
+
 	// -----------------------------------------------------------------
-	// Storage
+	// Build world
 	// -----------------------------------------------------------------
 
 	const world: World = {
+		specVersion: SPEC_VERSION_CURRENT,
+
+		// =============================================================
+		// Storage
+		// =============================================================
+
 		runs: {
-			async get(id, _params?: GetWorkflowRunParams): Promise<WorkflowRun> {
+			async get(
+				id: string,
+				_params?: GetWorkflowRunParams,
+			): Promise<WorkflowRun | WorkflowRunWithoutData> {
 				const run = (await runHandle(client, id).getRun()) as
 					| WorkflowRun
 					| null;
@@ -134,16 +164,15 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 			},
 			async list(
 				params: ListWorkflowRunsParams = {},
-			): Promise<PaginatedResponse<WorkflowRun>> {
+			): Promise<
+				PaginatedResponse<WorkflowRun | WorkflowRunWithoutData>
+			> {
+				const pagination = params.pagination ?? {};
 				const res = (await coordinatorHandle(client).listRuns({
-					cursor: params.cursor,
-					limit: params.limit,
+					cursor: pagination.cursor,
+					limit: pagination.limit,
 					workflowName: params.workflowName,
 					status: params.status,
-					deploymentId: params.deploymentId,
-					parentRunId: params.parentRunId,
-					createdAfter: params.createdAfter?.getTime(),
-					createdBefore: params.createdBefore?.getTime(),
 				})) as {
 					data: Array<{
 						id: string;
@@ -152,15 +181,11 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 						createdAt: number;
 						updatedAt: number;
 						deploymentId?: string;
-						parentRunId?: string;
 					}>;
 					cursor: string | null;
 					hasMore: boolean;
 				};
 
-				// The coordinator only stores an index row. Materialize full
-				// runs by hitting each run actor. In practice callers will
-				// paginate, so this fan-out is bounded by `limit`.
 				const data = await Promise.all(
 					res.data.map(async (row) => {
 						const run = (await runHandle(
@@ -168,16 +193,16 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 							row.id,
 						).getRun()) as WorkflowRun | null;
 						if (run) return run;
-						// Fall back to the index row if the run actor is gone.
 						return {
-							id: row.id,
+							runId: row.id,
 							workflowName: row.workflowName,
 							status: row.status,
+							deploymentId: row.deploymentId ?? deploymentId,
+							input: undefined,
+							output: undefined,
 							createdAt: new Date(row.createdAt),
 							updatedAt: new Date(row.updatedAt),
-							deploymentId: row.deploymentId,
-							parentRunId: row.parentRunId,
-						} satisfies WorkflowRun;
+						} satisfies WorkflowRunWithoutData;
 					}),
 				);
 
@@ -190,13 +215,10 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 		},
 		steps: {
 			async get(
-				runId: string | undefined,
+				runId: string,
 				stepId: string,
 				_params?: GetStepParams,
-			): Promise<Step> {
-				if (!runId) {
-					throw new NotFoundError("step", stepId);
-				}
+			): Promise<Step | StepWithoutData> {
 				const step = (await runHandle(client, runId).getStep(
 					stepId,
 				)) as Step | null;
@@ -205,11 +227,15 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 			},
 			async list(
 				params: ListWorkflowRunStepsParams,
-			): Promise<PaginatedResponse<Step>> {
-				const res = (await runHandle(client, params.runId).listSteps({
-					status: params.status,
-					cursor: params.cursor,
-					limit: params.limit,
+			): Promise<PaginatedResponse<Step | StepWithoutData>> {
+				const pagination = params.pagination ?? {};
+				const res = (await runHandle(
+					client,
+					params.runId,
+				).listSteps({
+					cursor: pagination.cursor,
+					limit: pagination.limit,
+					sortOrder: pagination.sortOrder,
 				})) as unknown as {
 					data: Step[];
 					cursor: string | null;
@@ -224,19 +250,19 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 				data: CreateEventRequest | RunCreatedEventRequest,
 				params?: CreateEventParams,
 			): Promise<EventResult> => {
-				if (data.type === "run_created") {
+				if (data.eventType === "run_created") {
 					const id = runId ?? uuidv4();
 					const runActor = runHandle(client, id);
 					const result = (await runActor.createEvent(
 						id,
 						data,
-						params,
+						params ? { requestId: params.requestId } : undefined,
 					)) as EventResult;
 
 					if (result.run) {
 						const run = result.run;
 						await coordinatorHandle(client).registerRun({
-							id: run.id,
+							id: run.runId,
 							workflowName: run.workflowName,
 							status: run.status,
 							createdAt:
@@ -252,7 +278,6 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 											run.updatedAt as unknown as string,
 										),
 							deploymentId: run.deploymentId ?? deploymentId,
-							parentRunId: run.parentRunId,
 						});
 					}
 					return result;
@@ -260,38 +285,40 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 
 				if (!runId) {
 					throw new Error(
-						`events.create requires runId for event type ${data.type}`,
+						`events.create requires runId for event type ${data.eventType}`,
 					);
 				}
 
 				const runActor = runHandle(client, runId);
 
-				// Special-case hook creation so the coordinator can enforce
-				// global token uniqueness before we commit the event.
-				if (data.type === "hook_created") {
-					const hookData = (data.data ?? {}) as {
+				if (data.eventType === "hook_created") {
+					const hookData = (data.eventData ?? {}) as {
 						token?: string;
-						name?: string;
 					};
 					if (hookData.token) {
+						const hookId =
+							data.correlationId ?? uuidv4();
 						const coord = coordinatorHandle(client);
 						const reg = (await coord.registerHookToken({
-							hookId: data.hookId ?? uuidv4(),
+							hookId,
 							runId,
 							token: hookData.token,
 							status: "pending",
 							createdAt: Date.now(),
-						})) as { ok: true } | { ok: false; reason: string };
+						})) as
+							| { ok: true }
+							| { ok: false; reason: string };
 						if (!reg.ok) {
-							// Materialize a hook_conflict event on the run so
-							// the event log reflects the rejection, then throw.
 							await runActor.createEvent(
 								runId,
 								{
-									type: "hook_conflict",
-									data: { token: hookData.token },
+									eventType: "hook_conflict",
+									correlationId: data.correlationId,
+									eventData: { token: hookData.token },
 								},
-								params,
+								params
+									? { requestId: params.requestId }
+									: undefined,
 							);
 							throw new HookConflictError(hookData.token);
 						}
@@ -301,18 +328,19 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 				const result = (await runActor.createEvent(
 					runId,
 					data,
-					params,
+					params ? { requestId: params.requestId } : undefined,
 				)) as EventResult;
 
-				// Mirror status into coordinator when the run status moved.
 				if (result.run) {
 					const run = result.run;
 					await coordinatorHandle(client).updateRunStatus(
-						run.id,
+						run.runId,
 						run.status,
 						run.updatedAt instanceof Date
 							? run.updatedAt.getTime()
-							: Date.parse(run.updatedAt as unknown as string),
+							: Date.parse(
+									run.updatedAt as unknown as string,
+								),
 					);
 					if (
 						run.status === "completed" ||
@@ -321,21 +349,37 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 					) {
 						await coordinatorHandle(
 							client,
-						).disposeHookTokensForRun(run.id);
+						).disposeHookTokensForRun(run.runId);
 					}
 				}
 
 				return result;
 			}) as World["events"]["create"],
+
+			async get(
+				runId: string,
+				eventId: string,
+				_params?: GetEventParams,
+			): Promise<WorldEvent> {
+				const ev = (await runHandle(
+					client,
+					runId,
+				).getEvent(eventId)) as WorldEvent | null;
+				if (!ev) throw new NotFoundError("event", eventId);
+				return ev;
+			},
+
 			async list(
 				params: ListEventsParams,
 			): Promise<PaginatedResponse<WorldEvent>> {
-				const res = (await runHandle(client, params.runId).listEvents({
-					types: params.types,
-					stepId: params.stepId,
-					hookId: params.hookId,
-					cursor: params.cursor,
-					limit: params.limit,
+				const pagination = params.pagination ?? {};
+				const res = (await runHandle(
+					client,
+					params.runId,
+				).listEvents({
+					cursor: pagination.cursor,
+					limit: pagination.limit,
+					sortOrder: pagination.sortOrder,
 				})) as unknown as {
 					data: WorldEvent[];
 					cursor: string | null;
@@ -343,13 +387,14 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 				};
 				return revivePaginated<WorldEvent>(res);
 			},
+
 			async listByCorrelationId(
 				params: ListEventsByCorrelationIdParams,
 			): Promise<PaginatedResponse<WorldEvent>> {
-				// Correlation ids are not indexed globally. We delegate to the
-				// caller-provided run scope in practice; if unknown, the
-				// Workflow SDK passes a correlation id that matches a single
-				// run. We fall back to returning an empty result.
+				// Correlation ids are scoped to a single run. Without a
+				// global correlation index we cannot resolve the runId.
+				// Callers that need this must use events.list on the known
+				// run. Return empty for now.
 				return {
 					data: [],
 					cursor: null,
@@ -359,24 +404,30 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 		},
 		hooks: {
 			async get(hookId: string, _params?: GetHookParams): Promise<Hook> {
-				// Hooks are keyed by runId; we need to resolve via the
-				// coordinator. For direct lookups by hook id, the Workflow
-				// SDK normally knows the runId already, but we support it by
-				// scanning hooks on the run if supplied via metadata prefix.
-				throw new NotFoundError("hook", hookId);
+				const lookup = (await coordinatorHandle(
+					client,
+				).lookupHookId(hookId)) as {
+					runId: string;
+					token: string;
+				} | null;
+				if (!lookup) throw new NotFoundError("hook", hookId);
+				const hook = (await runHandle(
+					client,
+					lookup.runId,
+				).getHook(hookId)) as Hook | null;
+				if (!hook) throw new NotFoundError("hook", hookId);
+				return hook;
 			},
 			async getByToken(
 				token: string,
 				_params?: GetHookParams,
 			): Promise<Hook> {
-				const row = (await coordinatorHandle(client).lookupHookToken(
-					token,
-				)) as {
+				const row = (await coordinatorHandle(
+					client,
+				).lookupHookToken(token)) as {
 					hookId: string;
 					runId: string;
 					token: string;
-					status: Hook["status"];
-					createdAt: number;
 				} | null;
 				if (!row) throw new NotFoundError("hook", token);
 				const hook = (await runHandle(client, row.runId).getHook(
@@ -388,10 +439,17 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 			async list(
 				params: ListHooksParams,
 			): Promise<PaginatedResponse<Hook>> {
-				const res = (await runHandle(client, params.runId).listHooks({
-					status: params.status,
-					cursor: params.cursor,
-					limit: params.limit,
+				if (!params.runId) {
+					return { data: [], cursor: null, hasMore: false };
+				}
+				const pagination = params.pagination ?? {};
+				const res = (await runHandle(
+					client,
+					params.runId,
+				).listHooks({
+					cursor: pagination.cursor,
+					limit: pagination.limit,
+					sortOrder: pagination.sortOrder,
 				})) as unknown as {
 					data: Hook[];
 					cursor: string | null;
@@ -401,9 +459,9 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 			},
 		},
 
-		// -----------------------------------------------------------------
+		// =============================================================
 		// Queue
-		// -----------------------------------------------------------------
+		// =============================================================
 
 		async getDeploymentId(): Promise<string> {
 			return deploymentId;
@@ -417,8 +475,27 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 			const res = (await queueHandle(client, queueName).enqueue(
 				queueName,
 				message,
-				opts,
+				opts
+					? {
+							idempotencyKey: opts.idempotencyKey,
+							delay: opts.delaySeconds
+								? opts.delaySeconds * 1000
+								: undefined,
+						}
+					: undefined,
 			)) as { messageId: string };
+
+			const delayMs = opts?.delaySeconds
+				? opts.delaySeconds * 1000
+				: 0;
+			if (delayMs > 0) {
+				setTimeout(() => {
+					dispatchMessage(queueName).catch(() => {});
+				}, delayMs);
+			} else {
+				dispatchMessage(queueName).catch(() => {});
+			}
+
 			return { messageId: res.messageId };
 		},
 
@@ -426,63 +503,41 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 			queueNamePrefix: QueuePrefix,
 			handler: QueueHandler,
 		): (req: Request) => Promise<Response> {
+			queueHandlers.set(queueNamePrefix, handler);
+
 			return async (req: Request): Promise<Response> => {
-				let body: {
-					queueName?: ValidQueueName;
-					messageId?: string;
-				};
+				let body: { queueName?: ValidQueueName };
 				try {
-					body = await req.json();
+					body = (await req.json()) as typeof body;
 				} catch {
 					return new Response("invalid body", { status: 400 });
 				}
 
 				const queueName = body.queueName;
-				if (!queueName || !queueName.startsWith(queueNamePrefix)) {
-					return new Response("queue name mismatch", { status: 400 });
-				}
-
-				const q = queueHandle(client, queueName);
-				const msg = (await q.claimNext()) as {
-					id: string;
-					queueName: ValidQueueName;
-					payload: unknown;
-					attempt: number;
-				} | null;
-				if (!msg) {
-					return new Response(null, { status: 204 });
+				if (
+					!queueName ||
+					!queueName.startsWith(queueNamePrefix)
+				) {
+					return new Response("queue name mismatch", {
+						status: 400,
+					});
 				}
 
 				try {
-					const result = await handler(msg.payload, {
-						attempt: msg.attempt,
-						queueName: msg.queueName,
-						messageId: msg.id,
-					});
-					await q.ack(msg.id);
+					await dispatchMessage(queueName);
 					return new Response(
-						JSON.stringify({
-							ok: true,
-							messageId: msg.id,
-							timeoutSeconds:
-								result && "timeoutSeconds" in result
-									? result.timeoutSeconds
-									: undefined,
-						}),
+						JSON.stringify({ ok: true }),
 						{
 							status: 200,
-							headers: { "content-type": "application/json" },
+							headers: {
+								"content-type": "application/json",
+							},
 						},
 					);
 				} catch (err) {
-					await q.nack(
-						msg.id,
-						err instanceof Error ? err.message : String(err),
-					);
 					return new Response(
 						JSON.stringify({
 							ok: false,
-							messageId: msg.id,
 							error:
 								err instanceof Error
 									? err.message
@@ -490,87 +545,157 @@ export function createRivetWorld(cfg: RivetWorldConfig = {}): World {
 						}),
 						{
 							status: 500,
-							headers: { "content-type": "application/json" },
+							headers: {
+								"content-type": "application/json",
+							},
 						},
 					);
 				}
 			};
 		},
 
-		// -----------------------------------------------------------------
+		// =============================================================
 		// Streamer
-		// -----------------------------------------------------------------
+		// =============================================================
 
-		async writeToStream(
-			name: string,
-			runId: string,
-			chunk: string | Uint8Array,
-		): Promise<void> {
-			await runHandle(client, runId).writeStream(name, [chunk]);
-		},
-		async writeToStreamMulti(
-			name: string,
-			runId: string,
-			chunks: (string | Uint8Array)[],
-		): Promise<void> {
-			await runHandle(client, runId).writeStream(name, chunks);
-		},
-		async closeStream(name: string, runId: string): Promise<void> {
-			await runHandle(client, runId).closeStream(name);
-		},
-		async getStreamChunks(
-			name: string,
-			runId: string,
-			options?: { limit?: number; cursor?: string },
-		): Promise<StreamChunksResult> {
-			const res = (await runHandle(client, runId).getStreamChunks(
-				name,
-				options,
-			)) as {
-				data: { index: number; data: string }[];
-				cursor: string | null;
-				hasMore: boolean;
-				done: boolean;
-			};
-			return {
-				data: reviveChunks(res.data),
-				cursor: res.cursor,
-				hasMore: res.hasMore,
-				done: res.done,
-			};
-		},
-		async getStreamInfo(name: string, runId: string): Promise<StreamInfo> {
-			return (await runHandle(client, runId).getStreamInfo(
-				name,
-			)) as StreamInfo;
-		},
-		async listStreamsByRunId(runId: string): Promise<string[]> {
-			return (await runHandle(client, runId).listStreams()) as string[];
-		},
-		async readFromStream(
-			_name: string,
-			_startIndex = 0,
-		): Promise<ReadableStream<Uint8Array>> {
-			// Live streaming support requires subscribing to the
-			// `streamAppended` actor event over WebSocket. Until that is
-			// wired up, callers must use `getStreamChunks` to drain the
-			// stream manually.
-			throw new Error(
-				"readFromStream is not yet implemented; use getStreamChunks",
-			);
+		streams: {
+			async write(
+				runId: string,
+				name: string,
+				chunk: string | Uint8Array,
+			): Promise<void> {
+				await runHandle(client, runId).writeStream(name, [chunk]);
+			},
+			async writeMulti(
+				runId: string,
+				name: string,
+				chunks: (string | Uint8Array)[],
+			): Promise<void> {
+				await runHandle(client, runId).writeStream(name, chunks);
+			},
+			async close(runId: string, name: string): Promise<void> {
+				await runHandle(client, runId).closeStream(name);
+			},
+			async getChunks(
+				runId: string,
+				name: string,
+				options?: GetChunksOptions,
+			): Promise<StreamChunksResponse> {
+				const res = (await runHandle(
+					client,
+					runId,
+				).getStreamChunks(name, options)) as {
+					data: { index: number; data: string }[];
+					cursor: string | null;
+					hasMore: boolean;
+					done: boolean;
+				};
+				return {
+					data: reviveChunks(res.data),
+					cursor: res.cursor,
+					hasMore: res.hasMore,
+					done: res.done,
+				};
+			},
+			async getInfo(
+				runId: string,
+				name: string,
+			): Promise<StreamInfoResponse> {
+				return (await runHandle(client, runId).getStreamInfo(
+					name,
+				)) as StreamInfoResponse;
+			},
+			async list(runId: string): Promise<string[]> {
+				return (await runHandle(
+					client,
+					runId,
+				).listStreams()) as string[];
+			},
+			async get(
+				runId: string,
+				name: string,
+				startIndex = 0,
+			): Promise<ReadableStream<Uint8Array>> {
+				return new ReadableStream<Uint8Array>({
+					async start(controller) {
+						let cursor: string | undefined;
+						while (true) {
+							const res = (await runHandle(
+								client,
+								runId,
+							).getStreamChunks(name, {
+								cursor,
+							})) as {
+								data: {
+									index: number;
+									data: string;
+								}[];
+								cursor: string | null;
+								hasMore: boolean;
+								done: boolean;
+							};
+
+							for (const chunk of res.data) {
+								if (chunk.index >= startIndex) {
+									controller.enqueue(
+										decodeBinary(chunk.data),
+									);
+								}
+							}
+
+							if (!res.hasMore) {
+								if (res.done) {
+									controller.close();
+									return;
+								}
+								break;
+							}
+							cursor = res.cursor ?? undefined;
+						}
+
+						// Subscribe to live updates.
+						const handle = runHandle(client, runId);
+						const conn = handle.connect();
+						conn.on(
+							"streamAppended",
+							(
+								payload: {
+									streamName: string;
+									chunks: {
+										index: number;
+										data: string;
+									}[];
+									done: boolean;
+								},
+							) => {
+								if (payload.streamName !== name) return;
+								for (const chunk of payload.chunks) {
+									if (chunk.index >= startIndex) {
+										controller.enqueue(
+											decodeBinary(chunk.data),
+										);
+									}
+								}
+								if (payload.done) {
+									controller.close();
+									conn.dispose();
+								}
+							},
+						);
+					},
+				});
+			},
 		},
 
-		// -----------------------------------------------------------------
+		// =============================================================
 		// Lifecycle
-		// -----------------------------------------------------------------
+		// =============================================================
 
-		async start(): Promise<void> {
-			// No-op: the RivetKit client lazily connects on first use.
-		},
-		async close(): Promise<void> {
-			// No-op: RivetKit client does not require explicit shutdown.
-		},
-		getEncryptionKeyForRun: cfg.getEncryptionKeyForRun,
+		async start(): Promise<void> {},
+		async close(): Promise<void> {},
+		getEncryptionKeyForRun: cfg.getEncryptionKeyForRun as
+			| World["getEncryptionKeyForRun"]
+			| undefined,
 	};
 
 	return world;

--- a/rivetkit-typescript/packages/world-workflow/tsconfig.json
+++ b/rivetkit-typescript/packages/world-workflow/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"types": ["node"],
+		"outDir": "./dist",
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*"]
+}

--- a/rivetkit-typescript/packages/world-workflow/tsup.config.ts
+++ b/rivetkit-typescript/packages/world-workflow/tsup.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "tsup";
+import defaultConfig from "../../../tsup.base";
+
+export default defineConfig({
+	...defaultConfig,
+	outDir: "dist/tsup/",
+});


### PR DESCRIPTION
# Description

This PR introduces `@rivetkit/world-workflow`, a new package that implements the Vercel Workflow SDK's `World` interface using Rivet Actors as the backing storage and queue infrastructure.

The implementation replaces traditional Postgres + queue infrastructure with three Rivet actors:

- **`workflowRunActor`** — One per workflow run (keyed by `runId`). Owns:
  - Append-only event log for the run
  - Materialized run, steps, and hooks state
  - Named streams keyed by stream name
  - All mutations go through `createEvent` to maintain the event log as the source of truth

- **`coordinatorActor`** — Singleton (keyed by `["coordinator"]`). Serves as a cross-run index for:
  - Paginated `runs.list()` queries
  - Global hook token lookup via `hooks.getByToken()`
  - Hook token uniqueness enforcement

- **`queueActor`** — One per `ValidQueueName` (e.g., `__wkf_workflow_0`). Handles:
  - Message enqueueing with idempotency and retry tracking
  - Message dispatch to user-provided handlers
  - Retry backoff based on configurable policies

The package exports:
- `createRivetWorld(config)` — Factory function to create a `World` instance
- `registry` — Pre-configured RivetKit registry containing all three actors
- Type definitions mirroring the Vercel Workflow SDK's public contract

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The package compiles successfully as a standalone workspace member. The implementation provides working implementations for the Storage, Queue, and Streamer interfaces with the following known limitations documented in the README:

- `readFromStream` live streaming is not yet wired to the `streamAppended` actor event
- `hooks.get(hookId)` lacks a global index; callers must use `hooks.getByToken`
- `events.listByCorrelationId` returns empty results (correlation IDs are not globally indexed)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Package compiles and type-checks successfully

https://claude.ai/code/session_014t3My5a42LHJ1umwV3vGgh