### PR TITLE
feat(rivetkit): expose actorOptions in agentOs config

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/agent-os/actor/index.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/agent-os/actor/index.ts
@@ -199,6 +199,7 @@ export function agentOs<TConnParams = undefined>(
 		options: {
 			sleepGracePeriod: 900_000,
 			actionTimeout: 900_000,
+			...parsedConfig.actorOptions,
 		},
 		createState: async () => ({}),
 		createVars: () => ({

--- a/rivetkit-typescript/packages/rivetkit/src/agent-os/config.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/agent-os/config.ts
@@ -4,7 +4,11 @@ import type {
 	PermissionRequest,
 } from "@rivet-dev/agent-os-core";
 import { z } from "zod/v4";
-import type { ActorContext, BeforeConnectContext } from "@/actor/config";
+import type {
+	ActorContext,
+	ActorOptionsInput,
+	BeforeConnectContext,
+} from "@/actor/config";
 import type { AgentOsActorState, AgentOsActorVars } from "./types";
 
 const zFunction = <
@@ -18,6 +22,9 @@ const AgentOsOptionsSchema = z.custom<AgentOsOptions>(
 export const agentOsActorConfigSchema = z
 	.object({
 		options: AgentOsOptionsSchema.optional(),
+		actorOptions: z
+			.record(z.string(), z.unknown())
+			.optional(),
 		preview: z
 			.object({
 				defaultExpiresInSeconds: z.number().positive().default(3600),
@@ -67,13 +74,15 @@ interface AgentOsActorConfigCallbacks<TConnParams> {
 // Parsed config (after Zod defaults/transforms applied).
 export type AgentOsActorConfig<TConnParams = undefined> = Omit<
 	z.infer<typeof agentOsActorConfigSchema>,
-	"onBeforeConnect" | "onSessionEvent" | "onPermissionRequest"
-> &
-	AgentOsActorConfigCallbacks<TConnParams>;
+	"onBeforeConnect" | "onSessionEvent" | "onPermissionRequest" | "actorOptions"
+> & {
+	actorOptions?: ActorOptionsInput;
+} & AgentOsActorConfigCallbacks<TConnParams>;
 
 // Input config (what users pass in before Zod transforms).
 export type AgentOsActorConfigInput<TConnParams = undefined> = Omit<
 	z.input<typeof agentOsActorConfigSchema>,
-	"onBeforeConnect" | "onSessionEvent" | "onPermissionRequest"
-> &
-	AgentOsActorConfigCallbacks<TConnParams>;
+	"onBeforeConnect" | "onSessionEvent" | "onPermissionRequest" | "actorOptions"
+> & {
+	actorOptions?: ActorOptionsInput;
+} & AgentOsActorConfigCallbacks<TConnParams>;


### PR DESCRIPTION
## Summary

- Add `actorOptions` field to `agentOsActorConfigSchema` so users can pass actor-level options (e.g. `sleepTimeout`) through `agentOs()` without patching internals
- User-supplied values are spread on top of the existing defaults (`sleepGracePeriod: 900_000`, `actionTimeout: 900_000`)

Closes https://github.com/rivet-dev/rivet/issues/5157