### PR TITLE
fix(rivetkit): wrap onMigrate in savepoints

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/common/database/config.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/common/database/config.ts
@@ -48,7 +48,6 @@ export interface SqliteDatabase {
 	): Promise<SqliteExecuteResult>;
 	run(sql: string, params?: SqliteBindings): Promise<void>;
 	query(sql: string, params?: SqliteBindings): Promise<SqliteQueryResult>;
-	writeMode<T>(callback: () => Promise<T>): Promise<T>;
 	nativeMetrics?():
 		| SqliteNativeMetrics
 		| Promise<SqliteNativeMetrics | null>

--- a/rivetkit-typescript/packages/rivetkit/src/common/database/mod.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/common/database/mod.test.ts
@@ -8,11 +8,9 @@ import type {
 import { db } from "./mod";
 
 class FakeSqliteDatabase implements SqliteDatabase {
-	writeModeDepth = 0;
 	executeCalls: {
 		sql: string;
 		params?: SqliteBindings;
-		writeMode: boolean;
 	}[] = [];
 
 	async exec(): Promise<void> {}
@@ -24,7 +22,6 @@ class FakeSqliteDatabase implements SqliteDatabase {
 		this.executeCalls.push({
 			sql,
 			params,
-			writeMode: this.writeModeDepth > 0,
 		});
 		return {
 			columns: [],
@@ -41,15 +38,6 @@ class FakeSqliteDatabase implements SqliteDatabase {
 	async query(sql: string, params?: SqliteBindings) {
 		const { columns, rows } = await this.execute(sql, params);
 		return { columns, rows };
-	}
-
-	async writeMode<T>(callback: () => Promise<T>): Promise<T> {
-		this.writeModeDepth++;
-		try {
-			return await callback();
-		} finally {
-			this.writeModeDepth--;
-		}
 	}
 
 	async close(): Promise<void> {}
@@ -73,7 +61,7 @@ function testProviderContext(
 }
 
 describe("db", () => {
-	test("runs onMigrate through sqlite write mode", async () => {
+	test("runs onMigrate inside a sqlite savepoint", async () => {
 		const nativeDb = new FakeSqliteDatabase();
 		const provider = db({
 			onMigrate: async (client) => {
@@ -91,14 +79,58 @@ describe("db", () => {
 
 		expect(nativeDb.executeCalls).toEqual([
 			{
+				sql: "SAVEPOINT __rivet_on_migrate",
+				params: undefined,
+			},
+			{
 				sql: "CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT)",
 				params: undefined,
-				writeMode: true,
 			},
 			{
 				sql: "SELECT COUNT(*) AS count FROM items",
 				params: undefined,
-				writeMode: true,
+			},
+			{
+				sql: "RELEASE SAVEPOINT __rivet_on_migrate",
+				params: undefined,
+			},
+		]);
+	});
+
+	test("rolls back the migration savepoint when onMigrate fails", async () => {
+		const nativeDb = new FakeSqliteDatabase();
+		const provider = db({
+			onMigrate: async (client) => {
+				await client.execute(
+					"CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT)",
+				);
+				throw new Error("migration failed");
+			},
+		});
+		const client = await provider.createClient(
+			testProviderContext(nativeDb),
+		);
+
+		await expect(provider.onMigrate(client)).rejects.toThrow(
+			"migration failed",
+		);
+
+		expect(nativeDb.executeCalls).toEqual([
+			{
+				sql: "SAVEPOINT __rivet_on_migrate",
+				params: undefined,
+			},
+			{
+				sql: "CREATE TABLE items(id INTEGER PRIMARY KEY, value TEXT)",
+				params: undefined,
+			},
+			{
+				sql: "ROLLBACK TO SAVEPOINT __rivet_on_migrate",
+				params: undefined,
+			},
+			{
+				sql: "RELEASE SAVEPOINT __rivet_on_migrate",
+				params: undefined,
 			},
 		]);
 	});

--- a/rivetkit-typescript/packages/rivetkit/src/common/database/mod.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/common/database/mod.ts
@@ -7,10 +7,6 @@ interface DatabaseFactoryConfig {
 	onMigrate?: (db: RawAccess) => Promise<void> | void;
 }
 
-type RawAccessWithWriteMode = RawAccess & {
-	__rivetWriteMode: <T>(callback: () => Promise<T> | T) => Promise<T>;
-};
-
 function hasMultipleStatements(query: string): boolean {
 	const trimmed = query.trim().replace(/;+$/, "").trimEnd();
 	return trimmed.includes(";");
@@ -38,7 +34,7 @@ export function db({
 				}
 			};
 
-			const client: RawAccessWithWriteMode = {
+			const client: RawAccess = {
 				execute: async <
 					TRow extends Record<string, unknown> = Record<
 						string,
@@ -103,17 +99,12 @@ export function db({
 					}
 				},
 				nativeMetrics: () => db.nativeMetrics?.() ?? null,
-				__rivetWriteMode: async <T>(
-					callback: () => Promise<T> | T,
-				): Promise<T> => {
-					return await db.writeMode(async () => await callback());
-				},
 			};
 			return client;
 		},
 		onMigrate: async (client) => {
 			if (onMigrate) {
-				await dbWriteMode(client, () => onMigrate(client));
+				await withMigrationSavepoint(client, () => onMigrate(client));
 			}
 		},
 	};
@@ -145,17 +136,21 @@ async function execMultiStatement<TRow extends Record<string, unknown>>(
 	return results as TRow[];
 }
 
-async function dbWriteMode<T>(
+async function withMigrationSavepoint<T>(
 	client: RawAccess,
 	callback: () => Promise<T> | T,
 ): Promise<T> {
-	const maybeClient = client as RawAccess & {
-		__rivetWriteMode?: <TInner>(
-			callback: () => Promise<TInner> | TInner,
-		) => Promise<TInner>;
-	};
-	if (maybeClient.__rivetWriteMode) {
-		return await maybeClient.__rivetWriteMode(callback);
+	await client.execute("SAVEPOINT __rivet_on_migrate");
+	try {
+		const result = await callback();
+		await client.execute("RELEASE SAVEPOINT __rivet_on_migrate");
+		return result;
+	} catch (error) {
+		try {
+			await client.execute("ROLLBACK TO SAVEPOINT __rivet_on_migrate");
+		} finally {
+			await client.execute("RELEASE SAVEPOINT __rivet_on_migrate");
+		}
+		throw error;
 	}
-	return await callback();
 }

--- a/rivetkit-typescript/packages/rivetkit/src/common/database/native-database.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/common/database/native-database.test.ts
@@ -104,28 +104,6 @@ describe("wrapJsNativeDatabase", () => {
 		});
 	});
 
-	test("keeps write mode on the normal native execute lane", async () => {
-		const native = new FakeNativeDatabase();
-		const db = wrapJsNativeDatabase(native);
-
-		const query = db.writeMode(async () => {
-			const promise = db.query("SELECT 1");
-			expect(native.executeCalls).toMatchObject([
-				{ sql: "SELECT 1", write: false },
-			]);
-			native.resolveNext({
-				columns: ["value"],
-				rows: [[1]],
-			});
-			return await promise;
-		});
-
-		await expect(query).resolves.toEqual({
-			columns: ["value"],
-			rows: [[1]],
-		});
-	});
-
 	test("normalizes supported sqlite bind values", async () => {
 		const native = new FakeNativeDatabase();
 		const db = wrapJsNativeDatabase(native);

--- a/rivetkit-typescript/packages/rivetkit/src/common/database/native-database.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/common/database/native-database.ts
@@ -346,9 +346,6 @@ export function wrapJsNativeDatabase(
 			const { columns, rows } = await executeNative(sql, params);
 			return { columns, rows };
 		},
-		async writeMode<T>(callback: () => Promise<T>): Promise<T> {
-			return await callback();
-		},
 		nativeMetrics(): SqliteNativeMetrics | null {
 			return normalizeNativeMetrics(database.metrics?.());
 		},

--- a/rivetkit-typescript/packages/rivetkit/src/db/drizzle.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/db/drizzle.ts
@@ -163,19 +163,14 @@ export function db<TSchema extends DrizzleSchema = Record<string, never>>({
 					await nativeDb.close();
 				}
 			};
-			(
-				drizzleDb as DrizzleDatabase<TSchema> & {
-					__rivetWriteMode: <T>(
-						callback: () => Promise<T> | T,
-					) => Promise<T>;
-				}
-			).__rivetWriteMode = async (callback) =>
-				await nativeDb.writeMode(async () => await callback());
 
 			return drizzleDb;
 		},
 		onMigrate: async (client) => {
-			await dbWriteMode(client, async () => {
+			if (!migrations && !onMigrate) {
+				return;
+			}
+			await withMigrationSavepoint(client, async () => {
 				if (migrations) {
 					await runMigrations(client, migrations);
 				}
@@ -187,19 +182,23 @@ export function db<TSchema extends DrizzleSchema = Record<string, never>>({
 	};
 }
 
-async function dbWriteMode<T>(
+async function withMigrationSavepoint<T>(
 	client: RawAccess,
 	callback: () => Promise<T> | T,
 ): Promise<T> {
-	const maybeClient = client as RawAccess & {
-		__rivetWriteMode?: <TInner>(
-			callback: () => Promise<TInner> | TInner,
-		) => Promise<TInner>;
-	};
-	if (maybeClient.__rivetWriteMode) {
-		return await maybeClient.__rivetWriteMode(callback);
+	await client.execute("SAVEPOINT __rivet_on_migrate");
+	try {
+		const result = await callback();
+		await client.execute("RELEASE SAVEPOINT __rivet_on_migrate");
+		return result;
+	} catch (error) {
+		try {
+			await client.execute("ROLLBACK TO SAVEPOINT __rivet_on_migrate");
+		} finally {
+			await client.execute("RELEASE SAVEPOINT __rivet_on_migrate");
+		}
+		throw error;
 	}
-	return await callback();
 }
 
 async function runMigrations<TSchema extends DrizzleSchema>(

--- a/rivetkit-typescript/packages/rivetkit/tests/platforms/shared-platform-harness.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/platforms/shared-platform-harness.ts
@@ -112,7 +112,6 @@ ${wasmModuleSource}
 interface SqliteDatabase {
 \trun(sql: string, params?: unknown[]): Promise<void>;
 \tquery(sql: string, params?: unknown[]): Promise<{ rows: unknown[][] }>;
-\twriteMode<T>(callback: () => Promise<T>): Promise<T>;
 }
 
 interface RegistryConfig {
@@ -137,29 +136,23 @@ const rawSqlDatabaseProvider = {
 };
 
 async function ensureCounterTable(db: SqliteDatabase) {
-\tawait db.writeMode(async () => {
-\t\tawait db.run(
-\t\t\t"CREATE TABLE IF NOT EXISTS platform_counter (id INTEGER PRIMARY KEY CHECK (id = 1), count INTEGER NOT NULL)",
-\t\t);
-\t});
+\tawait db.run(
+\t\t"CREATE TABLE IF NOT EXISTS platform_counter (id INTEGER PRIMARY KEY CHECK (id = 1), count INTEGER NOT NULL)",
+\t);
 }
 
 async function ensureLifecycleTable(db: SqliteDatabase) {
-\tawait db.writeMode(async () => {
-\t\tawait db.run(
-\t\t\t"CREATE TABLE IF NOT EXISTS platform_counter_lifecycle (event TEXT PRIMARY KEY, count INTEGER NOT NULL)",
-\t\t);
-\t});
+\tawait db.run(
+\t\t"CREATE TABLE IF NOT EXISTS platform_counter_lifecycle (event TEXT PRIMARY KEY, count INTEGER NOT NULL)",
+\t);
 }
 
 async function recordLifecycleEvent(db: SqliteDatabase, event: string) {
 \tawait ensureLifecycleTable(db);
-\tawait db.writeMode(async () => {
-\t\tawait db.run(
-\t\t\t"INSERT INTO platform_counter_lifecycle (event, count) VALUES (?, 1) ON CONFLICT(event) DO UPDATE SET count = count + 1",
-\t\t\t[event],
-\t\t);
-\t});
+\tawait db.run(
+\t\t"INSERT INTO platform_counter_lifecycle (event, count) VALUES (?, 1) ON CONFLICT(event) DO UPDATE SET count = count + 1",
+\t\t[event],
+\t);
 }
 
 async function readCounter(db: SqliteDatabase): Promise<number> {
@@ -201,12 +194,10 @@ const sqliteCounter = actor({
 \t\tincrement: async (ctx, amount = 1) => {
 \t\t\tconst db = ctx.sql as SqliteDatabase;
 \t\t\tawait ensureCounterTable(db);
-\t\t\tawait db.writeMode(async () => {
-\t\t\t\tawait db.run(
-\t\t\t\t\t"INSERT INTO platform_counter (id, count) VALUES (?, ?) ON CONFLICT(id) DO UPDATE SET count = count + excluded.count",
-\t\t\t\t\t[COUNTER_ID, amount],
-\t\t\t\t);
-\t\t\t});
+\t\t\tawait db.run(
+\t\t\t\t"INSERT INTO platform_counter (id, count) VALUES (?, ?) ON CONFLICT(id) DO UPDATE SET count = count + excluded.count",
+\t\t\t\t[COUNTER_ID, amount],
+\t\t\t);
 
 \t\t\treturn await readCounter(db);
 \t\t},

--- a/rivetkit-typescript/packages/rivetkit/tests/platforms/shared-registry.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/platforms/shared-registry.ts
@@ -14,7 +14,6 @@ interface SqliteDatabase {
 	): Promise<{
 		rows: unknown[][];
 	}>;
-	writeMode<T>(callback: () => Promise<T>): Promise<T>;
 }
 
 const COUNTER_ID = 1;
@@ -28,39 +27,33 @@ const rawSqlDatabaseProvider = {
 };
 
 async function ensureCounterTable(db: SqliteDatabase) {
-	await db.writeMode(async () => {
-		await db.run(`
-			CREATE TABLE IF NOT EXISTS platform_counter (
-				id INTEGER PRIMARY KEY CHECK (id = 1),
-				count INTEGER NOT NULL
-			)
-		`);
-	});
+	await db.run(`
+		CREATE TABLE IF NOT EXISTS platform_counter (
+			id INTEGER PRIMARY KEY CHECK (id = 1),
+			count INTEGER NOT NULL
+		)
+	`);
 }
 
 async function ensureLifecycleTable(db: SqliteDatabase) {
-	await db.writeMode(async () => {
-		await db.run(`
-			CREATE TABLE IF NOT EXISTS platform_counter_lifecycle (
-				event TEXT PRIMARY KEY,
-				count INTEGER NOT NULL
-			)
-		`);
-	});
+	await db.run(`
+		CREATE TABLE IF NOT EXISTS platform_counter_lifecycle (
+			event TEXT PRIMARY KEY,
+			count INTEGER NOT NULL
+		)
+	`);
 }
 
 async function recordLifecycleEvent(db: SqliteDatabase, event: string) {
 	await ensureLifecycleTable(db);
-	await db.writeMode(async () => {
-		await db.run(
-			`
-				INSERT INTO platform_counter_lifecycle (event, count)
-				VALUES (?, 1)
-				ON CONFLICT(event) DO UPDATE SET count = count + 1
-			`,
-			[event],
-		);
-	});
+	await db.run(
+		`
+			INSERT INTO platform_counter_lifecycle (event, count)
+			VALUES (?, 1)
+			ON CONFLICT(event) DO UPDATE SET count = count + 1
+		`,
+		[event],
+	);
 }
 
 async function readCounter(db: SqliteDatabase): Promise<number> {
@@ -102,16 +95,14 @@ export const sqliteCounterActor = actor({
 		increment: async (ctx, amount = 1) => {
 			const db = ctx.sql as SqliteDatabase;
 			await ensureCounterTable(db);
-			await db.writeMode(async () => {
-				await db.run(
-					`
-						INSERT INTO platform_counter (id, count)
-						VALUES (?, ?)
-						ON CONFLICT(id) DO UPDATE SET count = count + excluded.count
-					`,
-					[COUNTER_ID, amount],
-				);
-			});
+			await db.run(
+				`
+					INSERT INTO platform_counter (id, count)
+					VALUES (?, ?)
+					ON CONFLICT(id) DO UPDATE SET count = count + excluded.count
+				`,
+				[COUNTER_ID, amount],
+			);
 
 			return await readCounter(db);
 		},

--- a/rivetkit-typescript/packages/rivetkit/tests/wasm-host-smoke.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/wasm-host-smoke.test.ts
@@ -467,12 +467,10 @@ async function runHostSmoke(kind: HostKind): Promise<SmokeHost> {
 				scenario.remoteWriteReconnect.markStarted();
 				await scenario.remoteWriteReconnect.released;
 
-				await c.sql.writeMode(async () => {
-					await c.sql.execute(
-						"UPDATE smoke_events SET host = ? WHERE id = ?",
-						[label, 1],
-					);
-				});
+				await c.sql.execute(
+					"UPDATE smoke_events SET host = ? WHERE id = ?",
+					[label, 1],
+				);
 				const rows = await c.sql.query(
 					"SELECT host FROM smoke_events WHERE host = ?",
 					[label],

--- a/website/src/content/docs/actors/sqlite.mdx
+++ b/website/src/content/docs/actors/sqlite.mdx
@@ -45,6 +45,8 @@ For Drizzle setup, see [SQLite + Drizzle](/docs/actors/sqlite-drizzle).
 
 Define `db: db({ onMigrate })` on your actor, create your schema in `onMigrate`, and execute SQL with `c.db.execute(...)`.
 
+RivetKit wraps `onMigrate` in a SQLite savepoint, so migration steps are atomic. If `onMigrate` throws, all SQL run by that hook is rolled back before the actor starts.
+
 <CodeGroup workspace>
 ```ts index.ts
 import { actor, setup } from "rivetkit";
@@ -253,7 +255,7 @@ console.log(todos);
 
 ## Recommendations
 
-- Keep schema creation and migration steps in `onMigrate`.
+- Keep schema creation and migration steps in `onMigrate`; RivetKit runs them atomically inside a SQLite savepoint.
 - Use `?` placeholders for dynamic values.
 - Prefer queue-driven writes for ordered or background work.
 - Use transactions for related multi-step mutations when atomicity matters.

--- a/website/src/content/docs/actors/versions.mdx
+++ b/website/src/content/docs/actors/versions.mdx
@@ -229,7 +229,7 @@ Use [Drizzle](/docs/actors/sqlite-drizzle) for typed schemas with generated migr
 
 **Raw SQL**
 
-For actors using [raw SQLite](/docs/actors/sqlite), migrations run automatically via the `onMigrate` hook on every actor start. Use SQLite's `user_version` pragma to track which migrations have run:
+For actors using [raw SQLite](/docs/actors/sqlite), migrations run automatically via the `onMigrate` hook on every actor start. RivetKit wraps the hook in a SQLite savepoint, so the migration is fully atomic. Use SQLite's `user_version` pragma to track which migrations have run:
 
 ```ts
 import { actor, setup } from "rivetkit";

--- a/website/src/content/docs/connect/cloudflare.mdx
+++ b/website/src/content/docs/connect/cloudflare.mdx
@@ -64,7 +64,6 @@ interface Env {
 interface SqliteDatabase {
   run(sql: string, params?: unknown[]): Promise<void>;
   query(sql: string, params?: unknown[]): Promise<{ rows: unknown[][] }>;
-  writeMode<T>(callback: () => Promise<T>): Promise<T>;
 }
 
 const rawSqlDatabaseProvider = {
@@ -80,15 +79,13 @@ const counter = actor({
   actions: {
     increment: async (ctx, amount = 1) => {
       const db = ctx.sql as SqliteDatabase;
-      await db.writeMode(async () => {
-        await db.run(
-          "CREATE TABLE IF NOT EXISTS counters (id INTEGER PRIMARY KEY, count INTEGER NOT NULL)",
-        );
-        await db.run(
-          "INSERT INTO counters (id, count) VALUES (1, ?) ON CONFLICT(id) DO UPDATE SET count = count + excluded.count",
-          [amount],
-        );
-      });
+      await db.run(
+        "CREATE TABLE IF NOT EXISTS counters (id INTEGER PRIMARY KEY, count INTEGER NOT NULL)",
+      );
+      await db.run(
+        "INSERT INTO counters (id, count) VALUES (1, ?) ON CONFLICT(id) DO UPDATE SET count = count + excluded.count",
+        [amount],
+      );
 
       const result = await db.query("SELECT count FROM counters WHERE id = 1");
       return Number(result.rows[0]?.[0] ?? 0);

--- a/website/src/content/docs/connect/supabase.mdx
+++ b/website/src/content/docs/connect/supabase.mdx
@@ -41,7 +41,6 @@ import * as wasmBindings from "@rivetkit/rivetkit-wasm";
 interface SqliteDatabase {
   run(sql: string, params?: unknown[]): Promise<void>;
   query(sql: string, params?: unknown[]): Promise<{ rows: unknown[][] }>;
-  writeMode<T>(callback: () => Promise<T>): Promise<T>;
 }
 
 const wasmModule = await Deno.readFile(
@@ -61,15 +60,13 @@ const counter = actor({
   actions: {
     increment: async (ctx, amount = 1) => {
       const db = ctx.sql as SqliteDatabase;
-      await db.writeMode(async () => {
-        await db.run(
-          "CREATE TABLE IF NOT EXISTS counters (id INTEGER PRIMARY KEY, count INTEGER NOT NULL)",
-        );
-        await db.run(
-          "INSERT INTO counters (id, count) VALUES (1, ?) ON CONFLICT(id) DO UPDATE SET count = count + excluded.count",
-          [amount],
-        );
-      });
+      await db.run(
+        "CREATE TABLE IF NOT EXISTS counters (id INTEGER PRIMARY KEY, count INTEGER NOT NULL)",
+      );
+      await db.run(
+        "INSERT INTO counters (id, count) VALUES (1, ?) ON CONFLICT(id) DO UPDATE SET count = count + excluded.count",
+        [amount],
+      );
 
       const result = await db.query("SELECT count FROM counters WHERE id = 1");
       return Number(result.rows[0]?.[0] ?? 0);


### PR DESCRIPTION
## Stack Context

This PR updates RivetKit SQLite migration handling.

## What?

- Wrap raw SQL and Drizzle `onMigrate` work in a SQLite savepoint.
- Roll back the savepoint when `onMigrate` throws.
- Remove the dead `writeMode` API from active SQLite surfaces and examples.
- Document that `onMigrate` is atomic because it runs inside a savepoint.

## Why?

`writeMode` no longer routes anything specially, so `onMigrate` was not atomic by default. A savepoint gives migrations transaction semantics without using a top-level `BEGIN`, which keeps the wrapper nestable with SQLite's transaction model.

## Verification

- `pnpm run check-types`
- `pnpm vitest run src/common/database/mod.test.ts src/common/database/native-database.test.ts`
- `git diff --check`
