### PR TITLE
chore(rivetkit): log inspector errors + standardize pino errorKey `error`

### DIFF
--- a/engine/sdks/typescript/runner/src/mod.ts
+++ b/engine/sdks/typescript/runner/src/mod.ts
@@ -1214,14 +1214,14 @@ export class Runner {
 			await this.#config.onActorStart(actorId, generation, actorConfig);
 
 			instance.actorStartPromise.resolve();
-		} catch (err) {
+		} catch (error) {
 			this.log?.error({
 				msg: "error starting runner actor",
 				actorId,
-				err,
+				error,
 			});
 
-			instance.actorStartPromise.reject(err);
+			instance.actorStartPromise.reject(error);
 
 			// TODO: Mark as crashed
 			// Send stopped state update if start failed

--- a/engine/sdks/typescript/test-runner/src/log.ts
+++ b/engine/sdks/typescript/test-runner/src/log.ts
@@ -85,6 +85,7 @@ export async function configureDefaultLogger(): Promise<void> {
 	baseLogger = pino({
 		level: getPinoLevel(),
 		messageKey: "msg",
+		errorKey: "error",
 		// Do not include pid/hostname in output
 		base: {},
 		// Keep a string level in the output

--- a/rivetkit-typescript/packages/engine-runner/src/mod.ts
+++ b/rivetkit-typescript/packages/engine-runner/src/mod.ts
@@ -1178,14 +1178,14 @@ export class Runner {
 			await this.#config.onActorStart(actorId, generation, actorConfig);
 
 			instance.actorStartPromise.resolve();
-		} catch (err) {
+		} catch (error) {
 			this.log?.error({
 				msg: "error starting runner actor",
 				actorId,
-				err,
+				error,
 			});
 
-			instance.actorStartPromise.reject(err);
+			instance.actorStartPromise.reject(error);
 
 			// TODO: Mark as crashed
 			// Send stopped state update if start failed

--- a/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/sleep-db.ts
+++ b/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/sleep-db.ts
@@ -279,7 +279,7 @@ export const sleepWithDbConn = actor({
 		} catch (error) {
 			c.log.warn({
 				msg: "onDisconnect db write failed",
-				error: error instanceof Error ? error.message : String(error),
+				error,
 			});
 		}
 	},
@@ -292,7 +292,7 @@ export const sleepWithDbConn = actor({
 		} catch (error) {
 			c.log.warn({
 				msg: "onSleep db write failed",
-				error: error instanceof Error ? error.message : String(error),
+				error,
 			});
 		}
 	},
@@ -369,7 +369,7 @@ export const sleepWithDbAction = actor({
 		} catch (error) {
 			c.log.warn({
 				msg: "onSleep error",
-				error: error instanceof Error ? error.message : String(error),
+				error,
 			});
 		}
 	},

--- a/rivetkit-typescript/packages/rivetkit/src/agent-os/actor/session.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/agent-os/actor/session.ts
@@ -140,11 +140,11 @@ export function subscribeToSession<TConnParams>(
 		);
 
 		// Persist event to SQLite for sleep/wake recovery.
-		persistSessionEvent(c, sessionId, event).catch((err) =>
+		persistSessionEvent(c, sessionId, event).catch((error) =>
 			c.log.error({
 				msg: "agent-os failed to persist session event",
 				sessionId,
-				error: err,
+				error,
 			}),
 		);
 

--- a/rivetkit-typescript/packages/rivetkit/src/common/inline-websocket-adapter.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/common/inline-websocket-adapter.ts
@@ -161,28 +161,28 @@ export class InlineWebSocketAdapter {
 		}
 	}
 
-	#handleError(err: unknown): void {
-		console.error("INLINE_WEBSOCKET_ADAPTER_ERROR", err);
+	#handleError(error: unknown): void {
+		console.error("INLINE_WEBSOCKET_ADAPTER_ERROR", error);
 		logger().error({
 			msg: "error in websocket",
-			error: err,
-			errorMessage: err instanceof Error ? err.message : String(err),
-			stack: err instanceof Error ? err.stack : undefined,
+			error,
+			errorMessage: error instanceof Error ? error.message : String(error),
+			stack: error instanceof Error ? error.stack : undefined,
 		});
 
 		// Call handler.onError
 		try {
-			this.#handler.onError(err, this.#wsContext);
-		} catch (handlerErr) {
+			this.#handler.onError(error, this.#wsContext);
+		} catch (error) {
 			logger().error({
 				msg: "error in onError handler",
-				error: handlerErr,
+				error,
 			});
 		}
 
 		// Fire error event to both sides
-		this.#clientWs.triggerError(err);
-		this.#actorWs.triggerError(err);
+		this.#clientWs.triggerError(error);
+		this.#actorWs.triggerError(error);
 	}
 
 	#close(code: number, reason: string): void {
@@ -199,8 +199,8 @@ export class InlineWebSocketAdapter {
 				{ code, reason, wasClean: true },
 				this.#wsContext,
 			);
-		} catch (err) {
-			logger().error({ msg: "error closing websocket", error: err });
+		} catch (error) {
+			logger().error({ msg: "error closing websocket", error });
 		} finally {
 			this.#readyState = 3; // CLOSED
 

--- a/rivetkit-typescript/packages/rivetkit/src/common/log.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/common/log.ts
@@ -76,6 +76,7 @@ export function configureDefaultLogger(logLevel?: LogLevel) {
 			messageKey: "msg",
 			// Do not include pid/hostname in output
 			base: {},
+			errorKey: "error",
 			// Keep the numeric level so the logfmt sink can match Pino's levels.
 			formatters: {
 				level(_label: string, number: number) {

--- a/rivetkit-typescript/packages/rivetkit/src/drivers/engine/actor-driver.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/drivers/engine/actor-driver.ts
@@ -284,7 +284,7 @@ export class EngineActorDriver implements ActorDriver {
 				logger().debug({
 					msg: "actor crash cleanup errored",
 					actorId,
-					err: stringifyError(err),
+					error: stringifyError(err),
 				});
 			}
 		}
@@ -1346,7 +1346,7 @@ export class EngineActorDriver implements ActorDriver {
 				logger().warn({
 					msg: "failed to rebind dynamic hibernatable runner websocket",
 					actorId,
-					err: stringifyError(result.reason),
+					error: stringifyError(result.reason),
 				});
 			}
 		}
@@ -1369,7 +1369,7 @@ export class EngineActorDriver implements ActorDriver {
 				logger().warn({
 					msg: "failed to rebind hibernatable connect socket",
 					actorId,
-					err: stringifyError(result.reason),
+					error: stringifyError(result.reason),
 				});
 			}
 		}
@@ -1629,7 +1629,7 @@ export class EngineActorDriver implements ActorDriver {
 					logger().warn({
 						msg: "failed to restore dynamic hibernating requests after actor start",
 						actorId,
-						err: stringifyError(error),
+						error: stringifyError(error),
 					});
 				}
 			} else if (isStaticActorDefinition(definition)) {
@@ -1696,7 +1696,7 @@ export class EngineActorDriver implements ActorDriver {
 					logger().debug({
 						msg: "failed to dispose dynamic runtime after actor start failure",
 						actorId,
-						err: stringifyError(disposeError),
+						error: stringifyError(disposeError),
 					});
 				}
 				this.#dynamicRuntimes.delete(actorId);
@@ -1719,7 +1719,7 @@ export class EngineActorDriver implements ActorDriver {
 				actorId,
 				name,
 				key,
-				err: stringifyError(error),
+				error: stringifyError(error),
 			});
 
 			try {
@@ -1728,7 +1728,7 @@ export class EngineActorDriver implements ActorDriver {
 				logger().debug({
 					msg: "failed to stop actor after start failure",
 					actorId,
-					err: stringifyError(stopError),
+					error: stringifyError(stopError),
 				});
 			}
 		}
@@ -1775,7 +1775,7 @@ export class EngineActorDriver implements ActorDriver {
 				logger().debug({
 					msg: "actor start failed during stop, cleaning up handler",
 					actorId,
-					err: stringifyError(err),
+					error: stringifyError(err),
 				});
 			}
 		}
@@ -1793,7 +1793,7 @@ export class EngineActorDriver implements ActorDriver {
 			} catch (err) {
 				logger().error({
 					msg: "error in onStop, proceeding with removing actor",
-					err: stringifyError(err),
+					error: stringifyError(err),
 				});
 			}
 		}
@@ -1978,8 +1978,8 @@ export class EngineActorDriver implements ActorDriver {
 				isHibernatable,
 				isRestoringHibernatable,
 			);
-		} catch (err) {
-			logger().error({ msg: "building websocket handlers errored", err });
+		} catch (error) {
+			logger().error({ msg: "building websocket handlers errored", error });
 			websocketRaw.close(1011, "ws.route_error");
 			return;
 		}

--- a/rivetkit-typescript/packages/rivetkit/src/registry/index.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/index.ts
@@ -307,12 +307,12 @@ export class Registry<A extends RegistryActors> {
 				.then(async ({ runtime, registry, serveConfig }) => {
 					await runtime.serveRegistry(registry, serveConfig);
 				})
-				.catch((err) => {
+				.catch((error) => {
 					// Always-attached catch so the stored promise never leaves a
 					// rejection unhandled. Downstream awaits (e.g. #runShutdown's
 					// Promise.race) attach their own catches and still observe
 					// resolution via the race.
-					logger().warn({ err }, "runtime registry serve errored");
+					logger().warn({ error }, "runtime registry serve errored");
 				});
 			// Install signal handlers once an envoy lifecycle has begun. Only
 			// Mode A ever reaches here. Mode B (handler(request)) intentionally
@@ -374,8 +374,8 @@ export class Registry<A extends RegistryActors> {
 			signal,
 			config,
 			configuredRegistryPromise,
-		).catch((err) => {
-			logger().warn({ err }, "shutdown error");
+		).catch((error) => {
+			logger().warn({ error }, "shutdown error");
 		});
 	}
 
@@ -400,9 +400,9 @@ export class Registry<A extends RegistryActors> {
 						const { runtime, registry } =
 							await configuredRegistryPromise;
 						await runtime.shutdownRegistry(registry);
-					} catch (err) {
+					} catch (error) {
 						logger().warn(
-							{ err },
+							{ error },
 							"runtime registry shutdown errored (mode A)",
 						);
 					}
@@ -418,7 +418,7 @@ export class Registry<A extends RegistryActors> {
 							await runtime.shutdownRegistry(registry);
 						} catch (err) {
 							logger().warn(
-								{ err },
+								{ error: err },
 								"runtime registry shutdown errored (mode B)",
 							);
 						}

--- a/rivetkit-typescript/packages/rivetkit/src/registry/native.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/native.ts
@@ -3496,6 +3496,10 @@ export function buildNativeFactory(
 							getNativeWorkflowInspector(ctx) !== undefined,
 					});
 				} catch (error) {
+					logger().error({
+						msg: "error replaying workflow history",
+						error,
+					});
 					return errorResponse(error);
 				}
 			}
@@ -3675,6 +3679,10 @@ export function buildNativeFactory(
 					);
 					return jsonResponse({ output });
 				} catch (error) {
+					logger().error({
+						msg: "Error handling inspector action request",
+						error,
+					});
 					return errorResponse(error);
 				}
 			}
@@ -3689,6 +3697,10 @@ export function buildNativeFactory(
 				{ status: 404 },
 			);
 		} catch (error) {
+			logger().error({
+				msg: "Error handling inspector request",
+				error,
+			});
 			return errorResponse(error);
 		} finally {
 			await actorCtx.dispose();


### PR DESCRIPTION
Adds error logs to inpector requests + standardizes `error` errorKey for pino (was being used but not configured in base logger)