### PR TITLE
feat(rivetkit): configure client connection request size

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/client/actor-conn.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/client/actor-conn.ts
@@ -46,6 +46,7 @@ import {
 	isStaleResolvedActorError,
 } from "./actor-query";
 import { ACTOR_CONNS_SYMBOL, type ClientRaw } from "./client";
+import { DEFAULT_MAX_CONNECTION_REQUEST_SIZE } from "./config";
 import * as errors from "./errors";
 import { isRetryableLifecycleReconnectSignal } from "./lifecycle-errors";
 import { logger } from "./log";
@@ -92,8 +93,6 @@ interface EventSubscriptions<Args extends Array<unknown>> {
 	callback: (...args: Args) => void;
 	once: boolean;
 }
-
-const DEFAULT_MAX_INCOMING_MESSAGE_SIZE = 65_536;
 
 /**
  * A function that unsubscribes from an event.
@@ -190,6 +189,7 @@ export class ActorConnRaw {
 	#encoding: Encoding;
 	#actorResolutionState: ActorResolutionState;
 	#gatewayOptions: ResolvedActorGatewayOptions;
+	#maxConnectionRequestSize: number;
 
 	// TODO: ws message queue
 
@@ -208,6 +208,7 @@ export class ActorConnRaw {
 		encoding: Encoding,
 		actorResolutionState: ActorResolutionState,
 		gatewayOptions: ActorGatewayOptions = {},
+		maxConnectionRequestSize = DEFAULT_MAX_CONNECTION_REQUEST_SIZE,
 	) {
 		this.#client = client;
 		this.#driver = driver;
@@ -216,6 +217,7 @@ export class ActorConnRaw {
 		this.#encoding = encoding;
 		this.#actorResolutionState = actorResolutionState;
 		this.#gatewayOptions = resolveActorGatewayOptions(gatewayOptions);
+		this.#maxConnectionRequestSize = maxConnectionRequestSize;
 		this.#readyPromise = promiseWithResolvers((reason) =>
 			logger().warn({
 				msg: "unhandled ready promise rejection",
@@ -1282,7 +1284,7 @@ export class ActorConnRaw {
 					);
 					const serializedLength = messageLength(messageSerialized);
 					if (
-						serializedLength > DEFAULT_MAX_INCOMING_MESSAGE_SIZE &&
+						serializedLength > this.#maxConnectionRequestSize &&
 						message.body.tag === "ActionRequest"
 					) {
 						const actionId = Number(message.body.val.id);
@@ -1292,7 +1294,7 @@ export class ActorConnRaw {
 							"incoming_too_long",
 							"Incoming message too long",
 							{
-								maxSize: DEFAULT_MAX_INCOMING_MESSAGE_SIZE,
+								maxSize: this.#maxConnectionRequestSize,
 								actualSize: serializedLength,
 							},
 						);
@@ -1301,7 +1303,7 @@ export class ActorConnRaw {
 							actionId,
 							actionName: inFlight.name,
 							actualSize: serializedLength,
-							maxSize: DEFAULT_MAX_INCOMING_MESSAGE_SIZE,
+							maxSize: this.#maxConnectionRequestSize,
 						});
 						inFlight.reject(error);
 						this.#dispatchActorError(error);

--- a/rivetkit-typescript/packages/rivetkit/src/client/actor-handle.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/client/actor-handle.ts
@@ -36,6 +36,7 @@ import type {
 } from "./actor-common";
 import { resolveActorGatewayOptions } from "./actor-common";
 import { type ActorConn, ActorConnRaw } from "./actor-conn";
+import { DEFAULT_MAX_CONNECTION_REQUEST_SIZE } from "./config";
 import {
 	type ActorResolutionState,
 	checkForSchedulingError,
@@ -71,6 +72,7 @@ export class ActorHandleRaw {
 	#encoding: Encoding;
 	#actorResolutionState: ActorResolutionState;
 	#gatewayOptions: ActorGatewayOptions;
+	#maxConnectionRequestSize: number;
 	#params: unknown;
 	#getParams?: () => Promise<unknown>;
 	#resolvedActorId?: string;
@@ -92,12 +94,14 @@ export class ActorHandleRaw {
 		encoding: Encoding,
 		actorResolutionState: ActorResolutionState,
 		gatewayOptions: ActorGatewayOptions = {},
+		maxConnectionRequestSize = DEFAULT_MAX_CONNECTION_REQUEST_SIZE,
 	) {
 		this.#client = client;
 		this.#driver = driver;
 		this.#encoding = encoding;
 		this.#actorResolutionState = actorResolutionState;
 		this.#gatewayOptions = gatewayOptions;
+		this.#maxConnectionRequestSize = maxConnectionRequestSize;
 		this.#params = params;
 		this.#getParams = getParams;
 	}
@@ -602,6 +606,7 @@ export class ActorHandleRaw {
 			this.#encoding,
 			this.#actorResolutionState,
 			resolveActorGatewayOptions(this.#gatewayOptions, options),
+			this.#maxConnectionRequestSize,
 		);
 
 		return this.#client[CREATE_ACTOR_CONN_PROXY](

--- a/rivetkit-typescript/packages/rivetkit/src/client/client.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/client/client.ts
@@ -10,6 +10,7 @@ import {
 	CONNECT_SYMBOL,
 } from "./actor-conn";
 import { type ActorHandle, ActorHandleRaw } from "./actor-handle";
+import { DEFAULT_MAX_CONNECTION_REQUEST_SIZE } from "./config";
 import { logger } from "./log";
 import { resolveGatewayTarget } from "./resolve-gateway-target";
 
@@ -179,6 +180,7 @@ export class ClientRaw {
 	#driver: EngineControlClient;
 	#encodingKind: Encoding;
 	#gatewayOptions: ActorGatewayOptions;
+	#maxConnectionRequestSize: number;
 
 	/**
 	 * Creates an instance of Client.
@@ -187,11 +189,13 @@ export class ClientRaw {
 		driver: EngineControlClient,
 		encoding: Encoding | undefined,
 		gatewayOptions: ActorGatewayOptions = {},
+		maxConnectionRequestSize = DEFAULT_MAX_CONNECTION_REQUEST_SIZE,
 	) {
 		this.#driver = driver;
 
 		this.#encodingKind = encoding ?? "bare";
 		this.#gatewayOptions = gatewayOptions;
+		this.#maxConnectionRequestSize = maxConnectionRequestSize;
 	}
 
 	/**
@@ -386,6 +390,7 @@ export class ClientRaw {
 			this.#encodingKind,
 			actorQuery,
 			this.#gatewayOptions,
+			this.#maxConnectionRequestSize,
 		);
 	}
 
@@ -442,9 +447,18 @@ export type AnyClient = Client<Registry<any>>;
 
 export function createClientWithDriver<A extends Registry<any>>(
 	driver: EngineControlClient,
-	config: { encoding?: Encoding; gateway?: ActorGatewayOptions } = {},
+	config: {
+		encoding?: Encoding;
+		gateway?: ActorGatewayOptions;
+		maxConnectionRequestSize?: number;
+	} = {},
 ): Client<A> {
-	const client = new ClientRaw(driver, config.encoding, config.gateway);
+	const client = new ClientRaw(
+		driver,
+		config.encoding,
+		config.gateway,
+		config.maxConnectionRequestSize,
+	);
 
 	// Create proxy for accessing actors by name
 	return new Proxy(client, {

--- a/rivetkit-typescript/packages/rivetkit/src/client/config.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/client/config.ts
@@ -13,6 +13,7 @@ import {
 
 const DEFAULT_ENDPOINT = "http://localhost:6420";
 export const DEFAULT_MAX_QUERY_INPUT_SIZE = 4 * 1024;
+export const DEFAULT_MAX_CONNECTION_REQUEST_SIZE = 65_536;
 
 let hasWarnedMissingEndpoint = false;
 
@@ -97,6 +98,19 @@ export const ClientConfigSchemaBase = z.object({
 		.positive()
 		.default(DEFAULT_MAX_QUERY_INPUT_SIZE),
 
+	/**
+	 * Maximum serialized connection action request size in bytes.
+	 *
+	 * This is enforced client-side before sending action requests over a
+	 * persistent connection created by `.connect()`. It does not apply to
+	 * stateless action calls or raw HTTP fetch requests.
+	 */
+	maxConnectionRequestSize: z
+		.number()
+		.int()
+		.positive()
+		.default(DEFAULT_MAX_CONNECTION_REQUEST_SIZE),
+
 	/** Whether to enable RivetKit Devtools integration. */
 	devtools: z
 		.boolean()
@@ -160,6 +174,7 @@ export function convertRegistryConfigToClientConfig(
 		// We don't need health checks for internal clients
 		disableMetadataLookup: true,
 		maxInputSize: DEFAULT_MAX_QUERY_INPUT_SIZE,
+		maxConnectionRequestSize: config.maxIncomingMessageSize,
 		devtools:
 			typeof window !== "undefined" &&
 			(window?.location?.hostname === "127.0.0.1" ||

--- a/rivetkit-typescript/packages/rivetkit/src/registry/native.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/native.ts
@@ -3268,7 +3268,10 @@ export function buildNativeFactory(
 			new RemoteEngineControlClient(
 				convertRegistryConfigToClientConfig(registryConfig),
 			),
-			{ encoding: "bare" },
+			{
+				encoding: "bare",
+				maxConnectionRequestSize: registryConfig.maxIncomingMessageSize,
+			},
 		);
 	const nativeRunHandlerActiveByActorId = new Map<string, boolean>();
 	const isNativeRunHandlerActive = (ctx: ActorContextHandle) =>

--- a/rivetkit-typescript/packages/rivetkit/tests/actor-gateway-url.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/actor-gateway-url.test.ts
@@ -2,6 +2,7 @@ import * as cbor from "cbor-x";
 import { describe, expect, test } from "vitest";
 import {
 	ClientConfigSchema,
+	DEFAULT_MAX_CONNECTION_REQUEST_SIZE,
 	DEFAULT_MAX_QUERY_INPUT_SIZE,
 } from "@/client/config";
 import {
@@ -18,6 +19,25 @@ describe("gateway URL builders", () => {
 		});
 
 		expect(config.maxInputSize).toBe(DEFAULT_MAX_QUERY_INPUT_SIZE);
+	});
+
+	test("defaults maxConnectionRequestSize to 64 KiB", () => {
+		const config = ClientConfigSchema.parse({
+			endpoint: "https://api.rivet.dev",
+		});
+
+		expect(config.maxConnectionRequestSize).toBe(
+			DEFAULT_MAX_CONNECTION_REQUEST_SIZE,
+		);
+	});
+
+	test("allows larger connection action requests when maxConnectionRequestSize is increased", () => {
+		const config = ClientConfigSchema.parse({
+			endpoint: "https://api.rivet.dev",
+			maxConnectionRequestSize: 128 * 1024,
+		});
+
+		expect(config.maxConnectionRequestSize).toBe(128 * 1024);
 	});
 
 	test("preserves direct actor ID paths", () => {

--- a/website/src/content/docs/actors/limits.mdx
+++ b/website/src/content/docs/actors/limits.mdx
@@ -28,7 +28,7 @@ const rivet = setup({
 
 ### WebSocket
 
-These limits affect actions that use `.connect()` and [low-level WebSockets](/docs/actors/websocket-handler).
+These server-side limits affect actions that use `.connect()` and [low-level WebSockets](/docs/actors/websocket-handler).
 
 | Name | Soft Limit | Hard Limit | Description |
 |------|------------|------------|-------------|
@@ -36,6 +36,12 @@ These limits affect actions that use `.connect()` and [low-level WebSockets](/do
 | Max outgoing message size | 1 MiB | 32 MiB | Maximum size of outgoing WebSocket messages. Soft limit configurable via `maxOutgoingMessageSize`. |
 | WebSocket open timeout | — | 15 seconds | Time allowed for WebSocket connection to be established, including `onBeforeConnect` and `createConnState` hooks. Connection is closed if exceeded. |
 | Message ack timeout | — | 30 seconds | Time allowed for message acknowledgment before connection is closed. Only relevant in the case of a network issue and does not affect your application. |
+
+These client-side limits affect action requests sent through `.connect()`.
+
+| Name | Soft Limit | Hard Limit | Description |
+|------|------------|------------|-------------|
+| Max connection request size | 64 KiB | — | Maximum serialized action request size before the client sends it over a `.connect()` WebSocket. Configurable via `maxConnectionRequestSize` on `createClient`. |
 
 ### Hibernating WebSocket
 


### PR DESCRIPTION
# Description

Adds `maxConnectionRequestSize` to the RivetKit client config for action requests sent through `.connect()`.

Previously, the client rejected serialized connection action requests above 64 KiB before sending them, even when the actor-side `maxIncomingMessageSize` was configured
higher. This adds a connection-specific client knob and documents it separately from the server-side WebSocket limits.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

- `pnpm -F rivetkit test tests/actor-gateway-url.test.ts`
- `git diff --check HEAD`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
