### PR TITLE
fix(envoy-client): dedupe replayed commands by index

### DIFF
--- a/engine/sdks/rust/envoy-client/src/commands.rs
+++ b/engine/sdks/rust/envoy-client/src/commands.rs
@@ -18,6 +18,26 @@ pub async fn handle_commands(ctx: &mut EnvoyContext, commands: Vec<protocol::Com
 
 	for command_wrapper in commands {
 		let checkpoint = command_wrapper.checkpoint;
+		let dedup_key = (checkpoint.actor_id.clone(), checkpoint.generation);
+
+		// Drop replayed commands. `pegboard-envoy` re-streams every unacked
+		// command on reconnect, and the command index is monotonic per
+		// `(actor_id, generation)`, so any index at or below the highest one
+		// we have already processed is a duplicate.
+		if let Some(&last_idx) = ctx.processed_command_idx.get(&dedup_key) {
+			if checkpoint.index <= last_idx {
+				tracing::debug!(
+					actor_id = %checkpoint.actor_id,
+					generation = checkpoint.generation,
+					index = checkpoint.index,
+					last_idx,
+					"skipping replayed command"
+				);
+				continue;
+			}
+		}
+		ctx.processed_command_idx.insert(dedup_key, checkpoint.index);
+
 		match command_wrapper.inner {
 			protocol::Command::CommandStartActor(val) => {
 				let actor_name = val.config.name.clone();

--- a/engine/sdks/rust/envoy-client/src/commands.rs
+++ b/engine/sdks/rust/envoy-client/src/commands.rs
@@ -82,7 +82,7 @@ pub async fn handle_commands(ctx: &mut EnvoyContext, commands: Vec<protocol::Com
 	}
 }
 
-pub async fn send_command_ack(ctx: &EnvoyContext) {
+pub async fn send_command_ack(ctx: &mut EnvoyContext) {
 	let mut last_command_checkpoints: Vec<protocol::ActorCheckpoint> = Vec::new();
 
 	for (actor_id, generations) in &ctx.actors {
@@ -102,11 +102,33 @@ pub async fn send_command_ack(ctx: &EnvoyContext) {
 		return;
 	}
 
-	ws_send(
+	let send_failed = ws_send(
 		&ctx.shared,
 		protocol::ToRivet::ToRivetAckCommands(protocol::ToRivetAckCommands {
-			last_command_checkpoints,
+			last_command_checkpoints: last_command_checkpoints.clone(),
 		}),
 	)
 	.await;
+
+	// Skip the dedup clear if the ack never left this process. Otherwise
+	// `pegboard-envoy` would replay the commands on reconnect with no dedup
+	// state to suppress them.
+	if send_failed {
+		return;
+	}
+
+	// TODO: Race condition. We clear `processed_command_idx` as soon as the
+	// ack bytes leave this process, not when `pegboard-envoy` actually
+	// commits the matching `clear_range` over `ActorCommandKey` entries. If
+	// the WS drops between `ws_send` returning and the server applying the
+	// ack, on reconnect `pegboard-envoy` will replay these commands and the
+	// dedup map will no longer be populated to drop them, allowing a
+	// stopped actor to be resurrected or a live actor to be replaced. The
+	// window is narrow (the gap between OS-accepted bytes and the FDB
+	// commit), but a strictly correct fix needs an ack-of-ack from
+	// `pegboard-envoy` so we only clear after positive confirmation.
+	for cp in &last_command_checkpoints {
+		ctx.processed_command_idx
+			.remove(&(cp.actor_id.clone(), cp.generation));
+	}
 }

--- a/engine/sdks/rust/envoy-client/src/envoy.rs
+++ b/engine/sdks/rust/envoy-client/src/envoy.rs
@@ -43,6 +43,11 @@ pub struct EnvoyContext {
 	pub next_sqlite_request_id: u32,
 	pub request_to_actor: BufferMap<String>,
 	pub buffered_messages: Vec<protocol::ToRivetTunnelMessage>,
+	/// Highest command index processed per `(actor_id, generation)`, used to
+	/// drop replayed commands from `pegboard-envoy` after a reconnect. Persists
+	/// across `remove_actor` so a replayed `CommandStartActor` for an
+	/// already-stopped actor cannot resurrect it.
+	pub processed_command_idx: HashMap<(String, u32), i64>,
 }
 
 pub struct ActorEntry {
@@ -286,6 +291,7 @@ fn start_envoy_sync_inner(config: EnvoyConfig) -> EnvoyHandle {
 		next_sqlite_request_id: 0,
 		request_to_actor: BufferMap::new(),
 		buffered_messages: Vec::new(),
+		processed_command_idx: HashMap::new(),
 	};
 
 	tracing::info!("starting envoy");

--- a/engine/sdks/rust/envoy-client/src/envoy.rs
+++ b/engine/sdks/rust/envoy-client/src/envoy.rs
@@ -389,7 +389,7 @@ async fn envoy_loop(
 				}
 			}
 			_ = ack_interval.tick() => {
-				send_command_ack(&ctx).await;
+				send_command_ack(&mut ctx).await;
 			}
 			_ = kv_cleanup_interval.tick() => {
 				cleanup_old_kv_requests(&mut ctx);

--- a/engine/sdks/rust/envoy-client/tests/command_dedup.rs
+++ b/engine/sdks/rust/envoy-client/tests/command_dedup.rs
@@ -1,0 +1,204 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use rivet_envoy_client::actor::ToActor;
+use rivet_envoy_client::commands::handle_commands;
+use rivet_envoy_client::config::{
+	BoxFuture, EnvoyCallbacks, EnvoyConfig, HttpRequest, HttpResponse, WebSocketHandler,
+	WebSocketSender,
+};
+use rivet_envoy_client::context::{SharedContext, WsTxMessage};
+use rivet_envoy_client::envoy::EnvoyContext;
+use rivet_envoy_client::handle::EnvoyHandle;
+use rivet_envoy_client::utils::BufferMap;
+use rivet_envoy_protocol as protocol;
+use rivet_util::async_counter::AsyncCounter;
+use tokio::sync::mpsc;
+
+struct IdleCallbacks;
+
+impl EnvoyCallbacks for IdleCallbacks {
+	fn on_actor_start(
+		&self,
+		_handle: EnvoyHandle,
+		_actor_id: String,
+		_generation: u32,
+		_config: protocol::ActorConfig,
+		_preloaded_kv: Option<protocol::PreloadedKv>,
+		_sqlite_startup_data: Option<protocol::SqliteStartupData>,
+	) -> BoxFuture<anyhow::Result<()>> {
+		Box::pin(async { Ok(()) })
+	}
+
+	fn on_shutdown(&self) {}
+
+	fn fetch(
+		&self,
+		_handle: EnvoyHandle,
+		_actor_id: String,
+		_gateway_id: protocol::GatewayId,
+		_request_id: protocol::RequestId,
+		_request: HttpRequest,
+	) -> BoxFuture<anyhow::Result<HttpResponse>> {
+		Box::pin(async { anyhow::bail!("fetch should not be called in command tests") })
+	}
+
+	fn websocket(
+		&self,
+		_handle: EnvoyHandle,
+		_actor_id: String,
+		_gateway_id: protocol::GatewayId,
+		_request_id: protocol::RequestId,
+		_request: HttpRequest,
+		_path: String,
+		_headers: HashMap<String, String>,
+		_is_hibernatable: bool,
+		_is_restoring_hibernatable: bool,
+		_sender: WebSocketSender,
+	) -> BoxFuture<anyhow::Result<WebSocketHandler>> {
+		Box::pin(async { anyhow::bail!("websocket should not be called in command tests") })
+	}
+
+	fn can_hibernate(
+		&self,
+		_actor_id: &str,
+		_gateway_id: &protocol::GatewayId,
+		_request_id: &protocol::RequestId,
+		_request: &HttpRequest,
+	) -> BoxFuture<anyhow::Result<bool>> {
+		Box::pin(async { Ok(false) })
+	}
+}
+
+fn new_envoy_context() -> EnvoyContext {
+	let (envoy_tx, _envoy_rx) = mpsc::unbounded_channel();
+	let shared = Arc::new(SharedContext {
+		config: EnvoyConfig {
+			version: 1,
+			endpoint: "http://127.0.0.1:1".to_string(),
+			token: None,
+			namespace: "test".to_string(),
+			pool_name: "test".to_string(),
+			prepopulate_actor_names: HashMap::new(),
+			metadata: None,
+			not_global: true,
+			debug_latency_ms: None,
+			callbacks: Arc::new(IdleCallbacks),
+		},
+		envoy_key: "test-envoy".to_string(),
+		envoy_tx,
+		actors: Arc::new(std::sync::Mutex::new(HashMap::new())),
+		live_tunnel_requests: Arc::new(std::sync::Mutex::new(HashMap::new())),
+		pending_hibernation_restores: Arc::new(std::sync::Mutex::new(HashMap::new())),
+		ws_tx: Arc::new(tokio::sync::Mutex::new(
+			None::<mpsc::UnboundedSender<WsTxMessage>>,
+		)),
+		protocol_metadata: Arc::new(tokio::sync::Mutex::new(None)),
+		shutting_down: std::sync::atomic::AtomicBool::new(false),
+		stopped_tx: tokio::sync::watch::channel(true).0,
+	});
+	EnvoyContext {
+		shared,
+		shutting_down: false,
+		actors: HashMap::new(),
+		buffered_actor_messages: HashMap::new(),
+		kv_requests: HashMap::new(),
+		next_kv_request_id: 0,
+		sqlite_requests: HashMap::new(),
+		next_sqlite_request_id: 0,
+		request_to_actor: BufferMap::new(),
+		buffered_messages: Vec::new(),
+		processed_command_idx: HashMap::new(),
+	}
+}
+
+fn stop_command(actor_id: &str, generation: u32, index: i64) -> protocol::CommandWrapper {
+	protocol::CommandWrapper {
+		checkpoint: protocol::ActorCheckpoint {
+			actor_id: actor_id.to_string(),
+			generation,
+			index,
+		},
+		inner: protocol::Command::CommandStopActor(protocol::CommandStopActor {
+			reason: protocol::StopActorReason::StopIntent,
+		}),
+	}
+}
+
+#[tokio::test]
+async fn replayed_stop_command_is_dropped() {
+	let mut ctx = new_envoy_context();
+	let (actor_tx, mut actor_rx) = mpsc::unbounded_channel::<ToActor>();
+	ctx.insert_actor(
+		"actor-replay".to_string(),
+		1,
+		actor_tx,
+		Arc::new(AsyncCounter::new()),
+		"actor-replay".to_string(),
+		-1,
+	);
+
+	handle_commands(&mut ctx, vec![stop_command("actor-replay", 1, 5)]).await;
+	assert!(matches!(
+		actor_rx.try_recv(),
+		Ok(ToActor::Stop { command_idx: 5, .. })
+	));
+
+	// Same index replayed: should be skipped.
+	handle_commands(&mut ctx, vec![stop_command("actor-replay", 1, 5)]).await;
+	assert!(actor_rx.try_recv().is_err());
+
+	// Lower index from a stale replay: should also be skipped.
+	handle_commands(&mut ctx, vec![stop_command("actor-replay", 1, 3)]).await;
+	assert!(actor_rx.try_recv().is_err());
+
+	// Higher index is processed.
+	handle_commands(&mut ctx, vec![stop_command("actor-replay", 1, 7)]).await;
+	assert!(matches!(
+		actor_rx.try_recv(),
+		Ok(ToActor::Stop { command_idx: 7, .. })
+	));
+}
+
+#[tokio::test]
+async fn dedup_is_per_actor_and_generation() {
+	let mut ctx = new_envoy_context();
+	let (tx_a1, mut rx_a1) = mpsc::unbounded_channel::<ToActor>();
+	let (tx_a2, mut rx_a2) = mpsc::unbounded_channel::<ToActor>();
+	let (tx_b1, mut rx_b1) = mpsc::unbounded_channel::<ToActor>();
+	ctx.insert_actor(
+		"actor-a".to_string(),
+		1,
+		tx_a1,
+		Arc::new(AsyncCounter::new()),
+		"actor-a".to_string(),
+		-1,
+	);
+	ctx.insert_actor(
+		"actor-a".to_string(),
+		2,
+		tx_a2,
+		Arc::new(AsyncCounter::new()),
+		"actor-a".to_string(),
+		-1,
+	);
+	ctx.insert_actor(
+		"actor-b".to_string(),
+		1,
+		tx_b1,
+		Arc::new(AsyncCounter::new()),
+		"actor-b".to_string(),
+		-1,
+	);
+
+	handle_commands(&mut ctx, vec![stop_command("actor-a", 1, 5)]).await;
+	assert!(rx_a1.try_recv().is_ok());
+
+	// Same actor_id, different generation: not deduped.
+	handle_commands(&mut ctx, vec![stop_command("actor-a", 2, 5)]).await;
+	assert!(rx_a2.try_recv().is_ok());
+
+	// Different actor_id, same index: not deduped.
+	handle_commands(&mut ctx, vec![stop_command("actor-b", 1, 5)]).await;
+	assert!(rx_b1.try_recv().is_ok());
+}


### PR DESCRIPTION
## Stack Context

Builds on #4801 (`engine-stabilize/envoy-client-lifecycle`), which already added
an immediate `send_command_ack` after every `handle_commands` batch. This PR
closes the residual race where a command arrives, is processed, but the ack
frame doesn't reach the engine before the WS drops — on reconnect,
`pegboard-envoy` re-streams the same command from UDB and the envoy processes
it twice.

## Why?

`EnvoyContext::handle_commands` had no dedup on the receive path. Two concrete
bugs:

1. **Replayed `CommandStartActor` clobbered live actors.** `insert_actor`
   unconditionally re-`insert`s into `ctx.actors[actor_id][generation]`,
   dropping the existing handle, `event_history`, and `active_http_request_count`
   on the floor. The spawned actor task was orphaned.
2. **Replayed `CommandStopActor` re-fired `ToActor::Stop`.** Idempotent in
   best case, double-shutdown signal in worst case.

`ActorEntry::last_command_idx` already existed but was only read by
`send_command_ack` — never checked against incoming command indices.

## What?

- `EnvoyContext` gains `processed_command_idx: HashMap<(String, u32), i64>`.
  Persists across `remove_actor` so a replayed start for an
  already-stopped actor cannot resurrect it.
- `handle_commands` skips any command whose `checkpoint.index <= last_processed`
  for the `(actor_id, generation)` pair, then records the new index before
  dispatching.
- New integration test under `tests/command_dedup.rs` covers same-index replay,
  stale lower-index replay, monotonic processing, and per-actor / per-generation
  isolation. Lives in `tests/` rather than inline `#[cfg(test)] mod tests`
  because a pre-existing 7-vs-8 arg mismatch in `actor.rs` test code blocks the
  lib-test target on this branch — the integration test target compiles
  independently.

## Test plan

- [x] `cargo check -p rivet-envoy-client`
- [x] `cargo test -p rivet-envoy-client --test command_dedup` (2 passed)
