### PR TITLE
chore(envoy-client): log command and event payloads

### DIFF
--- a/engine/sdks/rust/envoy-client/src/commands.rs
+++ b/engine/sdks/rust/envoy-client/src/commands.rs
@@ -3,11 +3,18 @@ use rivet_envoy_protocol as protocol;
 use crate::actor::create_actor;
 use crate::connection::ws_send;
 use crate::envoy::EnvoyContext;
+use crate::stringify::stringify_command_wrapper;
 
 pub const ACK_COMMANDS_INTERVAL_MS: u64 = 5 * 60 * 1000;
 
 pub async fn handle_commands(ctx: &mut EnvoyContext, commands: Vec<protocol::CommandWrapper>) {
 	tracing::info!(command_count = commands.len(), "received commands");
+	for command_wrapper in &commands {
+		tracing::info!(
+			command = %stringify_command_wrapper(command_wrapper),
+			"received command"
+		);
+	}
 
 	for command_wrapper in commands {
 		let checkpoint = command_wrapper.checkpoint;

--- a/engine/sdks/rust/envoy-client/src/events.rs
+++ b/engine/sdks/rust/envoy-client/src/events.rs
@@ -2,8 +2,14 @@ use rivet_envoy_protocol as protocol;
 
 use crate::connection::ws_send;
 use crate::envoy::EnvoyContext;
+use crate::stringify::stringify_event_wrapper;
 
 pub async fn handle_send_events(ctx: &mut EnvoyContext, events: Vec<protocol::EventWrapper>) {
+	tracing::info!(event_count = events.len(), "sending events");
+	for event in &events {
+		tracing::info!(event = %stringify_event_wrapper(event), "sending event");
+	}
+
 	// Record in history per actor
 	for event in &events {
 		let mut remove_after_stop = false;
@@ -60,6 +66,9 @@ pub async fn resend_unacknowledged_events(ctx: &EnvoyContext) {
 	}
 
 	tracing::info!(count = events.len(), "resending unacknowledged events");
+	for event in &events {
+		tracing::info!(event = %stringify_event_wrapper(event), "resending event");
+	}
 
 	ws_send(&ctx.shared, protocol::ToRivet::ToRivetEvents(events)).await;
 }


### PR DESCRIPTION
## Summary
- log each decoded envoy command wrapper at info level when commands arrive
- log each event wrapper at info level when events are sent or resent

## Verification
- cargo check -p rivet-envoy-client