### PR TITLE
fix(rivetkit): preserve connected actor action types

### DIFF
--- a/examples/multiplayer-game-patterns-vercel/frontend/App.tsx
+++ b/examples/multiplayer-game-patterns-vercel/frontend/App.tsx
@@ -14,25 +14,40 @@ import {
 import { useEffect, useMemo, useState } from "react";
 import { makeClient } from "./client.ts";
 import { ArenaGameView } from "./games/arena/game.tsx";
-import { ArenaMenu } from "./games/arena/menu.tsx";
+import { ArenaMenu, type ArenaMatchInfo } from "./games/arena/menu.tsx";
 import { BattleRoyaleGameView } from "./games/battle-royale/game.tsx";
-import { BattleRoyaleMenu } from "./games/battle-royale/menu.tsx";
+import {
+	BattleRoyaleMenu,
+	type BattleRoyaleMatchInfo,
+} from "./games/battle-royale/menu.tsx";
 import { IdleGame } from "./games/idle/game.tsx";
-import { IdleMenu } from "./games/idle/menu.tsx";
+import { IdleMenu, type IdleMatchInfo } from "./games/idle/menu.tsx";
 import { IoStyleGame } from "./games/io-style/game.tsx";
-import { IoStyleMenu } from "./games/io-style/menu.tsx";
+import { IoStyleMenu, type IoStyleMatchInfo } from "./games/io-style/menu.tsx";
 import { OpenWorldGameView } from "./games/open-world/game.tsx";
-import { OpenWorldMenu } from "./games/open-world/menu.tsx";
+import {
+	OpenWorldMenu,
+	type OpenWorldMatchInfo,
+} from "./games/open-world/menu.tsx";
 import { PartyGame } from "./games/party/game.tsx";
-import { PartyMenu } from "./games/party/menu.tsx";
+import { PartyMenu, type PartyMatchInfo } from "./games/party/menu.tsx";
 import { Physics2dGameView } from "./games/physics-2d/game.tsx";
-import { Physics2dMenu } from "./games/physics-2d/menu.tsx";
+import {
+	Physics2dMenu,
+	type Physics2dMatchInfo,
+} from "./games/physics-2d/menu.tsx";
 import { Physics3dGameView } from "./games/physics-3d/game.tsx";
-import { Physics3dMenu } from "./games/physics-3d/menu.tsx";
+import {
+	Physics3dMenu,
+	type Physics3dMatchInfo,
+} from "./games/physics-3d/menu.tsx";
 import { RankedGameView } from "./games/ranked/game.tsx";
-import { RankedMenu } from "./games/ranked/menu.tsx";
+import { RankedMenu, type RankedMatchInfo } from "./games/ranked/menu.tsx";
 import { TurnBasedGame } from "./games/turn-based/game.tsx";
-import { TurnBasedMenu } from "./games/turn-based/menu.tsx";
+import {
+	TurnBasedMenu,
+	type TurnBasedMatchInfo,
+} from "./games/turn-based/menu.tsx";
 
 type PatternId =
 	| "io-style"
@@ -49,7 +64,20 @@ type PatternId =
 type Route =
 	| { page: "selector" }
 	| { page: "menu"; pattern: PatternId }
-	| { page: "game"; pattern: PatternId; matchInfo: unknown };
+	| { page: "game"; pattern: "io-style"; matchInfo: IoStyleMatchInfo }
+	| { page: "game"; pattern: "arena"; matchInfo: ArenaMatchInfo }
+	| { page: "game"; pattern: "party"; matchInfo: PartyMatchInfo }
+	| { page: "game"; pattern: "turn-based"; matchInfo: TurnBasedMatchInfo }
+	| { page: "game"; pattern: "ranked"; matchInfo: RankedMatchInfo }
+	| {
+			page: "game";
+			pattern: "battle-royale";
+			matchInfo: BattleRoyaleMatchInfo;
+	  }
+	| { page: "game"; pattern: "open-world"; matchInfo: OpenWorldMatchInfo }
+	| { page: "game"; pattern: "idle"; matchInfo: IdleMatchInfo }
+	| { page: "game"; pattern: "physics-2d"; matchInfo: Physics2dMatchInfo }
+	| { page: "game"; pattern: "physics-3d"; matchInfo: Physics3dMatchInfo };
 
 const PATTERNS: Array<{
 	id: PatternId;
@@ -169,70 +197,238 @@ export function App() {
 
 	const goSelector = () => setRoute({ page: "selector" });
 	const goMenu = (pattern: PatternId) => setRoute({ page: "menu", pattern });
-	const goGame = (pattern: PatternId, matchInfo: unknown) =>
-		setRoute({ page: "game", pattern, matchInfo });
 
 	if (route.page === "selector") {
 		return <Selector onSelect={goMenu} />;
 	}
 
 	if (route.page === "menu") {
-		const props = {
-			client,
-			onReady: (info: unknown) => goGame(route.pattern, info),
-			onBack: goSelector,
-		};
 		switch (route.pattern) {
 			case "io-style":
-				return <IoStyleMenu {...props} />;
+				return (
+					<IoStyleMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "io-style",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "arena":
-				return <ArenaMenu {...props} />;
+				return (
+					<ArenaMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "arena",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "party":
-				return <PartyMenu {...props} />;
+				return (
+					<PartyMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "party",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "turn-based":
-				return <TurnBasedMenu {...props} />;
+				return (
+					<TurnBasedMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "turn-based",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "ranked":
-				return <RankedMenu {...props} />;
+				return (
+					<RankedMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "ranked",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "battle-royale":
-				return <BattleRoyaleMenu {...props} />;
+				return (
+					<BattleRoyaleMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "battle-royale",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "open-world":
-				return <OpenWorldMenu {...props} />;
+				return (
+					<OpenWorldMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "open-world",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "idle":
-				return <IdleMenu {...props} />;
+				return (
+					<IdleMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "idle",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "physics-2d":
-				return <Physics2dMenu {...props} />;
+				return (
+					<Physics2dMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "physics-2d",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "physics-3d":
-				return <Physics3dMenu {...props} />;
+				return (
+					<Physics3dMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "physics-3d",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 		}
 	}
 
 	if (route.page === "game") {
-		const props = {
-			client,
-			matchInfo: route.matchInfo as never,
-			onLeave: goSelector,
-		};
 		switch (route.pattern) {
 			case "io-style":
-				return <IoStyleGame {...props} />;
+				return (
+					<IoStyleGame
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "arena":
-				return <ArenaGameView {...props} />;
+				return (
+					<ArenaGameView
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "party":
-				return <PartyGame {...props} />;
+				return (
+					<PartyGame
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "turn-based":
-				return <TurnBasedGame {...props} />;
+				return (
+					<TurnBasedGame
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "ranked":
-				return <RankedGameView {...props} />;
+				return (
+					<RankedGameView
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "battle-royale":
-				return <BattleRoyaleGameView {...props} />;
+				return (
+					<BattleRoyaleGameView
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "open-world":
-				return <OpenWorldGameView {...props} />;
+				return (
+					<OpenWorldGameView
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "idle":
-				return <IdleGame {...props} />;
+				return (
+					<IdleGame
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "physics-2d":
-				return <Physics2dGameView {...props} />;
+				return (
+					<Physics2dGameView
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "physics-3d":
-				return <Physics3dGameView {...props} />;
+				return (
+					<Physics3dGameView
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 		}
 	}
 

--- a/examples/multiplayer-game-patterns-vercel/frontend/actor-types.ts
+++ b/examples/multiplayer-game-patterns-vercel/frontend/actor-types.ts
@@ -1,0 +1,34 @@
+import type { ActorConn } from "rivetkit/client";
+import type {
+	arenaMatch,
+	arenaMatchmaker,
+	battleRoyaleMatch,
+	idleLeaderboard,
+	idleWorld,
+	ioStyleMatch,
+	openWorldChunk,
+	partyMatch,
+	physics2dWorld,
+	physics3dWorld,
+	rankedLeaderboard,
+	rankedMatch,
+	rankedMatchmaker,
+	turnBasedMatch,
+	turnBasedMatchmaker,
+} from "../src/actors/index.ts";
+
+export type ArenaMatchConn = ActorConn<typeof arenaMatch>;
+export type ArenaMatchmakerConn = ActorConn<typeof arenaMatchmaker>;
+export type BattleRoyaleMatchConn = ActorConn<typeof battleRoyaleMatch>;
+export type IdleLeaderboardConn = ActorConn<typeof idleLeaderboard>;
+export type IdleWorldConn = ActorConn<typeof idleWorld>;
+export type IoStyleMatchConn = ActorConn<typeof ioStyleMatch>;
+export type OpenWorldChunkConn = ActorConn<typeof openWorldChunk>;
+export type PartyMatchConn = ActorConn<typeof partyMatch>;
+export type Physics2dConn = ActorConn<typeof physics2dWorld>;
+export type Physics3dConn = ActorConn<typeof physics3dWorld>;
+export type RankedLeaderboardConn = ActorConn<typeof rankedLeaderboard>;
+export type RankedMatchConn = ActorConn<typeof rankedMatch>;
+export type RankedMatchmakerConn = ActorConn<typeof rankedMatchmaker>;
+export type TurnBasedMatchConn = ActorConn<typeof turnBasedMatch>;
+export type TurnBasedMatchmakerConn = ActorConn<typeof turnBasedMatchmaker>;

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/arena/arena-game.ts
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/arena/arena-game.ts
@@ -1,3 +1,4 @@
+import type { ArenaMatchConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import type { ArenaMatchInfo } from "./menu.tsx";
 
@@ -17,10 +18,6 @@ interface ShotLine {
 	hit: boolean;
 	createdAt: number;
 }
-
-type ArenaMatchConn = ReturnType<
-	ReturnType<GameClient["arenaMatch"]["get"]>["connect"]
->;
 
 export class ArenaGame {
 	private stopped = false;
@@ -56,24 +53,7 @@ export class ArenaGame {
 			})
 			.connect();
 
-		this.conn.on("snapshot", (raw: unknown) => {
-			const snap = raw as {
-				worldSize: number;
-				scoreLimit: number;
-				phase: "waiting" | "live" | "finished";
-				winnerTeam: number | null;
-				winnerPlayerId: string | null;
-				players: Record<
-					string,
-					{
-						x: number;
-						y: number;
-						teamId: number;
-						color: string;
-						score: number;
-					}
-				>;
-			};
+		this.conn.on("snapshot", (snap) => {
 			this.worldSize = snap.worldSize;
 			this.scoreLimit = snap.scoreLimit;
 			this.phase = snap.phase;
@@ -103,15 +83,7 @@ export class ArenaGame {
 			}
 		});
 
-		this.conn.on("shoot", (raw: unknown) => {
-			const shot = raw as {
-				shooterId: string;
-				fromX: number;
-				fromY: number;
-				dirX: number;
-				dirY: number;
-				hitPlayerId: string | null;
-			};
+		this.conn.on("shoot", (shot) => {
 			const lineLen = 300;
 			this.shotLines.push({
 				fromX: shot.fromX,

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/arena/bot.ts
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/arena/bot.ts
@@ -1,4 +1,5 @@
 import type { Mode } from "../../../src/actors/arena/config.ts";
+import type { ArenaMatchmakerConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import { ArenaGame } from "./arena-game.ts";
 import type { ArenaMatchInfo } from "./menu.tsx";
@@ -7,8 +8,7 @@ import { waitForAssignment } from "./wait-for-assignment.ts";
 export class ArenaBot {
 	private game: ArenaGame | null = null;
 	private destroyed = false;
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	private mm: any = null;
+	private mm: ArenaMatchmakerConn | null = null;
 
 	constructor(
 		private client: GameClient,
@@ -23,9 +23,9 @@ export class ArenaBot {
 				.getOrCreate(["main"])
 				.connect();
 			this.mm = mm;
-			const response = (await mm.queueForMatch({
+			const response = await mm.queueForMatch({
 				mode: this.mode,
-			})) as { playerId?: string };
+			});
 			if (!response?.playerId || this.destroyed) return;
 
 			const assignment = await waitForAssignment<ArenaMatchInfo>(

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/arena/menu.tsx
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/arena/menu.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { MODE_CONFIG, type Mode } from "../../../src/actors/arena/config.ts";
+import type { ArenaMatchmakerConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import { ArenaBot } from "./bot.ts";
 import { waitForAssignment } from "./wait-for-assignment.ts";
@@ -34,8 +35,7 @@ export function ArenaMenu({
 	const [queueCount, setQueueCount] = useState(0);
 	const [error, setError] = useState("");
 
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle type
-	const mmRef = useRef<any>(null);
+	const mmRef = useRef<ArenaMatchmakerConn | null>(null);
 	const abortRef = useRef(false);
 	const botsRef = useRef<ArenaBot[]>([]);
 	const matchedRef = useRef(false);
@@ -83,23 +83,21 @@ export function ArenaMenu({
 				}, 1500);
 			};
 
-			mm.on("queueUpdate", (raw: unknown) => {
-				const data = raw as { counts: Record<string, number> };
+			mm.on("queueUpdate", (data) => {
 				setQueueCount(data.counts[mode] ?? 0);
 			});
 
 			setStatus("queued");
 
-			const response = (await mm.queueForMatch({
+			const response = await mm.queueForMatch({
 				mode,
-			})) as { playerId?: string };
+			});
 			if (!response?.playerId || abortRef.current)
 				throw new Error("Failed to queue");
 			myPlayerId = response.playerId;
 
 			const sizes = await mm.getQueueSizes();
-			if (!abortRef.current)
-				setQueueCount((sizes as Record<string, number>)[mode] ?? 0);
+			if (!abortRef.current) setQueueCount(sizes[mode] ?? 0);
 
 			const assignment = await waitForAssignment<ArenaMatchInfo>(
 				mm,

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/arena/wait-for-assignment.ts
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/arena/wait-for-assignment.ts
@@ -3,13 +3,10 @@ interface Assignment {
 }
 
 type AssignmentConnection = {
-	action: <Args extends unknown[], Response>(opts: {
-		name: string;
-		args: Args;
-	}) => Promise<Response>;
+	getAssignment: (input: { playerId: string }) => Promise<Assignment | null>;
 	on: (
 		event: "assignmentReady",
-		handler: (raw: unknown) => void,
+		handler: (assignment: Assignment) => void,
 	) => (() => void) | undefined;
 };
 
@@ -24,7 +21,7 @@ export async function waitForAssignment<T extends Assignment>(
 	timeoutMs = 120_000,
 ): Promise<T> {
 	const existing = await readAssignment<T>(mm, playerId);
-	if (existing) return existing as T;
+	if (existing) return existing;
 
 	return await new Promise<T>((resolve, reject) => {
 		let settled = false;
@@ -39,10 +36,9 @@ export async function waitForAssignment<T extends Assignment>(
 			fn();
 		};
 
-		off = mm.on("assignmentReady", (raw: unknown) => {
-			const next = raw as T;
+		off = mm.on("assignmentReady", (next) => {
 			if (next.playerId !== playerId) return;
-			settle(() => resolve(next));
+			settle(() => resolve(next as T));
 		});
 
 		timeout = window.setTimeout(() => {
@@ -64,8 +60,5 @@ async function readAssignment<T extends Assignment>(
 	mm: AssignmentConnection,
 	playerId: string,
 ): Promise<T | null> {
-	return await mm.action<[{ playerId: string }], T | null>({
-		name: "getAssignment",
-		args: [{ playerId }],
-	});
+	return (await mm.getAssignment({ playerId })) as T | null;
 }

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/battle-royale/battle-royale-game.ts
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/battle-royale/battle-royale-game.ts
@@ -1,3 +1,4 @@
+import type { BattleRoyaleMatchConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import type { BattleRoyaleMatchInfo } from "./menu.tsx";
 
@@ -18,10 +19,6 @@ interface ShotLine {
 	hit: boolean;
 	createdAt: number;
 }
-
-type BattleRoyaleMatchConn = ReturnType<
-	ReturnType<GameClient["battleRoyaleMatch"]["get"]>["connect"]
->;
 
 export class BattleRoyaleGame {
 	private stopped = false;
@@ -70,29 +67,7 @@ export class BattleRoyaleGame {
 			})
 			.connect();
 
-		this.conn.on("snapshot", (raw: unknown) => {
-			const snap = raw as {
-				worldSize: number;
-				phase: "lobby" | "live" | "finished";
-				winnerId: string | null;
-				playerCount: number;
-				aliveCount: number;
-				capacity: number;
-				lobbyCountdown: number | null;
-				zone: { centerX: number; centerY: number; radius: number };
-				players: Record<
-					string,
-					{
-						x: number;
-						y: number;
-						color: string;
-						hp: number;
-						maxHp: number;
-						alive: boolean;
-						placement: number | null;
-					}
-				>;
-			};
+		this.conn.on("snapshot", (snap) => {
 			this.worldSize = snap.worldSize;
 			this.phase = snap.phase;
 			this.winnerId = snap.winnerId;
@@ -131,14 +106,7 @@ export class BattleRoyaleGame {
 			}
 		});
 
-		this.conn.on("shoot", (raw: unknown) => {
-			const shot = raw as {
-				fromX: number;
-				fromY: number;
-				dirX: number;
-				dirY: number;
-				hitPlayerId: string | null;
-			};
+		this.conn.on("shoot", (shot) => {
 			this.shotLines.push({
 				fromX: shot.fromX,
 				fromY: shot.fromY,

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/battle-royale/menu.tsx
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/battle-royale/menu.tsx
@@ -30,8 +30,7 @@ export function BattleRoyaleMenu({
 				{ wait: true, timeout: 10_000 },
 			);
 			mm.dispose();
-			const response = (result as { response?: BattleRoyaleMatchInfo })
-				?.response;
+			const response = result.response;
 			if (!response?.matchId || !response?.playerId) {
 				throw new Error("Matchmaker did not return a valid match");
 			}

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/idle/game.tsx
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/idle/game.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { BUILDINGS } from "../../../src/actors/idle/config.ts";
+import type { IdleLeaderboardConn, IdleWorldConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import type { IdleMatchInfo } from "./menu.tsx";
 
@@ -37,10 +38,8 @@ export function IdleGame({
 	const [state, setState] = useState<IdleSnapshot | null>(null);
 	const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
 	const [now, setNow] = useState(Date.now());
-	// biome-ignore lint/suspicious/noExplicitAny: connection handles
-	const worldRef = useRef<any>(null);
-	// biome-ignore lint/suspicious/noExplicitAny: connection handles
-	const lbRef = useRef<any>(null);
+	const worldRef = useRef<IdleWorldConn | null>(null);
+	const lbRef = useRef<IdleLeaderboardConn | null>(null);
 
 	const cleanup = useCallback(() => {
 		const world = worldRef.current;
@@ -57,8 +56,8 @@ export function IdleGame({
 			.connect();
 		worldRef.current = world;
 
-		world.on("stateUpdate", (raw: unknown) => {
-			setState(raw as IdleSnapshot);
+		world.on("stateUpdate", (snap) => {
+			setState(snap);
 		});
 
 		// Initialize the actor.
@@ -70,21 +69,21 @@ export function IdleGame({
 			.then(() => {
 				return world.getState();
 			})
-			.then((s: unknown) => {
-				setState(s as IdleSnapshot);
+			.then((snap) => {
+				setState(snap);
 			});
 
 		// Fetch initial leaderboard.
-		world.getLeaderboard().then((lb: unknown) => {
-			setLeaderboard(lb as LeaderboardEntry[]);
+		world.getLeaderboard().then((scores) => {
+			setLeaderboard(scores);
 		});
 
 		// Connect to leaderboard for live updates.
 		const lb = client.idleLeaderboard.getOrCreate(["main"]).connect();
 		lbRef.current = lb;
 
-		lb.on("leaderboardUpdate", (raw: unknown) => {
-			setLeaderboard(raw as LeaderboardEntry[]);
+		lb.on("leaderboardUpdate", (scores) => {
+			setLeaderboard(scores);
 		});
 
 		return () => {

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/io-style/io-game.ts
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/io-style/io-game.ts
@@ -1,13 +1,10 @@
+import type { IoStyleMatchConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import type { IoStyleMatchInfo } from "./menu.tsx";
 
 const PLAYER_RADIUS = 12;
 const LERP_FACTOR = 0.2;
 const GRID_SPACING = 50;
-
-type IoStyleMatchConn = ReturnType<
-	ReturnType<GameClient["ioStyleMatch"]["get"]>["connect"]
->;
 
 export class IoGame {
 	private stopped = false;
@@ -36,14 +33,7 @@ export class IoGame {
 			})
 			.connect();
 
-		this.conn.on("snapshot", (raw: unknown) => {
-			const snap = raw as {
-				worldSize: number;
-				players: Record<
-					string,
-					{ x: number; y: number; color: string }
-				>;
-			};
+		this.conn.on("snapshot", (snap) => {
 			this.worldSize = snap.worldSize;
 			for (const [id, pos] of Object.entries(snap.players)) {
 				this.targets[id] = pos;

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/io-style/menu.tsx
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/io-style/menu.tsx
@@ -28,8 +28,7 @@ export function IoStyleMenu({
 				{ wait: true, timeout: 10_000 },
 			);
 			mm.dispose();
-			const response = (result as { response?: IoStyleMatchInfo })
-				?.response;
+			const response = result.response;
 			if (!response?.matchId || !response?.playerId) {
 				throw new Error("Matchmaker did not return a valid lobby");
 			}

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/open-world/open-world-game.ts
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/open-world/open-world-game.ts
@@ -1,5 +1,6 @@
 import { CHUNK_SIZE, WORLD_ID } from "../../../src/actors/open-world/config.ts";
 import { getPlayerColor } from "../../../src/actors/player-color.ts";
+import type { OpenWorldChunkConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import type { OpenWorldMatchInfo } from "./menu.tsx";
 
@@ -11,10 +12,6 @@ const DEFAULT_VIEWPORT_SIZE = 600;
 const MIN_ZOOM = 0.25;
 const MAX_ZOOM = 2;
 const ZOOM_STEP = 0.15;
-
-type OpenWorldChunkConn = ReturnType<
-	ReturnType<GameClient["openWorldChunk"]["getOrCreate"]>["connect"]
->;
 
 interface ChunkConnection {
 	cx: number;
@@ -124,8 +121,7 @@ export class OpenWorldGame {
 			selfPresent: false,
 		};
 
-		conn.on("snapshot", (raw: unknown) => {
-			const snap = raw as ChunkSnapshot;
+		conn.on("snapshot", (snap) => {
 			this.chunkSize = snap.chunkSize;
 			const isPrimaryChunk =
 				chunk.cx === this.chunkX && chunk.cy === this.chunkY;

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/party/bot.ts
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/party/bot.ts
@@ -1,8 +1,8 @@
+import type { PartyMatchConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 
 export class PartyBot {
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	private conn: any = null;
+	private conn: PartyMatchConn | null = null;
 	private destroyed = false;
 
 	constructor(
@@ -26,16 +26,7 @@ export class PartyBot {
 				{ wait: true, timeout: 10_000 },
 			);
 			mm.dispose();
-			const response = (
-				result as {
-					response?: {
-						matchId: string;
-						playerId: string;
-						joinToken: string;
-						playerName: string;
-					};
-				}
-			)?.response;
+			const response = result.response;
 			if (!response || this.destroyed) return;
 
 			this.conn = this.client.partyMatch

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/party/game.tsx
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/party/game.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { PartyMatchConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import { PartyBot } from "./bot.ts";
 import type { PartyMatchInfo } from "./menu.tsx";
@@ -32,8 +33,7 @@ export function PartyGame({
 	const [nameInput, setNameInput] = useState(
 		matchInfo.playerName || "Player",
 	);
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	const connRef = useRef<any>(null);
+	const connRef = useRef<PartyMatchConn | null>(null);
 	const botsRef = useRef<PartyBot[]>([]);
 	const nameTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -54,14 +54,13 @@ export function PartyGame({
 			.connect();
 		connRef.current = conn;
 
-		conn.on("partyUpdate", (raw: unknown) => {
-			setSnapshot(raw as PartySnapshot);
+		conn.on("partyUpdate", (snap) => {
+			setSnapshot(snap);
 		});
 
-		conn.getSnapshot().then((snap: unknown) => {
-			const s = snap as PartySnapshot;
-			setSnapshot(s);
-			const myName = s.members[matchInfo.playerId]?.name;
+		conn.getSnapshot().then((snap) => {
+			setSnapshot(snap);
+			const myName = snap.members[matchInfo.playerId]?.name;
 			if (myName) setNameInput(myName);
 		});
 

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/party/menu.tsx
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/party/menu.tsx
@@ -33,8 +33,7 @@ export function PartyMenu({
 				{ wait: true, timeout: 10_000 },
 			);
 			mm.dispose();
-			const response = (result as { response?: PartyMatchInfo })
-				?.response;
+			const response = result.response;
 			if (!response?.matchId) throw new Error("Failed to create party");
 			onReady(response);
 		} catch (err) {
@@ -55,16 +54,7 @@ export function PartyMenu({
 				{ wait: true, timeout: 10_000 },
 			);
 			mm.dispose();
-			const response = (
-				result as {
-					response?: {
-						matchId: string;
-						playerId: string;
-						joinToken: string;
-						playerName: string;
-					};
-				}
-			)?.response;
+			const response = result.response;
 			if (!response?.matchId) throw new Error("Failed to join party");
 			onReady({ ...response, partyCode: joinCode.trim().toUpperCase() });
 		} catch (err) {

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/physics-2d/physics-2d-game.ts
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/physics-2d/physics-2d-game.ts
@@ -4,12 +4,9 @@ import {
 	SCALE,
 	SCENE_STATIC,
 } from "../../../src/actors/physics-2d/config.ts";
+import type { Physics2dConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import type { Physics2dMatchInfo } from "./menu.tsx";
-
-type Physics2dConn = ReturnType<
-	ReturnType<GameClient["physics2dWorld"]["getOrCreate"]>["connect"]
->;
 
 interface BodySnapshot {
 	id: string;
@@ -72,8 +69,7 @@ export class Physics2dGame {
 		});
 		this.conn = handle.connect();
 
-		this.conn.on("snapshot", (raw: unknown) => {
-			const snap = raw as Snapshot;
+		this.conn.on("snapshot", (snap) => {
 			const now = Date.now();
 
 			// Measure tick interval and one-way latency estimate.

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/physics-3d/physics-3d-game.ts
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/physics-3d/physics-3d-game.ts
@@ -4,12 +4,9 @@ import {
 	PLAYER_RADIUS,
 	SCENE_STATIC,
 } from "../../../src/actors/physics-3d/config.ts";
+import type { Physics3dConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import type { Physics3dMatchInfo } from "./menu.tsx";
-
-type Physics3dConn = ReturnType<
-	ReturnType<GameClient["physics3dWorld"]["getOrCreate"]>["connect"]
->;
 
 interface BodySnapshot {
 	id: string;
@@ -140,8 +137,7 @@ export class Physics3dGame {
 		});
 		this.conn = handle.connect();
 
-		this.conn.on("snapshot", (raw: unknown) => {
-			const snap = raw as Snapshot;
+		this.conn.on("snapshot", (snap) => {
 			const now = Date.now();
 
 			if (this.lastSnapshotTime > 0) {

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/ranked/bot.ts
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/ranked/bot.ts
@@ -1,3 +1,4 @@
+import type { RankedMatchmakerConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import { RankedGame } from "./ranked-game.ts";
 import { waitForAssignment } from "./wait-for-assignment.ts";
@@ -5,8 +6,7 @@ import { waitForAssignment } from "./wait-for-assignment.ts";
 export class RankedBot {
 	private game: RankedGame | null = null;
 	private destroyed = false;
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	private mm: any = null;
+	private mm: RankedMatchmakerConn | null = null;
 
 	constructor(private client: GameClient) {
 		this.start();
@@ -21,9 +21,9 @@ export class RankedBot {
 				.getOrCreate(["main"])
 				.connect();
 			this.mm = mm;
-			const queueResult = (await mm.queueForMatch({
+			const queueResult = await mm.queueForMatch({
 				username: botUsername,
-			})) as { queued: boolean; connId?: string };
+			});
 			if (this.destroyed) return;
 
 			const assignment = await waitForAssignment(

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/ranked/menu.tsx
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/ranked/menu.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { LeaderboardEntry } from "../../../src/actors/ranked/leaderboard.ts";
+import type { RankedQueueUpdate } from "../../../src/actors/ranked/matchmaker.ts";
 import type { PlayerSnapshot } from "../../../src/actors/ranked/player.ts";
+import type {
+	RankedLeaderboardConn,
+	RankedMatchmakerConn,
+} from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import { RankedBot } from "./bot.ts";
 import { waitForAssignment } from "./wait-for-assignment.ts";
@@ -66,10 +71,8 @@ export function RankedMenu({
 	const [profile, setProfile] = useState<PlayerSnapshot | null>(null);
 	const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
 
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	const mmRef = useRef<any>(null);
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	const lbRef = useRef<any>(null);
+	const mmRef = useRef<RankedMatchmakerConn | null>(null);
+	const lbRef = useRef<RankedLeaderboardConn | null>(null);
 	const abortRef = useRef(false);
 	const botsRef = useRef<RankedBot[]>([]);
 	const matchedRef = useRef(false);
@@ -79,12 +82,12 @@ export function RankedMenu({
 		const lb = client.rankedLeaderboard.getOrCreate(["main"]).connect();
 		lbRef.current = lb;
 
-		lb.on("leaderboardUpdate", (raw: unknown) => {
-			setLeaderboard(raw as LeaderboardEntry[]);
+		lb.on("leaderboardUpdate", (scores) => {
+			setLeaderboard(scores);
 		});
 
-		lb.getTopScores().then((scores: unknown) => {
-			setLeaderboard(scores as LeaderboardEntry[]);
+		lb.getTopScores().then((scores) => {
+			setLeaderboard(scores);
 		});
 
 		return () => {
@@ -104,7 +107,7 @@ export function RankedMenu({
 		handle
 			.initialize({ username })
 			.then(() => handle.getProfile())
-			.then((p: unknown) => setProfile(p as PlayerSnapshot))
+			.then((p) => setProfile(p))
 			.catch(() => setProfile(null));
 	}, [client, username]);
 
@@ -151,15 +154,7 @@ export function RankedMenu({
 				}, 1500);
 			};
 
-			mm.on("queueUpdate", (raw: unknown) => {
-				const data = raw as {
-					queued: boolean;
-					count: number;
-					queueDurationMs?: number;
-					ratingWindow?: number;
-					ratingMin?: number;
-					ratingMax?: number;
-				};
+			mm.on("queueUpdate", (data: RankedQueueUpdate) => {
 				setQueueCount(data.count ?? 0);
 				if (!data.queued) {
 					setQueueDurationMs(0);
@@ -188,10 +183,7 @@ export function RankedMenu({
 
 			setStatus("queued");
 
-			const queueResult = (await mm.queueForMatch({ username })) as {
-				queued: boolean;
-				connId?: string;
-			};
+			const queueResult = await mm.queueForMatch({ username });
 			if (abortRef.current) {
 				throw new Error("Failed to queue");
 			}

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/ranked/ranked-game.ts
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/ranked/ranked-game.ts
@@ -1,3 +1,4 @@
+import type { RankedMatchConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import type { RankedMatchInfo } from "./menu.tsx";
 
@@ -17,10 +18,6 @@ interface ShotLine {
 	hit: boolean;
 	createdAt: number;
 }
-
-type RankedMatchConn = ReturnType<
-	ReturnType<GameClient["rankedMatch"]["get"]>["connect"]
->;
 
 export class RankedGame {
 	private stopped = false;
@@ -55,23 +52,7 @@ export class RankedGame {
 			})
 			.connect();
 
-		this.conn.on("snapshot", (raw: unknown) => {
-			const snap = raw as {
-				worldSize: number;
-				phase: "waiting" | "live" | "finished";
-				winnerId: string | null;
-				scoreLimit: number;
-				players: Record<
-					string,
-					{
-						x: number;
-						y: number;
-						color: string;
-						score: number;
-						rating: number;
-					}
-				>;
-			};
+		this.conn.on("snapshot", (snap) => {
 			this.worldSize = snap.worldSize;
 			this.phase = snap.phase;
 			this.winnerId = snap.winnerId;
@@ -98,14 +79,7 @@ export class RankedGame {
 			}
 		});
 
-		this.conn.on("shoot", (raw: unknown) => {
-			const shot = raw as {
-				fromX: number;
-				fromY: number;
-				dirX: number;
-				dirY: number;
-				hitPlayerId: string | null;
-			};
+		this.conn.on("shoot", (shot) => {
 			this.shotLines.push({
 				fromX: shot.fromX,
 				fromY: shot.fromY,

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/ranked/wait-for-assignment.ts
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/ranked/wait-for-assignment.ts
@@ -1,6 +1,6 @@
 import type { RankedMatchInfo } from "./menu.tsx";
 
-interface RankedAssignmentEvent {
+interface RankedAssignment {
 	matchId: string;
 	username: string;
 	rating: number;
@@ -8,13 +8,12 @@ interface RankedAssignmentEvent {
 }
 
 type AssignmentConnection = {
-	action: <Args extends unknown[], Response>(opts: {
-		name: string;
-		args: Args;
-	}) => Promise<Response>;
+	getAssignment: (input: {
+		username: string;
+	}) => Promise<RankedAssignment | null>;
 	on: (
 		event: "assignmentReady",
-		handler: (raw: unknown) => void,
+		handler: (assignment: RankedAssignment) => void,
 	) => (() => void) | undefined;
 };
 
@@ -45,8 +44,7 @@ export async function waitForAssignment(
 			fn();
 		};
 
-		off = mm.on("assignmentReady", (raw: unknown) => {
-			const next = raw as RankedAssignmentEvent;
+		off = mm.on("assignmentReady", (next) => {
 			if (next.username !== username) return;
 			// Bind assignment delivery to the queueing connection so duplicate usernames in
 			// other tabs do not accept the wrong match assignment.
@@ -73,8 +71,5 @@ async function readAssignment(
 	mm: AssignmentConnection,
 	username: string,
 ): Promise<RankedMatchInfo | null> {
-	return await mm.action<[{ username: string }], RankedMatchInfo | null>({
-		name: "getAssignment",
-		args: [{ username }],
-	});
+	return await mm.getAssignment({ username });
 }

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/turn-based/bot.ts
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/turn-based/bot.ts
@@ -2,6 +2,7 @@ import type {
 	CellValue,
 	GameResult,
 } from "../../../src/actors/turn-based/config.ts";
+import type { TurnBasedMatchConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 
 interface GameSnapshot {
@@ -12,8 +13,7 @@ interface GameSnapshot {
 }
 
 export class TurnBasedBot {
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	private conn: any = null;
+	private conn: TurnBasedMatchConn | null = null;
 	private destroyed = false;
 	private playerId = "";
 	private symbol: "X" | "O" = "O";
@@ -39,9 +39,7 @@ export class TurnBasedBot {
 				{ wait: true, timeout: 10_000 },
 			);
 			mm.dispose();
-			const response = (
-				result as { response?: { matchId: string; playerId: string } }
-			)?.response;
+			const response = result.response;
 			if (!response || this.destroyed) return;
 
 			this.playerId = response.playerId;
@@ -52,11 +50,11 @@ export class TurnBasedBot {
 				})
 				.connect();
 
-			this.conn.on("gameUpdate", (raw: unknown) => {
-				this.tryMove(raw as GameSnapshot);
+			this.conn.on("gameUpdate", (snap) => {
+				this.tryMove(snap);
 			});
 
-			this.conn.getSnapshot().then((snap: unknown) => {
+			this.conn.getSnapshot().then((snap) => {
 				this.tryMove(snap as GameSnapshot);
 			});
 		} catch {

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/turn-based/game.tsx
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/turn-based/game.tsx
@@ -3,6 +3,7 @@ import type {
 	CellValue,
 	GameResult,
 } from "../../../src/actors/turn-based/config.ts";
+import type { TurnBasedMatchConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import { TurnBasedBot } from "./bot.ts";
 import type { TurnBasedMatchInfo } from "./menu.tsx";
@@ -29,8 +30,7 @@ export function TurnBasedGame({
 	onLeave: () => void;
 }) {
 	const [snapshot, setSnapshot] = useState<GameSnapshot | null>(null);
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	const connRef = useRef<any>(null);
+	const connRef = useRef<TurnBasedMatchConn | null>(null);
 	const botsRef = useRef<TurnBasedBot[]>([]);
 
 	const cleanup = useCallback(() => {
@@ -47,12 +47,12 @@ export function TurnBasedGame({
 			.connect();
 		connRef.current = conn;
 
-		conn.on("gameUpdate", (raw: unknown) => {
-			setSnapshot(raw as GameSnapshot);
+		conn.on("gameUpdate", (snap) => {
+			setSnapshot(snap);
 		});
 
-		conn.getSnapshot().then((snap: unknown) => {
-			setSnapshot(snap as GameSnapshot);
+		conn.getSnapshot().then((snap) => {
+			setSnapshot(snap);
 		});
 
 		return () => {

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/turn-based/menu.tsx
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/turn-based/menu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import type { TurnBasedMatchmakerConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import { waitForAssignment } from "./wait-for-assignment.ts";
 
@@ -28,8 +29,7 @@ export function TurnBasedMenu({
 		"idle" | "loading" | "waiting" | "error"
 	>("idle");
 	const [error, setError] = useState("");
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	const queueConnRef = useRef<any>(null);
+	const queueConnRef = useRef<TurnBasedMatchmakerConn | null>(null);
 
 	const cancelQueue = () => {
 		const conn = queueConnRef.current;
@@ -55,11 +55,9 @@ export function TurnBasedMenu({
 				.getOrCreate(["main"])
 				.connect();
 			queueConnRef.current = mm;
-			const queueResult = (await mm.queueForMatch({
+			const queueResult = await mm.queueForMatch({
 				playerName: name.trim(),
-			})) as {
-				playerId?: string;
-			};
+			});
 			const playerId = queueResult.playerId;
 			if (!playerId) {
 				throw new Error("Failed to queue for match");
@@ -101,8 +99,7 @@ export function TurnBasedMenu({
 				{ wait: true, timeout: 10_000 },
 			);
 			mm.dispose();
-			const response = (result as { response?: TurnBasedMatchInfo })
-				?.response;
+			const response = result.response;
 			if (!response?.matchId) throw new Error("Failed to create game");
 			onReady(response);
 		} catch (err) {
@@ -125,9 +122,7 @@ export function TurnBasedMenu({
 				{ wait: true, timeout: 10_000 },
 			);
 			mm.dispose();
-			const response = (
-				result as { response?: { matchId: string; playerId: string } }
-			)?.response;
+			const response = result.response;
 			if (!response?.matchId) throw new Error("Failed to join game");
 			onReady(response);
 		} catch (err) {

--- a/examples/multiplayer-game-patterns-vercel/frontend/games/turn-based/wait-for-assignment.ts
+++ b/examples/multiplayer-game-patterns-vercel/frontend/games/turn-based/wait-for-assignment.ts
@@ -3,13 +3,10 @@ interface Assignment {
 }
 
 type AssignmentConnection = {
-	action: <Args extends unknown[], Response>(opts: {
-		name: string;
-		args: Args;
-	}) => Promise<Response>;
+	getAssignment: (input: { playerId: string }) => Promise<Assignment | null>;
 	on: (
 		event: "assignmentReady",
-		handler: (raw: unknown) => void,
+		handler: (assignment: Assignment) => void,
 	) => (() => void) | undefined;
 };
 
@@ -24,7 +21,7 @@ export async function waitForAssignment<T extends Assignment>(
 	timeoutMs = 120_000,
 ): Promise<T> {
 	const existing = await readAssignment<T>(mm, playerId);
-	if (existing) return existing as T;
+	if (existing) return existing;
 
 	return await new Promise<T>((resolve, reject) => {
 		let settled = false;
@@ -39,10 +36,9 @@ export async function waitForAssignment<T extends Assignment>(
 			fn();
 		};
 
-		off = mm.on("assignmentReady", (raw: unknown) => {
-			const next = raw as T;
+		off = mm.on("assignmentReady", (next) => {
 			if (next.playerId !== playerId) return;
-			settle(() => resolve(next));
+			settle(() => resolve(next as T));
 		});
 
 		timeout = window.setTimeout(() => {
@@ -64,8 +60,5 @@ async function readAssignment<T extends Assignment>(
 	mm: AssignmentConnection,
 	playerId: string,
 ): Promise<T | null> {
-	return await mm.action<[{ playerId: string }], T | null>({
-		name: "getAssignment",
-		args: [{ playerId }],
-	});
+	return (await mm.getAssignment({ playerId })) as T | null;
 }

--- a/examples/multiplayer-game-patterns-vercel/src/actors/arena/matchmaker.ts
+++ b/examples/multiplayer-game-patterns-vercel/src/actors/arena/matchmaker.ts
@@ -5,7 +5,7 @@ This matchmaker uses a queue and fill flow.
 3. The matchmaker stores assignments and broadcasts assignmentReady so each client can connect to the new match.
 4. onDisconnect unqueues pending players so stale queue entries do not stay in the pool.
 */
-import { type ActorContextOf, actor, queue } from "rivetkit";
+import { type ActorContextOf, actor, event, queue } from "rivetkit";
 import { db, type RawAccess } from "rivetkit/db";
 
 import type { registry } from "../index.ts";
@@ -37,6 +37,10 @@ export const arenaMatchmaker = actor({
 		}>(),
 		unqueueForMatch: queue<{ connId: string }>(),
 		matchCompleted: queue<{ matchId: string }>(),
+	},
+	events: {
+		assignmentReady: event<ArenaAssignment>(),
+		queueUpdate: event<{ counts: Record<string, number> }>(),
 	},
 	actions: {
 		queueForMatch: async (c, { mode }: { mode: Mode }) => {

--- a/examples/multiplayer-game-patterns-vercel/src/actors/battle-royale/match.ts
+++ b/examples/multiplayer-game-patterns-vercel/src/actors/battle-royale/match.ts
@@ -382,8 +382,7 @@ async function claimPendingPlayer(
 	if (result.status !== "completed") {
 		return false;
 	}
-	const response = (result as { response?: { accepted?: boolean } }).response;
-	return response?.accepted === true;
+	return result.response?.accepted === true;
 }
 
 function countAlivePlayers(state: State): number {

--- a/examples/multiplayer-game-patterns-vercel/src/actors/io-style/match.ts
+++ b/examples/multiplayer-game-patterns-vercel/src/actors/io-style/match.ts
@@ -165,8 +165,7 @@ async function claimPendingPlayer(
 	if (result.status !== "completed") {
 		return false;
 	}
-	const response = (result as { response?: { accepted?: boolean } }).response;
-	return response?.accepted === true;
+	return result.response?.accepted === true;
 }
 
 interface Snapshot {

--- a/examples/multiplayer-game-patterns-vercel/src/actors/ranked/matchmaker.ts
+++ b/examples/multiplayer-game-patterns-vercel/src/actors/ranked/matchmaker.ts
@@ -5,7 +5,7 @@ This matchmaker uses a rating window flow.
 3. createRankedMatch removes paired players, creates a match actor, stores assignments, and broadcasts assignmentReady.
 4. matchCompleted updates player rating actors and leaderboard entries, then removes the match row.
 */
-import { type ActorContextOf, actor, queue } from "rivetkit";
+import { type ActorContextOf, actor, event, queue } from "rivetkit";
 import { db, type RawAccess } from "rivetkit/db";
 import { interval } from "rivetkit/utils";
 
@@ -22,6 +22,22 @@ export interface RankedAssignment {
 	rating: number;
 	connId: string | null;
 }
+
+export type RankedQueueUpdate =
+	| {
+			queued: false;
+			count: number;
+	  }
+	| {
+			queued: true;
+			count: number;
+			username: string;
+			rating: number;
+			queueDurationMs: number;
+			ratingWindow: number;
+			ratingMin: number;
+			ratingMax: number;
+	  };
 
 type QueuePlayerRow = {
 	username: string;
@@ -51,6 +67,10 @@ export const rankedMatchmaker = actor({
 			winnerNewRating: number;
 			loserNewRating: number;
 		}>(),
+	},
+	events: {
+		assignmentReady: event<RankedAssignment>(),
+		queueUpdate: event<RankedQueueUpdate>(),
 	},
 	actions: {
 		queueForMatch: async (c, { username }: { username: string }) => {

--- a/examples/multiplayer-game-patterns-vercel/src/actors/turn-based/matchmaker.ts
+++ b/examples/multiplayer-game-patterns-vercel/src/actors/turn-based/matchmaker.ts
@@ -7,7 +7,7 @@ This matchmaker supports invite and queued public matchmaking flows.
 5. getAssignment lets clients poll for their match assignment.
 6. onDisconnect unqueues waiting players so stale queue entries do not remain.
 */
-import { type ActorContextOf, actor, queue, UserError } from "rivetkit";
+import { type ActorContextOf, actor, event, queue, UserError } from "rivetkit";
 import { db, type RawAccess } from "rivetkit/db";
 
 import type { registry } from "../index.ts";
@@ -48,6 +48,9 @@ export const turnBasedMatchmaker = actor({
 		}>(),
 		unqueueForMatch: queue<{ connId: string }>(),
 		closeMatch: queue<{ matchId: string }>(),
+	},
+	events: {
+		assignmentReady: event<TurnBasedAssignment>(),
 	},
 	actions: {
 		queueForMatch: async (c, { playerName }: { playerName: string }) => {

--- a/examples/multiplayer-game-patterns-vercel/tests/matchmaking-and-session-patterns.test.ts
+++ b/examples/multiplayer-game-patterns-vercel/tests/matchmaking-and-session-patterns.test.ts
@@ -5,6 +5,19 @@ import { CHUNK_SIZE, WORLD_ID } from "../src/actors/open-world/config.ts";
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+type QueueResult<T> = {
+	status: "completed" | "timedOut";
+	response?: T;
+};
+
+type RawQueueConnection = {
+	send<TResponse>(
+		name: string,
+		body: unknown,
+		options: { wait: true; timeout?: number },
+	): Promise<QueueResult<TResponse>>;
+};
+
 describe("matchmaking and session patterns", () => {
 	test("io-style open lobby + 10 tps match with movement", async (ctx) => {
 		const { client } = await setupTest(ctx, registry);
@@ -190,12 +203,14 @@ describe("matchmaking and session patterns", () => {
 		)?.response;
 		expect(createResponse?.matchId).toBeTypeOf("string");
 		expect(createResponse?.partyCode).toHaveLength(6);
+		if (!createResponse)
+			throw new Error("expected party creation response");
 
 		const hostConn = client.partyMatch
-			.get([createResponse?.matchId], {
+			.get([createResponse.matchId], {
 				params: {
-					playerId: createResponse?.playerId,
-					joinToken: createResponse?.joinToken,
+					playerId: createResponse.playerId,
+					joinToken: createResponse.joinToken,
 				},
 			})
 			.connect();
@@ -205,31 +220,28 @@ describe("matchmaking and session patterns", () => {
 		expect(snap1.partyCode).toBe(createResponse?.partyCode);
 		expect(snap1.phase).toBe("waiting");
 		expect(Object.keys(snap1.members)).toHaveLength(1);
-		const hostMember = snap1.members[createResponse?.playerId];
+		const hostMember = snap1.members[createResponse.playerId];
 		expect(hostMember.isHost).toBe(true);
 
-		const joinResult = await mm.send(
+		const joinResult = await (mm as RawQueueConnection).send<{
+			matchId: string;
+			playerId: string;
+			joinToken: string;
+			playerName: string;
+		}>(
 			"joinParty",
-			{ partyCode: createResponse?.partyCode, playerName: "Player2" },
+			{ partyCode: createResponse.partyCode, playerName: "Player2" },
 			{ wait: true, timeout: 5_000 },
 		);
-		const joinResponse = (
-			joinResult as {
-				response?: {
-					matchId: string;
-					playerId: string;
-					joinToken: string;
-					playerName: string;
-				};
-			}
-		)?.response;
+		const joinResponse = joinResult.response;
 		expect(joinResponse?.matchId).toBe(createResponse?.matchId);
+		if (!joinResponse) throw new Error("expected party join response");
 
 		const p2Conn = client.partyMatch
-			.get([joinResponse?.matchId], {
+			.get([joinResponse.matchId], {
 				params: {
-					playerId: joinResponse?.playerId,
-					joinToken: joinResponse?.joinToken,
+					playerId: joinResponse.playerId,
+					joinToken: joinResponse.joinToken,
 				},
 			})
 			.connect();
@@ -282,25 +294,28 @@ describe("matchmaking and session patterns", () => {
 		)?.response;
 		expect(createResponse?.matchId).toBeTypeOf("string");
 		expect(createResponse?.inviteCode).toHaveLength(6);
+		if (!createResponse) throw new Error("expected game creation response");
 
-		const joinResult = await mm.send(
+		const joinResult = await (mm as RawQueueConnection).send<{
+			matchId: string;
+			playerId: string;
+		}>(
 			"joinByCode",
-			{ inviteCode: createResponse?.inviteCode, playerName: "PlayerO" },
+			{ inviteCode: createResponse.inviteCode, playerName: "PlayerO" },
 			{ wait: true, timeout: 5_000 },
 		);
-		const joinResponse = (
-			joinResult as { response?: { matchId: string; playerId: string } }
-		)?.response;
+		const joinResponse = joinResult.response;
 		expect(joinResponse?.matchId).toBe(createResponse?.matchId);
+		if (!joinResponse) throw new Error("expected game join response");
 
 		const xConn = client.turnBasedMatch
-			.get([createResponse?.matchId], {
-				params: { playerId: createResponse?.playerId },
+			.get([createResponse.matchId], {
+				params: { playerId: createResponse.playerId },
 			})
 			.connect();
 		const oConn = client.turnBasedMatch
-			.get([joinResponse?.matchId], {
-				params: { playerId: joinResponse?.playerId },
+			.get([joinResponse.matchId], {
+				params: { playerId: joinResponse.playerId },
 			})
 			.connect();
 		await sleep(200);
@@ -519,18 +534,21 @@ describe("matchmaking and session patterns", () => {
 		)?.response;
 		expect(r1?.matchId).toBeTypeOf("string");
 		expect(r2?.matchId).toBe(r1?.matchId);
+		if (!r1 || !r2) {
+			throw new Error("expected battle royale queue responses");
+		}
 
 		const a = client.battleRoyaleMatch
-			.get([r1?.matchId], {
+			.get([r1.matchId], {
 				params: {
-					playerId: r1?.playerId,
+					playerId: r1.playerId,
 				},
 			})
 			.connect();
 		const b = client.battleRoyaleMatch
-			.get([r2?.matchId], {
+			.get([r2.matchId], {
 				params: {
-					playerId: r2?.playerId,
+					playerId: r2.playerId,
 				},
 			})
 			.connect();
@@ -569,9 +587,9 @@ describe("matchmaking and session patterns", () => {
 		expect(snap.chunkY).toBe(0);
 		expect(snap.chunkSize).toBe(1200);
 		expect(Object.keys(snap.players)).toHaveLength(1);
-		const myConnId = Object.entries(snap.players).find(
-			([, p]) => p.name === "Explorer",
-		)?.[0];
+		const myConnId = (
+			Object.entries(snap.players) as Array<[string, { name: string }]>
+		).find(([, p]) => p.name === "Explorer")?.[0];
 		expect(myConnId).toBeTypeOf("string");
 
 		await chunk.setInput({ inputX: 1, inputY: 0 });
@@ -609,17 +627,20 @@ describe("matchmaking and session patterns", () => {
 		await sleep(500);
 
 		const snapAtEdge = await chunk0.getSnapshot();
-		const travelerConnId = Object.entries(snapAtEdge.players).find(
-			([, p]) => p.name === "Traveler",
-		)?.[0];
+		const travelerConnId = (
+			Object.entries(snapAtEdge.players) as Array<
+				[string, { name: string }]
+			>
+		).find(([, p]) => p.name === "Traveler")?.[0];
 		const posAtEdge = travelerConnId
 			? snapAtEdge.players[travelerConnId]
 			: undefined;
 		expect(posAtEdge).toBeDefined();
 		expect(posAtEdge?.x).toBe(1199);
 
-		const absX = 0 * 1200 + posAtEdge?.x + 1;
-		const absY = 0 * 1200 + posAtEdge?.y;
+		if (!posAtEdge) throw new Error("expected traveler position");
+		const absX = 0 * 1200 + posAtEdge.x + 1;
+		const absY = 0 * 1200 + posAtEdge.y;
 		const r2 = resolveChunkForPosition(absX, absY);
 		expect(r2.chunkKey).toEqual([WORLD_ID, 1, 0]);
 		expect(r2.spawnX).toBeTypeOf("number");
@@ -636,14 +657,17 @@ describe("matchmaking and session patterns", () => {
 		const snapNewChunk = await chunk1.getSnapshot();
 		expect(snapNewChunk.chunkX).toBe(1);
 		expect(snapNewChunk.chunkY).toBe(0);
-		const newTravelerConnId = Object.entries(snapNewChunk.players).find(
-			([, p]) => p.name === "Traveler",
-		)?.[0];
+		const newTravelerConnId = (
+			Object.entries(snapNewChunk.players) as Array<
+				[string, { name: string }]
+			>
+		).find(([, p]) => p.name === "Traveler")?.[0];
 		const newPos = newTravelerConnId
 			? snapNewChunk.players[newTravelerConnId]
 			: undefined;
 		expect(newPos).toBeDefined();
-		expect(newPos?.x).toBeLessThan(100);
+		if (!newPos) throw new Error("traveler position missing");
+		expect(newPos.x).toBeLessThan(100);
 
 		await chunk1.setInput({ inputX: 1, inputY: 0 });
 		await sleep(350);

--- a/examples/multiplayer-game-patterns/frontend/App.tsx
+++ b/examples/multiplayer-game-patterns/frontend/App.tsx
@@ -14,25 +14,40 @@ import {
 import { useEffect, useMemo, useState } from "react";
 import { makeClient } from "./client.ts";
 import { ArenaGameView } from "./games/arena/game.tsx";
-import { ArenaMenu } from "./games/arena/menu.tsx";
+import { ArenaMenu, type ArenaMatchInfo } from "./games/arena/menu.tsx";
 import { BattleRoyaleGameView } from "./games/battle-royale/game.tsx";
-import { BattleRoyaleMenu } from "./games/battle-royale/menu.tsx";
+import {
+	BattleRoyaleMenu,
+	type BattleRoyaleMatchInfo,
+} from "./games/battle-royale/menu.tsx";
 import { IdleGame } from "./games/idle/game.tsx";
-import { IdleMenu } from "./games/idle/menu.tsx";
+import { IdleMenu, type IdleMatchInfo } from "./games/idle/menu.tsx";
 import { IoStyleGame } from "./games/io-style/game.tsx";
-import { IoStyleMenu } from "./games/io-style/menu.tsx";
+import { IoStyleMenu, type IoStyleMatchInfo } from "./games/io-style/menu.tsx";
 import { OpenWorldGameView } from "./games/open-world/game.tsx";
-import { OpenWorldMenu } from "./games/open-world/menu.tsx";
+import {
+	OpenWorldMenu,
+	type OpenWorldMatchInfo,
+} from "./games/open-world/menu.tsx";
 import { PartyGame } from "./games/party/game.tsx";
-import { PartyMenu } from "./games/party/menu.tsx";
+import { PartyMenu, type PartyMatchInfo } from "./games/party/menu.tsx";
 import { Physics2dGameView } from "./games/physics-2d/game.tsx";
-import { Physics2dMenu } from "./games/physics-2d/menu.tsx";
+import {
+	Physics2dMenu,
+	type Physics2dMatchInfo,
+} from "./games/physics-2d/menu.tsx";
 import { Physics3dGameView } from "./games/physics-3d/game.tsx";
-import { Physics3dMenu } from "./games/physics-3d/menu.tsx";
+import {
+	Physics3dMenu,
+	type Physics3dMatchInfo,
+} from "./games/physics-3d/menu.tsx";
 import { RankedGameView } from "./games/ranked/game.tsx";
-import { RankedMenu } from "./games/ranked/menu.tsx";
+import { RankedMenu, type RankedMatchInfo } from "./games/ranked/menu.tsx";
 import { TurnBasedGame } from "./games/turn-based/game.tsx";
-import { TurnBasedMenu } from "./games/turn-based/menu.tsx";
+import {
+	TurnBasedMenu,
+	type TurnBasedMatchInfo,
+} from "./games/turn-based/menu.tsx";
 
 type PatternId =
 	| "io-style"
@@ -49,7 +64,20 @@ type PatternId =
 type Route =
 	| { page: "selector" }
 	| { page: "menu"; pattern: PatternId }
-	| { page: "game"; pattern: PatternId; matchInfo: unknown };
+	| { page: "game"; pattern: "io-style"; matchInfo: IoStyleMatchInfo }
+	| { page: "game"; pattern: "arena"; matchInfo: ArenaMatchInfo }
+	| { page: "game"; pattern: "party"; matchInfo: PartyMatchInfo }
+	| { page: "game"; pattern: "turn-based"; matchInfo: TurnBasedMatchInfo }
+	| { page: "game"; pattern: "ranked"; matchInfo: RankedMatchInfo }
+	| {
+			page: "game";
+			pattern: "battle-royale";
+			matchInfo: BattleRoyaleMatchInfo;
+	  }
+	| { page: "game"; pattern: "open-world"; matchInfo: OpenWorldMatchInfo }
+	| { page: "game"; pattern: "idle"; matchInfo: IdleMatchInfo }
+	| { page: "game"; pattern: "physics-2d"; matchInfo: Physics2dMatchInfo }
+	| { page: "game"; pattern: "physics-3d"; matchInfo: Physics3dMatchInfo };
 
 const PATTERNS: Array<{
 	id: PatternId;
@@ -169,70 +197,238 @@ export function App() {
 
 	const goSelector = () => setRoute({ page: "selector" });
 	const goMenu = (pattern: PatternId) => setRoute({ page: "menu", pattern });
-	const goGame = (pattern: PatternId, matchInfo: unknown) =>
-		setRoute({ page: "game", pattern, matchInfo });
 
 	if (route.page === "selector") {
 		return <Selector onSelect={goMenu} />;
 	}
 
 	if (route.page === "menu") {
-		const props = {
-			client,
-			onReady: (info: unknown) => goGame(route.pattern, info),
-			onBack: goSelector,
-		};
 		switch (route.pattern) {
 			case "io-style":
-				return <IoStyleMenu {...props} />;
+				return (
+					<IoStyleMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "io-style",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "arena":
-				return <ArenaMenu {...props} />;
+				return (
+					<ArenaMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "arena",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "party":
-				return <PartyMenu {...props} />;
+				return (
+					<PartyMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "party",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "turn-based":
-				return <TurnBasedMenu {...props} />;
+				return (
+					<TurnBasedMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "turn-based",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "ranked":
-				return <RankedMenu {...props} />;
+				return (
+					<RankedMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "ranked",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "battle-royale":
-				return <BattleRoyaleMenu {...props} />;
+				return (
+					<BattleRoyaleMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "battle-royale",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "open-world":
-				return <OpenWorldMenu {...props} />;
+				return (
+					<OpenWorldMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "open-world",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "idle":
-				return <IdleMenu {...props} />;
+				return (
+					<IdleMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "idle",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "physics-2d":
-				return <Physics2dMenu {...props} />;
+				return (
+					<Physics2dMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "physics-2d",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 			case "physics-3d":
-				return <Physics3dMenu {...props} />;
+				return (
+					<Physics3dMenu
+						client={client}
+						onReady={(matchInfo) =>
+							setRoute({
+								page: "game",
+								pattern: "physics-3d",
+								matchInfo,
+							})
+						}
+						onBack={goSelector}
+					/>
+				);
 		}
 	}
 
 	if (route.page === "game") {
-		const props = {
-			client,
-			matchInfo: route.matchInfo as never,
-			onLeave: goSelector,
-		};
 		switch (route.pattern) {
 			case "io-style":
-				return <IoStyleGame {...props} />;
+				return (
+					<IoStyleGame
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "arena":
-				return <ArenaGameView {...props} />;
+				return (
+					<ArenaGameView
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "party":
-				return <PartyGame {...props} />;
+				return (
+					<PartyGame
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "turn-based":
-				return <TurnBasedGame {...props} />;
+				return (
+					<TurnBasedGame
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "ranked":
-				return <RankedGameView {...props} />;
+				return (
+					<RankedGameView
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "battle-royale":
-				return <BattleRoyaleGameView {...props} />;
+				return (
+					<BattleRoyaleGameView
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "open-world":
-				return <OpenWorldGameView {...props} />;
+				return (
+					<OpenWorldGameView
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "idle":
-				return <IdleGame {...props} />;
+				return (
+					<IdleGame
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "physics-2d":
-				return <Physics2dGameView {...props} />;
+				return (
+					<Physics2dGameView
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 			case "physics-3d":
-				return <Physics3dGameView {...props} />;
+				return (
+					<Physics3dGameView
+						client={client}
+						matchInfo={route.matchInfo}
+						onLeave={goSelector}
+					/>
+				);
 		}
 	}
 

--- a/examples/multiplayer-game-patterns/frontend/actor-types.ts
+++ b/examples/multiplayer-game-patterns/frontend/actor-types.ts
@@ -1,0 +1,34 @@
+import type { ActorConn } from "rivetkit/client";
+import type {
+	arenaMatch,
+	arenaMatchmaker,
+	battleRoyaleMatch,
+	idleLeaderboard,
+	idleWorld,
+	ioStyleMatch,
+	openWorldChunk,
+	partyMatch,
+	physics2dWorld,
+	physics3dWorld,
+	rankedLeaderboard,
+	rankedMatch,
+	rankedMatchmaker,
+	turnBasedMatch,
+	turnBasedMatchmaker,
+} from "../src/actors/index.ts";
+
+export type ArenaMatchConn = ActorConn<typeof arenaMatch>;
+export type ArenaMatchmakerConn = ActorConn<typeof arenaMatchmaker>;
+export type BattleRoyaleMatchConn = ActorConn<typeof battleRoyaleMatch>;
+export type IdleLeaderboardConn = ActorConn<typeof idleLeaderboard>;
+export type IdleWorldConn = ActorConn<typeof idleWorld>;
+export type IoStyleMatchConn = ActorConn<typeof ioStyleMatch>;
+export type OpenWorldChunkConn = ActorConn<typeof openWorldChunk>;
+export type PartyMatchConn = ActorConn<typeof partyMatch>;
+export type Physics2dConn = ActorConn<typeof physics2dWorld>;
+export type Physics3dConn = ActorConn<typeof physics3dWorld>;
+export type RankedLeaderboardConn = ActorConn<typeof rankedLeaderboard>;
+export type RankedMatchConn = ActorConn<typeof rankedMatch>;
+export type RankedMatchmakerConn = ActorConn<typeof rankedMatchmaker>;
+export type TurnBasedMatchConn = ActorConn<typeof turnBasedMatch>;
+export type TurnBasedMatchmakerConn = ActorConn<typeof turnBasedMatchmaker>;

--- a/examples/multiplayer-game-patterns/frontend/games/arena/arena-game.ts
+++ b/examples/multiplayer-game-patterns/frontend/games/arena/arena-game.ts
@@ -1,3 +1,4 @@
+import type { ArenaMatchConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import type { ArenaMatchInfo } from "./menu.tsx";
 
@@ -17,10 +18,6 @@ interface ShotLine {
 	hit: boolean;
 	createdAt: number;
 }
-
-type ArenaMatchConn = ReturnType<
-	ReturnType<GameClient["arenaMatch"]["get"]>["connect"]
->;
 
 export class ArenaGame {
 	private stopped = false;
@@ -56,24 +53,7 @@ export class ArenaGame {
 			})
 			.connect();
 
-		this.conn.on("snapshot", (raw: unknown) => {
-			const snap = raw as {
-				worldSize: number;
-				scoreLimit: number;
-				phase: "waiting" | "live" | "finished";
-				winnerTeam: number | null;
-				winnerPlayerId: string | null;
-				players: Record<
-					string,
-					{
-						x: number;
-						y: number;
-						teamId: number;
-						color: string;
-						score: number;
-					}
-				>;
-			};
+		this.conn.on("snapshot", (snap) => {
 			this.worldSize = snap.worldSize;
 			this.scoreLimit = snap.scoreLimit;
 			this.phase = snap.phase;
@@ -103,15 +83,7 @@ export class ArenaGame {
 			}
 		});
 
-		this.conn.on("shoot", (raw: unknown) => {
-			const shot = raw as {
-				shooterId: string;
-				fromX: number;
-				fromY: number;
-				dirX: number;
-				dirY: number;
-				hitPlayerId: string | null;
-			};
+		this.conn.on("shoot", (shot) => {
 			const lineLen = 300;
 			this.shotLines.push({
 				fromX: shot.fromX,

--- a/examples/multiplayer-game-patterns/frontend/games/arena/bot.ts
+++ b/examples/multiplayer-game-patterns/frontend/games/arena/bot.ts
@@ -1,4 +1,5 @@
 import type { Mode } from "../../../src/actors/arena/config.ts";
+import type { ArenaMatchmakerConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import { ArenaGame } from "./arena-game.ts";
 import type { ArenaMatchInfo } from "./menu.tsx";
@@ -7,8 +8,7 @@ import { waitForAssignment } from "./wait-for-assignment.ts";
 export class ArenaBot {
 	private game: ArenaGame | null = null;
 	private destroyed = false;
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	private mm: any = null;
+	private mm: ArenaMatchmakerConn | null = null;
 
 	constructor(
 		private client: GameClient,
@@ -23,9 +23,9 @@ export class ArenaBot {
 				.getOrCreate(["main"])
 				.connect();
 			this.mm = mm;
-			const response = (await mm.queueForMatch({
+			const response = await mm.queueForMatch({
 				mode: this.mode,
-			})) as { playerId?: string };
+			});
 			if (!response?.playerId || this.destroyed) return;
 
 			const assignment = await waitForAssignment<ArenaMatchInfo>(

--- a/examples/multiplayer-game-patterns/frontend/games/arena/menu.tsx
+++ b/examples/multiplayer-game-patterns/frontend/games/arena/menu.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { MODE_CONFIG, type Mode } from "../../../src/actors/arena/config.ts";
+import type { ArenaMatchmakerConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import { ArenaBot } from "./bot.ts";
 import { waitForAssignment } from "./wait-for-assignment.ts";
@@ -34,8 +35,7 @@ export function ArenaMenu({
 	const [queueCount, setQueueCount] = useState(0);
 	const [error, setError] = useState("");
 
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle type
-	const mmRef = useRef<any>(null);
+	const mmRef = useRef<ArenaMatchmakerConn | null>(null);
 	const abortRef = useRef(false);
 	const botsRef = useRef<ArenaBot[]>([]);
 	const matchedRef = useRef(false);
@@ -83,23 +83,21 @@ export function ArenaMenu({
 				}, 1500);
 			};
 
-			mm.on("queueUpdate", (raw: unknown) => {
-				const data = raw as { counts: Record<string, number> };
+			mm.on("queueUpdate", (data) => {
 				setQueueCount(data.counts[mode] ?? 0);
 			});
 
 			setStatus("queued");
 
-			const response = (await mm.queueForMatch({
+			const response = await mm.queueForMatch({
 				mode,
-			})) as { playerId?: string };
+			});
 			if (!response?.playerId || abortRef.current)
 				throw new Error("Failed to queue");
 			myPlayerId = response.playerId;
 
 			const sizes = await mm.getQueueSizes();
-			if (!abortRef.current)
-				setQueueCount((sizes as Record<string, number>)[mode] ?? 0);
+			if (!abortRef.current) setQueueCount(sizes[mode] ?? 0);
 
 			const assignment = await waitForAssignment<ArenaMatchInfo>(
 				mm,

--- a/examples/multiplayer-game-patterns/frontend/games/arena/wait-for-assignment.ts
+++ b/examples/multiplayer-game-patterns/frontend/games/arena/wait-for-assignment.ts
@@ -3,13 +3,10 @@ interface Assignment {
 }
 
 type AssignmentConnection = {
-	action: <Args extends unknown[], Response>(opts: {
-		name: string;
-		args: Args;
-	}) => Promise<Response>;
+	getAssignment: (input: { playerId: string }) => Promise<Assignment | null>;
 	on: (
 		event: "assignmentReady",
-		handler: (raw: unknown) => void,
+		handler: (assignment: Assignment) => void,
 	) => (() => void) | undefined;
 };
 
@@ -24,7 +21,7 @@ export async function waitForAssignment<T extends Assignment>(
 	timeoutMs = 120_000,
 ): Promise<T> {
 	const existing = await readAssignment<T>(mm, playerId);
-	if (existing) return existing as T;
+	if (existing) return existing;
 
 	return await new Promise<T>((resolve, reject) => {
 		let settled = false;
@@ -39,10 +36,9 @@ export async function waitForAssignment<T extends Assignment>(
 			fn();
 		};
 
-		off = mm.on("assignmentReady", (raw: unknown) => {
-			const next = raw as T;
+		off = mm.on("assignmentReady", (next) => {
 			if (next.playerId !== playerId) return;
-			settle(() => resolve(next));
+			settle(() => resolve(next as T));
 		});
 
 		timeout = window.setTimeout(() => {
@@ -64,8 +60,5 @@ async function readAssignment<T extends Assignment>(
 	mm: AssignmentConnection,
 	playerId: string,
 ): Promise<T | null> {
-	return await mm.action<[{ playerId: string }], T | null>({
-		name: "getAssignment",
-		args: [{ playerId }],
-	});
+	return (await mm.getAssignment({ playerId })) as T | null;
 }

--- a/examples/multiplayer-game-patterns/frontend/games/battle-royale/battle-royale-game.ts
+++ b/examples/multiplayer-game-patterns/frontend/games/battle-royale/battle-royale-game.ts
@@ -1,3 +1,4 @@
+import type { BattleRoyaleMatchConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import type { BattleRoyaleMatchInfo } from "./menu.tsx";
 
@@ -18,10 +19,6 @@ interface ShotLine {
 	hit: boolean;
 	createdAt: number;
 }
-
-type BattleRoyaleMatchConn = ReturnType<
-	ReturnType<GameClient["battleRoyaleMatch"]["get"]>["connect"]
->;
 
 export class BattleRoyaleGame {
 	private stopped = false;
@@ -70,29 +67,7 @@ export class BattleRoyaleGame {
 			})
 			.connect();
 
-		this.conn.on("snapshot", (raw: unknown) => {
-			const snap = raw as {
-				worldSize: number;
-				phase: "lobby" | "live" | "finished";
-				winnerId: string | null;
-				playerCount: number;
-				aliveCount: number;
-				capacity: number;
-				lobbyCountdown: number | null;
-				zone: { centerX: number; centerY: number; radius: number };
-				players: Record<
-					string,
-					{
-						x: number;
-						y: number;
-						color: string;
-						hp: number;
-						maxHp: number;
-						alive: boolean;
-						placement: number | null;
-					}
-				>;
-			};
+		this.conn.on("snapshot", (snap) => {
 			this.worldSize = snap.worldSize;
 			this.phase = snap.phase;
 			this.winnerId = snap.winnerId;
@@ -131,14 +106,7 @@ export class BattleRoyaleGame {
 			}
 		});
 
-		this.conn.on("shoot", (raw: unknown) => {
-			const shot = raw as {
-				fromX: number;
-				fromY: number;
-				dirX: number;
-				dirY: number;
-				hitPlayerId: string | null;
-			};
+		this.conn.on("shoot", (shot) => {
 			this.shotLines.push({
 				fromX: shot.fromX,
 				fromY: shot.fromY,

--- a/examples/multiplayer-game-patterns/frontend/games/battle-royale/menu.tsx
+++ b/examples/multiplayer-game-patterns/frontend/games/battle-royale/menu.tsx
@@ -30,8 +30,7 @@ export function BattleRoyaleMenu({
 				{ wait: true, timeout: 10_000 },
 			);
 			mm.dispose();
-			const response = (result as { response?: BattleRoyaleMatchInfo })
-				?.response;
+			const response = result.response;
 			if (!response?.matchId || !response?.playerId) {
 				throw new Error("Matchmaker did not return a valid match");
 			}

--- a/examples/multiplayer-game-patterns/frontend/games/idle/game.tsx
+++ b/examples/multiplayer-game-patterns/frontend/games/idle/game.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { BUILDINGS } from "../../../src/actors/idle/config.ts";
+import type { IdleLeaderboardConn, IdleWorldConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import type { IdleMatchInfo } from "./menu.tsx";
 
@@ -37,10 +38,8 @@ export function IdleGame({
 	const [state, setState] = useState<IdleSnapshot | null>(null);
 	const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
 	const [now, setNow] = useState(Date.now());
-	// biome-ignore lint/suspicious/noExplicitAny: connection handles
-	const worldRef = useRef<any>(null);
-	// biome-ignore lint/suspicious/noExplicitAny: connection handles
-	const lbRef = useRef<any>(null);
+	const worldRef = useRef<IdleWorldConn | null>(null);
+	const lbRef = useRef<IdleLeaderboardConn | null>(null);
 
 	const cleanup = useCallback(() => {
 		const world = worldRef.current;
@@ -57,8 +56,8 @@ export function IdleGame({
 			.connect();
 		worldRef.current = world;
 
-		world.on("stateUpdate", (raw: unknown) => {
-			setState(raw as IdleSnapshot);
+		world.on("stateUpdate", (snap) => {
+			setState(snap);
 		});
 
 		// Initialize the actor.
@@ -70,21 +69,21 @@ export function IdleGame({
 			.then(() => {
 				return world.getState();
 			})
-			.then((s: unknown) => {
-				setState(s as IdleSnapshot);
+			.then((snap) => {
+				setState(snap);
 			});
 
 		// Fetch initial leaderboard.
-		world.getLeaderboard().then((lb: unknown) => {
-			setLeaderboard(lb as LeaderboardEntry[]);
+		world.getLeaderboard().then((scores) => {
+			setLeaderboard(scores);
 		});
 
 		// Connect to leaderboard for live updates.
 		const lb = client.idleLeaderboard.getOrCreate(["main"]).connect();
 		lbRef.current = lb;
 
-		lb.on("leaderboardUpdate", (raw: unknown) => {
-			setLeaderboard(raw as LeaderboardEntry[]);
+		lb.on("leaderboardUpdate", (scores) => {
+			setLeaderboard(scores);
 		});
 
 		return () => {

--- a/examples/multiplayer-game-patterns/frontend/games/io-style/io-game.ts
+++ b/examples/multiplayer-game-patterns/frontend/games/io-style/io-game.ts
@@ -1,13 +1,10 @@
+import type { IoStyleMatchConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import type { IoStyleMatchInfo } from "./menu.tsx";
 
 const PLAYER_RADIUS = 12;
 const LERP_FACTOR = 0.2;
 const GRID_SPACING = 50;
-
-type IoStyleMatchConn = ReturnType<
-	ReturnType<GameClient["ioStyleMatch"]["get"]>["connect"]
->;
 
 export class IoGame {
 	private stopped = false;
@@ -36,14 +33,7 @@ export class IoGame {
 			})
 			.connect();
 
-		this.conn.on("snapshot", (raw: unknown) => {
-			const snap = raw as {
-				worldSize: number;
-				players: Record<
-					string,
-					{ x: number; y: number; color: string }
-				>;
-			};
+		this.conn.on("snapshot", (snap) => {
 			this.worldSize = snap.worldSize;
 			for (const [id, pos] of Object.entries(snap.players)) {
 				this.targets[id] = pos;

--- a/examples/multiplayer-game-patterns/frontend/games/io-style/menu.tsx
+++ b/examples/multiplayer-game-patterns/frontend/games/io-style/menu.tsx
@@ -28,8 +28,7 @@ export function IoStyleMenu({
 				{ wait: true, timeout: 10_000 },
 			);
 			mm.dispose();
-			const response = (result as { response?: IoStyleMatchInfo })
-				?.response;
+			const response = result.response;
 			if (!response?.matchId || !response?.playerId) {
 				throw new Error("Matchmaker did not return a valid lobby");
 			}

--- a/examples/multiplayer-game-patterns/frontend/games/open-world/open-world-game.ts
+++ b/examples/multiplayer-game-patterns/frontend/games/open-world/open-world-game.ts
@@ -1,5 +1,6 @@
 import { CHUNK_SIZE, WORLD_ID } from "../../../src/actors/open-world/config.ts";
 import { getPlayerColor } from "../../../src/actors/player-color.ts";
+import type { OpenWorldChunkConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import type { OpenWorldMatchInfo } from "./menu.tsx";
 
@@ -11,10 +12,6 @@ const DEFAULT_VIEWPORT_SIZE = 600;
 const MIN_ZOOM = 0.25;
 const MAX_ZOOM = 2;
 const ZOOM_STEP = 0.15;
-
-type OpenWorldChunkConn = ReturnType<
-	ReturnType<GameClient["openWorldChunk"]["getOrCreate"]>["connect"]
->;
 
 interface ChunkConnection {
 	cx: number;
@@ -124,8 +121,7 @@ export class OpenWorldGame {
 			selfPresent: false,
 		};
 
-		conn.on("snapshot", (raw: unknown) => {
-			const snap = raw as ChunkSnapshot;
+		conn.on("snapshot", (snap) => {
 			this.chunkSize = snap.chunkSize;
 			const isPrimaryChunk =
 				chunk.cx === this.chunkX && chunk.cy === this.chunkY;

--- a/examples/multiplayer-game-patterns/frontend/games/party/bot.ts
+++ b/examples/multiplayer-game-patterns/frontend/games/party/bot.ts
@@ -1,8 +1,8 @@
+import type { PartyMatchConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 
 export class PartyBot {
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	private conn: any = null;
+	private conn: PartyMatchConn | null = null;
 	private destroyed = false;
 
 	constructor(
@@ -26,16 +26,7 @@ export class PartyBot {
 				{ wait: true, timeout: 10_000 },
 			);
 			mm.dispose();
-			const response = (
-				result as {
-					response?: {
-						matchId: string;
-						playerId: string;
-						joinToken: string;
-						playerName: string;
-					};
-				}
-			)?.response;
+			const response = result.response;
 			if (!response || this.destroyed) return;
 
 			this.conn = this.client.partyMatch

--- a/examples/multiplayer-game-patterns/frontend/games/party/game.tsx
+++ b/examples/multiplayer-game-patterns/frontend/games/party/game.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { PartyMatchConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import { PartyBot } from "./bot.ts";
 import type { PartyMatchInfo } from "./menu.tsx";
@@ -32,8 +33,7 @@ export function PartyGame({
 	const [nameInput, setNameInput] = useState(
 		matchInfo.playerName || "Player",
 	);
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	const connRef = useRef<any>(null);
+	const connRef = useRef<PartyMatchConn | null>(null);
 	const botsRef = useRef<PartyBot[]>([]);
 	const nameTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -54,14 +54,13 @@ export function PartyGame({
 			.connect();
 		connRef.current = conn;
 
-		conn.on("partyUpdate", (raw: unknown) => {
-			setSnapshot(raw as PartySnapshot);
+		conn.on("partyUpdate", (snap) => {
+			setSnapshot(snap);
 		});
 
-		conn.getSnapshot().then((snap: unknown) => {
-			const s = snap as PartySnapshot;
-			setSnapshot(s);
-			const myName = s.members[matchInfo.playerId]?.name;
+		conn.getSnapshot().then((snap) => {
+			setSnapshot(snap);
+			const myName = snap.members[matchInfo.playerId]?.name;
 			if (myName) setNameInput(myName);
 		});
 

--- a/examples/multiplayer-game-patterns/frontend/games/party/menu.tsx
+++ b/examples/multiplayer-game-patterns/frontend/games/party/menu.tsx
@@ -33,8 +33,7 @@ export function PartyMenu({
 				{ wait: true, timeout: 10_000 },
 			);
 			mm.dispose();
-			const response = (result as { response?: PartyMatchInfo })
-				?.response;
+			const response = result.response;
 			if (!response?.matchId) throw new Error("Failed to create party");
 			onReady(response);
 		} catch (err) {
@@ -55,16 +54,7 @@ export function PartyMenu({
 				{ wait: true, timeout: 10_000 },
 			);
 			mm.dispose();
-			const response = (
-				result as {
-					response?: {
-						matchId: string;
-						playerId: string;
-						joinToken: string;
-						playerName: string;
-					};
-				}
-			)?.response;
+			const response = result.response;
 			if (!response?.matchId) throw new Error("Failed to join party");
 			onReady({ ...response, partyCode: joinCode.trim().toUpperCase() });
 		} catch (err) {

--- a/examples/multiplayer-game-patterns/frontend/games/physics-2d/physics-2d-game.ts
+++ b/examples/multiplayer-game-patterns/frontend/games/physics-2d/physics-2d-game.ts
@@ -4,12 +4,9 @@ import {
 	SCALE,
 	SCENE_STATIC,
 } from "../../../src/actors/physics-2d/config.ts";
+import type { Physics2dConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import type { Physics2dMatchInfo } from "./menu.tsx";
-
-type Physics2dConn = ReturnType<
-	ReturnType<GameClient["physics2dWorld"]["getOrCreate"]>["connect"]
->;
 
 interface BodySnapshot {
 	id: string;
@@ -72,8 +69,7 @@ export class Physics2dGame {
 		});
 		this.conn = handle.connect();
 
-		this.conn.on("snapshot", (raw: unknown) => {
-			const snap = raw as Snapshot;
+		this.conn.on("snapshot", (snap) => {
 			const now = Date.now();
 
 			// Measure tick interval and one-way latency estimate.

--- a/examples/multiplayer-game-patterns/frontend/games/physics-3d/physics-3d-game.ts
+++ b/examples/multiplayer-game-patterns/frontend/games/physics-3d/physics-3d-game.ts
@@ -4,12 +4,9 @@ import {
 	PLAYER_RADIUS,
 	SCENE_STATIC,
 } from "../../../src/actors/physics-3d/config.ts";
+import type { Physics3dConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import type { Physics3dMatchInfo } from "./menu.tsx";
-
-type Physics3dConn = ReturnType<
-	ReturnType<GameClient["physics3dWorld"]["getOrCreate"]>["connect"]
->;
 
 interface BodySnapshot {
 	id: string;
@@ -140,8 +137,7 @@ export class Physics3dGame {
 		});
 		this.conn = handle.connect();
 
-		this.conn.on("snapshot", (raw: unknown) => {
-			const snap = raw as Snapshot;
+		this.conn.on("snapshot", (snap) => {
 			const now = Date.now();
 
 			if (this.lastSnapshotTime > 0) {

--- a/examples/multiplayer-game-patterns/frontend/games/ranked/bot.ts
+++ b/examples/multiplayer-game-patterns/frontend/games/ranked/bot.ts
@@ -1,3 +1,4 @@
+import type { RankedMatchmakerConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import { RankedGame } from "./ranked-game.ts";
 import { waitForAssignment } from "./wait-for-assignment.ts";
@@ -5,8 +6,7 @@ import { waitForAssignment } from "./wait-for-assignment.ts";
 export class RankedBot {
 	private game: RankedGame | null = null;
 	private destroyed = false;
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	private mm: any = null;
+	private mm: RankedMatchmakerConn | null = null;
 
 	constructor(private client: GameClient) {
 		this.start();
@@ -21,9 +21,9 @@ export class RankedBot {
 				.getOrCreate(["main"])
 				.connect();
 			this.mm = mm;
-			const queueResult = (await mm.queueForMatch({
+			const queueResult = await mm.queueForMatch({
 				username: botUsername,
-			})) as { queued: boolean; connId?: string };
+			});
 			if (this.destroyed) return;
 
 			const assignment = await waitForAssignment(

--- a/examples/multiplayer-game-patterns/frontend/games/ranked/menu.tsx
+++ b/examples/multiplayer-game-patterns/frontend/games/ranked/menu.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { LeaderboardEntry } from "../../../src/actors/ranked/leaderboard.ts";
+import type { RankedQueueUpdate } from "../../../src/actors/ranked/matchmaker.ts";
 import type { PlayerSnapshot } from "../../../src/actors/ranked/player.ts";
+import type {
+	RankedLeaderboardConn,
+	RankedMatchmakerConn,
+} from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import { RankedBot } from "./bot.ts";
 import { waitForAssignment } from "./wait-for-assignment.ts";
@@ -66,10 +71,8 @@ export function RankedMenu({
 	const [profile, setProfile] = useState<PlayerSnapshot | null>(null);
 	const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
 
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	const mmRef = useRef<any>(null);
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	const lbRef = useRef<any>(null);
+	const mmRef = useRef<RankedMatchmakerConn | null>(null);
+	const lbRef = useRef<RankedLeaderboardConn | null>(null);
 	const abortRef = useRef(false);
 	const botsRef = useRef<RankedBot[]>([]);
 	const matchedRef = useRef(false);
@@ -79,12 +82,12 @@ export function RankedMenu({
 		const lb = client.rankedLeaderboard.getOrCreate(["main"]).connect();
 		lbRef.current = lb;
 
-		lb.on("leaderboardUpdate", (raw: unknown) => {
-			setLeaderboard(raw as LeaderboardEntry[]);
+		lb.on("leaderboardUpdate", (scores) => {
+			setLeaderboard(scores);
 		});
 
-		lb.getTopScores().then((scores: unknown) => {
-			setLeaderboard(scores as LeaderboardEntry[]);
+		lb.getTopScores().then((scores) => {
+			setLeaderboard(scores);
 		});
 
 		return () => {
@@ -104,7 +107,7 @@ export function RankedMenu({
 		handle
 			.initialize({ username })
 			.then(() => handle.getProfile())
-			.then((p: unknown) => setProfile(p as PlayerSnapshot))
+			.then((p) => setProfile(p))
 			.catch(() => setProfile(null));
 	}, [client, username]);
 
@@ -151,15 +154,7 @@ export function RankedMenu({
 				}, 1500);
 			};
 
-			mm.on("queueUpdate", (raw: unknown) => {
-				const data = raw as {
-					queued: boolean;
-					count: number;
-					queueDurationMs?: number;
-					ratingWindow?: number;
-					ratingMin?: number;
-					ratingMax?: number;
-				};
+			mm.on("queueUpdate", (data: RankedQueueUpdate) => {
 				setQueueCount(data.count ?? 0);
 				if (!data.queued) {
 					setQueueDurationMs(0);
@@ -188,10 +183,7 @@ export function RankedMenu({
 
 			setStatus("queued");
 
-			const queueResult = (await mm.queueForMatch({ username })) as {
-				queued: boolean;
-				connId?: string;
-			};
+			const queueResult = await mm.queueForMatch({ username });
 			if (abortRef.current) {
 				throw new Error("Failed to queue");
 			}

--- a/examples/multiplayer-game-patterns/frontend/games/ranked/ranked-game.ts
+++ b/examples/multiplayer-game-patterns/frontend/games/ranked/ranked-game.ts
@@ -1,3 +1,4 @@
+import type { RankedMatchConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import type { RankedMatchInfo } from "./menu.tsx";
 
@@ -17,10 +18,6 @@ interface ShotLine {
 	hit: boolean;
 	createdAt: number;
 }
-
-type RankedMatchConn = ReturnType<
-	ReturnType<GameClient["rankedMatch"]["get"]>["connect"]
->;
 
 export class RankedGame {
 	private stopped = false;
@@ -55,23 +52,7 @@ export class RankedGame {
 			})
 			.connect();
 
-		this.conn.on("snapshot", (raw: unknown) => {
-			const snap = raw as {
-				worldSize: number;
-				phase: "waiting" | "live" | "finished";
-				winnerId: string | null;
-				scoreLimit: number;
-				players: Record<
-					string,
-					{
-						x: number;
-						y: number;
-						color: string;
-						score: number;
-						rating: number;
-					}
-				>;
-			};
+		this.conn.on("snapshot", (snap) => {
 			this.worldSize = snap.worldSize;
 			this.phase = snap.phase;
 			this.winnerId = snap.winnerId;
@@ -98,14 +79,7 @@ export class RankedGame {
 			}
 		});
 
-		this.conn.on("shoot", (raw: unknown) => {
-			const shot = raw as {
-				fromX: number;
-				fromY: number;
-				dirX: number;
-				dirY: number;
-				hitPlayerId: string | null;
-			};
+		this.conn.on("shoot", (shot) => {
 			this.shotLines.push({
 				fromX: shot.fromX,
 				fromY: shot.fromY,

--- a/examples/multiplayer-game-patterns/frontend/games/ranked/wait-for-assignment.ts
+++ b/examples/multiplayer-game-patterns/frontend/games/ranked/wait-for-assignment.ts
@@ -1,6 +1,6 @@
 import type { RankedMatchInfo } from "./menu.tsx";
 
-interface RankedAssignmentEvent {
+interface RankedAssignment {
 	matchId: string;
 	username: string;
 	rating: number;
@@ -8,13 +8,12 @@ interface RankedAssignmentEvent {
 }
 
 type AssignmentConnection = {
-	action: <Args extends unknown[], Response>(opts: {
-		name: string;
-		args: Args;
-	}) => Promise<Response>;
+	getAssignment: (input: {
+		username: string;
+	}) => Promise<RankedAssignment | null>;
 	on: (
 		event: "assignmentReady",
-		handler: (raw: unknown) => void,
+		handler: (assignment: RankedAssignment) => void,
 	) => (() => void) | undefined;
 };
 
@@ -45,8 +44,7 @@ export async function waitForAssignment(
 			fn();
 		};
 
-		off = mm.on("assignmentReady", (raw: unknown) => {
-			const next = raw as RankedAssignmentEvent;
+		off = mm.on("assignmentReady", (next) => {
 			if (next.username !== username) return;
 			// Bind assignment delivery to the queueing connection so duplicate usernames in
 			// other tabs do not accept the wrong match assignment.
@@ -73,8 +71,5 @@ async function readAssignment(
 	mm: AssignmentConnection,
 	username: string,
 ): Promise<RankedMatchInfo | null> {
-	return await mm.action<[{ username: string }], RankedMatchInfo | null>({
-		name: "getAssignment",
-		args: [{ username }],
-	});
+	return await mm.getAssignment({ username });
 }

--- a/examples/multiplayer-game-patterns/frontend/games/turn-based/bot.ts
+++ b/examples/multiplayer-game-patterns/frontend/games/turn-based/bot.ts
@@ -2,6 +2,7 @@ import type {
 	CellValue,
 	GameResult,
 } from "../../../src/actors/turn-based/config.ts";
+import type { TurnBasedMatchConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 
 interface GameSnapshot {
@@ -12,8 +13,7 @@ interface GameSnapshot {
 }
 
 export class TurnBasedBot {
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	private conn: any = null;
+	private conn: TurnBasedMatchConn | null = null;
 	private destroyed = false;
 	private playerId = "";
 	private symbol: "X" | "O" = "O";
@@ -39,9 +39,7 @@ export class TurnBasedBot {
 				{ wait: true, timeout: 10_000 },
 			);
 			mm.dispose();
-			const response = (
-				result as { response?: { matchId: string; playerId: string } }
-			)?.response;
+			const response = result.response;
 			if (!response || this.destroyed) return;
 
 			this.playerId = response.playerId;
@@ -52,11 +50,11 @@ export class TurnBasedBot {
 				})
 				.connect();
 
-			this.conn.on("gameUpdate", (raw: unknown) => {
-				this.tryMove(raw as GameSnapshot);
+			this.conn.on("gameUpdate", (snap) => {
+				this.tryMove(snap);
 			});
 
-			this.conn.getSnapshot().then((snap: unknown) => {
+			this.conn.getSnapshot().then((snap) => {
 				this.tryMove(snap as GameSnapshot);
 			});
 		} catch {

--- a/examples/multiplayer-game-patterns/frontend/games/turn-based/game.tsx
+++ b/examples/multiplayer-game-patterns/frontend/games/turn-based/game.tsx
@@ -3,6 +3,7 @@ import type {
 	CellValue,
 	GameResult,
 } from "../../../src/actors/turn-based/config.ts";
+import type { TurnBasedMatchConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import { TurnBasedBot } from "./bot.ts";
 import type { TurnBasedMatchInfo } from "./menu.tsx";
@@ -29,8 +30,7 @@ export function TurnBasedGame({
 	onLeave: () => void;
 }) {
 	const [snapshot, setSnapshot] = useState<GameSnapshot | null>(null);
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	const connRef = useRef<any>(null);
+	const connRef = useRef<TurnBasedMatchConn | null>(null);
 	const botsRef = useRef<TurnBasedBot[]>([]);
 
 	const cleanup = useCallback(() => {
@@ -47,12 +47,12 @@ export function TurnBasedGame({
 			.connect();
 		connRef.current = conn;
 
-		conn.on("gameUpdate", (raw: unknown) => {
-			setSnapshot(raw as GameSnapshot);
+		conn.on("gameUpdate", (snap) => {
+			setSnapshot(snap);
 		});
 
-		conn.getSnapshot().then((snap: unknown) => {
-			setSnapshot(snap as GameSnapshot);
+		conn.getSnapshot().then((snap) => {
+			setSnapshot(snap);
 		});
 
 		return () => {

--- a/examples/multiplayer-game-patterns/frontend/games/turn-based/menu.tsx
+++ b/examples/multiplayer-game-patterns/frontend/games/turn-based/menu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import type { TurnBasedMatchmakerConn } from "../../actor-types.ts";
 import type { GameClient } from "../../client.ts";
 import { waitForAssignment } from "./wait-for-assignment.ts";
 
@@ -28,8 +29,7 @@ export function TurnBasedMenu({
 		"idle" | "loading" | "waiting" | "error"
 	>("idle");
 	const [error, setError] = useState("");
-	// biome-ignore lint/suspicious/noExplicitAny: connection handle
-	const queueConnRef = useRef<any>(null);
+	const queueConnRef = useRef<TurnBasedMatchmakerConn | null>(null);
 
 	const cancelQueue = () => {
 		const conn = queueConnRef.current;
@@ -55,11 +55,9 @@ export function TurnBasedMenu({
 				.getOrCreate(["main"])
 				.connect();
 			queueConnRef.current = mm;
-			const queueResult = (await mm.queueForMatch({
+			const queueResult = await mm.queueForMatch({
 				playerName: name.trim(),
-			})) as {
-				playerId?: string;
-			};
+			});
 			const playerId = queueResult.playerId;
 			if (!playerId) {
 				throw new Error("Failed to queue for match");
@@ -101,8 +99,7 @@ export function TurnBasedMenu({
 				{ wait: true, timeout: 10_000 },
 			);
 			mm.dispose();
-			const response = (result as { response?: TurnBasedMatchInfo })
-				?.response;
+			const response = result.response;
 			if (!response?.matchId) throw new Error("Failed to create game");
 			onReady(response);
 		} catch (err) {
@@ -125,9 +122,7 @@ export function TurnBasedMenu({
 				{ wait: true, timeout: 10_000 },
 			);
 			mm.dispose();
-			const response = (
-				result as { response?: { matchId: string; playerId: string } }
-			)?.response;
+			const response = result.response;
 			if (!response?.matchId) throw new Error("Failed to join game");
 			onReady(response);
 		} catch (err) {

--- a/examples/multiplayer-game-patterns/frontend/games/turn-based/wait-for-assignment.ts
+++ b/examples/multiplayer-game-patterns/frontend/games/turn-based/wait-for-assignment.ts
@@ -3,13 +3,10 @@ interface Assignment {
 }
 
 type AssignmentConnection = {
-	action: <Args extends unknown[], Response>(opts: {
-		name: string;
-		args: Args;
-	}) => Promise<Response>;
+	getAssignment: (input: { playerId: string }) => Promise<Assignment | null>;
 	on: (
 		event: "assignmentReady",
-		handler: (raw: unknown) => void,
+		handler: (assignment: Assignment) => void,
 	) => (() => void) | undefined;
 };
 
@@ -24,7 +21,7 @@ export async function waitForAssignment<T extends Assignment>(
 	timeoutMs = 120_000,
 ): Promise<T> {
 	const existing = await readAssignment<T>(mm, playerId);
-	if (existing) return existing as T;
+	if (existing) return existing;
 
 	return await new Promise<T>((resolve, reject) => {
 		let settled = false;
@@ -39,10 +36,9 @@ export async function waitForAssignment<T extends Assignment>(
 			fn();
 		};
 
-		off = mm.on("assignmentReady", (raw: unknown) => {
-			const next = raw as T;
+		off = mm.on("assignmentReady", (next) => {
 			if (next.playerId !== playerId) return;
-			settle(() => resolve(next));
+			settle(() => resolve(next as T));
 		});
 
 		timeout = window.setTimeout(() => {
@@ -64,8 +60,5 @@ async function readAssignment<T extends Assignment>(
 	mm: AssignmentConnection,
 	playerId: string,
 ): Promise<T | null> {
-	return await mm.action<[{ playerId: string }], T | null>({
-		name: "getAssignment",
-		args: [{ playerId }],
-	});
+	return (await mm.getAssignment({ playerId })) as T | null;
 }

--- a/examples/multiplayer-game-patterns/src/actors/arena/matchmaker.ts
+++ b/examples/multiplayer-game-patterns/src/actors/arena/matchmaker.ts
@@ -5,7 +5,7 @@ This matchmaker uses a queue and fill flow.
 3. The matchmaker stores assignments and broadcasts assignmentReady so each client can connect to the new match.
 4. onDisconnect unqueues pending players so stale queue entries do not stay in the pool.
 */
-import { type ActorContextOf, actor, queue } from "rivetkit";
+import { type ActorContextOf, actor, event, queue } from "rivetkit";
 import { db, type RawAccess } from "rivetkit/db";
 
 import type { registry } from "../index.ts";
@@ -37,6 +37,10 @@ export const arenaMatchmaker = actor({
 		}>(),
 		unqueueForMatch: queue<{ connId: string }>(),
 		matchCompleted: queue<{ matchId: string }>(),
+	},
+	events: {
+		assignmentReady: event<ArenaAssignment>(),
+		queueUpdate: event<{ counts: Record<string, number> }>(),
 	},
 	actions: {
 		queueForMatch: async (c, { mode }: { mode: Mode }) => {

--- a/examples/multiplayer-game-patterns/src/actors/battle-royale/match.ts
+++ b/examples/multiplayer-game-patterns/src/actors/battle-royale/match.ts
@@ -382,8 +382,7 @@ async function claimPendingPlayer(
 	if (result.status !== "completed") {
 		return false;
 	}
-	const response = (result as { response?: { accepted?: boolean } }).response;
-	return response?.accepted === true;
+	return result.response?.accepted === true;
 }
 
 function countAlivePlayers(state: State): number {

--- a/examples/multiplayer-game-patterns/src/actors/io-style/match.ts
+++ b/examples/multiplayer-game-patterns/src/actors/io-style/match.ts
@@ -165,8 +165,7 @@ async function claimPendingPlayer(
 	if (result.status !== "completed") {
 		return false;
 	}
-	const response = (result as { response?: { accepted?: boolean } }).response;
-	return response?.accepted === true;
+	return result.response?.accepted === true;
 }
 
 interface Snapshot {

--- a/examples/multiplayer-game-patterns/src/actors/ranked/matchmaker.ts
+++ b/examples/multiplayer-game-patterns/src/actors/ranked/matchmaker.ts
@@ -5,7 +5,7 @@ This matchmaker uses a rating window flow.
 3. createRankedMatch removes paired players, creates a match actor, stores assignments, and broadcasts assignmentReady.
 4. matchCompleted updates player rating actors and leaderboard entries, then removes the match row.
 */
-import { type ActorContextOf, actor, queue } from "rivetkit";
+import { type ActorContextOf, actor, event, queue } from "rivetkit";
 import { db, type RawAccess } from "rivetkit/db";
 import { interval } from "rivetkit/utils";
 
@@ -22,6 +22,22 @@ export interface RankedAssignment {
 	rating: number;
 	connId: string | null;
 }
+
+export type RankedQueueUpdate =
+	| {
+			queued: false;
+			count: number;
+	  }
+	| {
+			queued: true;
+			count: number;
+			username: string;
+			rating: number;
+			queueDurationMs: number;
+			ratingWindow: number;
+			ratingMin: number;
+			ratingMax: number;
+	  };
 
 type QueuePlayerRow = {
 	username: string;
@@ -51,6 +67,10 @@ export const rankedMatchmaker = actor({
 			winnerNewRating: number;
 			loserNewRating: number;
 		}>(),
+	},
+	events: {
+		assignmentReady: event<RankedAssignment>(),
+		queueUpdate: event<RankedQueueUpdate>(),
 	},
 	actions: {
 		queueForMatch: async (c, { username }: { username: string }) => {

--- a/examples/multiplayer-game-patterns/src/actors/turn-based/matchmaker.ts
+++ b/examples/multiplayer-game-patterns/src/actors/turn-based/matchmaker.ts
@@ -7,7 +7,7 @@ This matchmaker supports invite and queued public matchmaking flows.
 5. getAssignment lets clients poll for their match assignment.
 6. onDisconnect unqueues waiting players so stale queue entries do not remain.
 */
-import { type ActorContextOf, actor, queue, UserError } from "rivetkit";
+import { type ActorContextOf, actor, event, queue, UserError } from "rivetkit";
 import { db, type RawAccess } from "rivetkit/db";
 
 import type { registry } from "../index.ts";
@@ -48,6 +48,9 @@ export const turnBasedMatchmaker = actor({
 		}>(),
 		unqueueForMatch: queue<{ connId: string }>(),
 		closeMatch: queue<{ matchId: string }>(),
+	},
+	events: {
+		assignmentReady: event<TurnBasedAssignment>(),
 	},
 	actions: {
 		queueForMatch: async (c, { playerName }: { playerName: string }) => {

--- a/examples/multiplayer-game-patterns/tests/matchmaking-and-session-patterns.test.ts
+++ b/examples/multiplayer-game-patterns/tests/matchmaking-and-session-patterns.test.ts
@@ -666,7 +666,8 @@ describe("matchmaking and session patterns", () => {
 			? snapNewChunk.players[newTravelerConnId]
 			: undefined;
 		expect(newPos).toBeDefined();
-		expect(newPos?.x).toBeLessThan(100);
+		if (!newPos) throw new Error("traveler position missing");
+		expect(newPos.x).toBeLessThan(100);
 
 		await chunk1.setInput({ inputX: 1, inputY: 0 });
 		await sleep(350);

--- a/rivetkit-typescript/packages/rivetkit/src/actor/config.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/config.ts
@@ -1505,6 +1505,25 @@ export type ActorConfig<
 	TDatabase extends AnyDatabaseProvider,
 	TEvents extends EventSchemaConfig = Record<never, never>,
 	TQueues extends QueueSchemaConfig = Record<never, never>,
+	TActions extends Actions<
+		TState,
+		TConnParams,
+		TConnState,
+		TVars,
+		TInput,
+		TDatabase,
+		TEvents,
+		TQueues
+	> = Actions<
+		TState,
+		TConnParams,
+		TConnState,
+		TVars,
+		TInput,
+		TDatabase,
+		TEvents,
+		TQueues
+	>,
 > = Omit<
 	z.infer<typeof ActorConfigSchema>,
 	| "actions"
@@ -1540,16 +1559,7 @@ export type ActorConfig<
 		TDatabase,
 		TEvents,
 		TQueues,
-		Actions<
-			TState,
-			TConnParams,
-			TConnState,
-			TVars,
-			TInput,
-			TDatabase,
-			TEvents,
-			TQueues
-		>
+		TActions
 	> &
 	CreateState<
 		TState,

--- a/rivetkit-typescript/packages/rivetkit/src/actor/definition.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/actor/definition.ts
@@ -44,7 +44,7 @@ export interface BaseActorDefinition<
 		Q
 	>,
 > {
-	readonly config: ActorConfig<S, CP, CS, V, I, DB, E, Q>;
+	readonly config: ActorConfig<S, CP, CS, V, I, DB, E, Q, _R>;
 }
 
 export interface AnyActorDefinition {
@@ -84,13 +84,13 @@ export class ActorDefinition<
 	>,
 > implements BaseActorDefinition<S, CP, CS, V, I, DB, E, Q, R>
 {
-	#config: ActorConfig<S, CP, CS, V, I, DB, E, Q>;
+	#config: ActorConfig<S, CP, CS, V, I, DB, E, Q, R>;
 
-	constructor(config: ActorConfig<S, CP, CS, V, I, DB, E, Q>) {
+	constructor(config: ActorConfig<S, CP, CS, V, I, DB, E, Q, R>) {
 		this.#config = config;
 	}
 
-	get config(): ActorConfig<S, CP, CS, V, I, DB, E, Q> {
+	get config(): ActorConfig<S, CP, CS, V, I, DB, E, Q, R> {
 		return this.#config;
 	}
 }
@@ -192,7 +192,8 @@ export function actor<
 		TInput,
 		TDatabase,
 		TEvents,
-		TQueues
+		TQueues,
+		TActions
 	>;
 	return new ActorDefinition(config);
 }

--- a/rivetkit-typescript/packages/rivetkit/src/client/actor-common.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/client/actor-common.ts
@@ -46,6 +46,21 @@ type ActorActionMap<R> = {
 		: never;
 };
 
+type ActionsOf<AD extends AnyActorDefinition> =
+	AD extends BaseActorDefinition<
+		any,
+		any,
+		any,
+		any,
+		any,
+		any,
+		any,
+		any,
+		infer R
+	>
+		? R
+		: never;
+
 export interface ActorGatewayOptions {
 	skipReadyWait?: boolean;
 }
@@ -81,21 +96,7 @@ export type ActorDefinitionActions<AD extends AnyActorDefinition> =
 	// biome-ignore lint/suspicious/noExplicitAny: safe to use any here
 	IsAny<AD> extends true
 		? Record<string, ActorActionFunction<any[], any>>
-		: AD extends { config: { actions?: infer R } }
-			? ActorActionMap<R>
-			: AD extends BaseActorDefinition<
-						any,
-						any,
-						any,
-						any,
-						any,
-						any,
-						any,
-						any,
-						infer R
-					>
-				? ActorActionMap<R>
-				: {};
+		: ActorActionMap<ActionsOf<AD>>;
 
 type ActorQueueSend<TQueues extends QueueSchemaConfig> = {
 	<K extends keyof TQueues & string>(

--- a/rivetkit-typescript/packages/rivetkit/src/client/actor-common.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/client/actor-common.ts
@@ -38,6 +38,14 @@ type LooseEventSubscribe = (
 	callback: (...args: any[]) => void,
 ) => () => void;
 
+type ActorActionMap<R> = {
+	[K in keyof NonNullable<R>]: NonNullable<R>[K] extends (
+		...args: infer Args
+	) => infer Return
+		? ActorActionFunction<Args, Awaited<Return>>
+		: never;
+};
+
 export interface ActorGatewayOptions {
 	skipReadyWait?: boolean;
 }
@@ -74,13 +82,7 @@ export type ActorDefinitionActions<AD extends AnyActorDefinition> =
 	IsAny<AD> extends true
 		? Record<string, ActorActionFunction<any[], any>>
 		: AD extends { config: { actions?: infer R } }
-			? {
-					[K in keyof R]: R[K] extends (
-						...args: infer Args
-					) => infer Return
-						? ActorActionFunction<Args, Return>
-						: never;
-				}
+			? ActorActionMap<R>
 			: AD extends BaseActorDefinition<
 						any,
 						any,
@@ -92,13 +94,7 @@ export type ActorDefinitionActions<AD extends AnyActorDefinition> =
 						any,
 						infer R
 					>
-				? {
-						[K in keyof R]: R[K] extends (
-							...args: infer Args
-						) => infer Return
-							? ActorActionFunction<Args, Return>
-							: never;
-					}
+				? ActorActionMap<R>
 				: {};
 
 type ActorQueueSend<TQueues extends QueueSchemaConfig> = {


### PR DESCRIPTION
Keep actor action generics on ActorConfig and unwrap async action results for client proxies. Use the restored types in multiplayer-game-patterns to remove explicit any/unknown casts from connection refs, event handlers, match assignment helpers, and route payloads.