### PR TITLE
feat(frontend): rename profile to account and drop members from user dropdown

### DIFF
--- a/frontend/src/app/user-dropdown.tsx
+++ b/frontend/src/app/user-dropdown.tsx
@@ -9,7 +9,6 @@ import {
 	faSparkles,
 	faSun,
 	faUserCircle,
-	faUsers,
 	Icon,
 } from "@rivet-gg/icons";
 import { useQuery } from "@tanstack/react-query";
@@ -110,7 +109,7 @@ export function UserDropdown({ children }: { children?: React.ReactNode }) {
 					}}
 				>
 					<Icon icon={faUserCircle} className="mr-2 size-3.5 text-muted-foreground" />
-					Profile
+					Account
 				</DropdownMenuItem>
 				<DropdownMenuItem
 					onSelect={() => {
@@ -134,22 +133,6 @@ export function UserDropdown({ children }: { children?: React.ReactNode }) {
 							<BillingUsageGauge />
 							<BillingPlanBadge />
 						</span>
-					</DropdownMenuItem>
-				) : null}
-				{params.organization ? (
-					<DropdownMenuItem
-						onSelect={() => {
-							return navigate({
-								to: ".",
-								search: (old) => ({
-									...old,
-									settings: "members",
-								}),
-							});
-						}}
-					>
-						<Icon icon={faUsers} className="mr-2 size-3.5 text-muted-foreground" />
-						Members
 					</DropdownMenuItem>
 				) : null}
 				<DropdownMenuSeparator />


### PR DESCRIPTION
## What?

In the user dropdown menu:
- Rename "Profile" → "Account"
- Remove the "Members" entry

## Why?

Aligns the dropdown copy with the account-centric framing and trims the menu down to the entries that belong in this surface; members management lives in settings.