### PR TITLE
docs(rivetkit): add rust quickstart preview

### DIFF
--- a/website/src/content/docs/actors/quickstart/index.mdx
+++ b/website/src/content/docs/actors/quickstart/index.mdx
@@ -10,6 +10,7 @@ import {
 	faNodeJs,
 	faReact,
 	faNextjs,
+	faRust,
 } from "@rivet-gg/icons";
 
 <Note>
@@ -40,6 +41,13 @@ npx skills add rivet-dev/skills
 		icon={faNextjs}
 	>
 		Build server-rendered Next.js experiences backed by actors
+	</Card>
+	<Card
+		title="Rust Quickstart (Preview)"
+		href="/docs/actors/quickstart/rust"
+		icon={faRust}
+	>
+		Run a RivetKit Rust counter actor with `rivetkit-core`
 	</Card>
 	<Card
 		title="Cloudflare Workers"

--- a/website/src/content/docs/actors/quickstart/rust.mdx
+++ b/website/src/content/docs/actors/quickstart/rust.mdx
@@ -1,0 +1,120 @@
+---
+title: "Rust Quickstart (Preview)"
+description: "Run a RivetKit Rust counter actor with rivetkit-core"
+skill: true
+---
+
+<Note>
+RivetKit Rust is in preview. This quickstart uses the low-level `rivetkit-core` API directly.
+</Note>
+
+## Steps
+
+<Steps>
+<Step title="Build The Local Engine">
+
+The Rust runtime connects to the Rivet Engine. Build the local engine binary once:
+
+```sh
+cargo build -p rivet-engine
+```
+
+</Step>
+
+<Step title="Run The Rust Counter">
+
+Start the example actor runtime. `RIVET_ENGINE_BINARY_PATH` tells `rivetkit-core` where to find `rivet-engine`; the runtime will spawn or reuse a local engine at `http://127.0.0.1:6420`.
+
+```sh
+cd examples/rust-counter
+RIVET_ENGINE_BINARY_PATH=../../target/debug/rivet-engine cargo run
+```
+
+If you prefer to run the engine yourself, start `rivet-engine start` separately and run the example with `RIVET_ENDPOINT` pointing at that engine.
+
+</Step>
+
+<Step title="Create A Counter Actor">
+
+In another terminal, create the default namespace and a `counter` actor. These examples use the local dev token `dev`.
+
+```sh
+curl -s -X POST 'http://127.0.0.1:6420/namespaces' \
+  -H 'authorization: Bearer dev' \
+  -H 'content-type: application/json' \
+  -d '{"name":"default","display_name":"Default"}'
+```
+
+```sh
+ACTOR_ID=$(curl -s -X POST 'http://127.0.0.1:6420/actors?namespace=default' \
+  -H 'authorization: Bearer dev' \
+  -H 'content-type: application/json' \
+  -d '{"name":"counter","runner_name_selector":"rivetkit-rust","key":null,"input":null,"datacenter":null,"crash_policy":"destroy"}' \
+  | jq -r '.actor.actor_id')
+```
+
+</Step>
+
+<Step title="Call Actions">
+
+Call `increment` to update the actor state:
+
+```sh
+curl -s -X POST "http://127.0.0.1:6420/gateway/$ACTOR_ID/action/increment" \
+  -H 'x-rivet-encoding: json' \
+  -H 'content-type: application/json' \
+  -d '{"args":[]}'
+```
+
+Read the current count:
+
+```sh
+curl -s -X POST "http://127.0.0.1:6420/gateway/$ACTOR_ID/action/get" \
+  -H 'x-rivet-encoding: json' \
+  -H 'content-type: application/json' \
+  -d '{"args":[]}'
+```
+
+</Step>
+
+<Step title="Inspect The Actor Code">
+
+The example registers a `counter` actor factory with `rivetkit-core` and handles action events in a receive loop:
+
+```rust examples/rust-counter/src/main.rs
+use anyhow::Result;
+use rivetkit_core::ServeConfig;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+	let config = ServeConfig::from_env();
+	let shutdown = CancellationToken::new();
+	let registry = rivetkit_rust_counter_example::registry();
+	let serve = tokio::spawn({
+		let shutdown = shutdown.clone();
+		async move { registry.serve_with_config(config, shutdown).await }
+	});
+
+	tokio::signal::ctrl_c().await?;
+	shutdown.cancel();
+	serve.await??;
+
+	Ok(())
+}
+```
+
+Full source: [`examples/rust-counter`](https://github.com/rivet-dev/rivet/tree/main/examples/rust-counter).
+
+</Step>
+
+<Step title="Run The E2E Test">
+
+The example includes an e2e test that starts a temporary engine, serves the Rust registry, creates a counter actor, calls `increment` twice, and verifies `get` returns `2`.
+
+```sh
+cargo test -p rivetkit-rust-counter-example --test e2e -- --nocapture
+```
+
+</Step>
+</Steps>

--- a/website/src/content/docs/quickstart/index.mdx
+++ b/website/src/content/docs/quickstart/index.mdx
@@ -10,6 +10,7 @@ import {
 	faNodeJs,
 	faReact,
 	faNextjs,
+	faRust,
 } from "@rivet-gg/icons";
 
 <CardGroup cols={2}>
@@ -33,6 +34,13 @@ import {
 		icon={faNextjs}
 	>
 		Build server-rendered Next.js experiences backed by actors
+	</Card>
+	<Card
+		title="Rust Quickstart (Preview)"
+		href="/docs/actors/quickstart/rust"
+		icon={faRust}
+	>
+		Run a RivetKit Rust counter actor with `rivetkit-core`
 	</Card>
 	<Card
 		title="Cloudflare Workers"

--- a/website/src/sitemap/mod.ts
+++ b/website/src/sitemap/mod.ts
@@ -133,6 +133,11 @@ export const sitemap = [
 								href: "/docs/actors/quickstart/next-js",
 								icon: faNextjs,
 							},
+							{
+								title: "Rust (Preview)",
+								href: "/docs/actors/quickstart/rust",
+								icon: faRust,
+							},
 						],
 					},
 				]


### PR DESCRIPTION
Adds a dedicated RivetKit Rust quickstart marked as preview.

Documents how to build/run the local rivet-engine, start the examples/rust-counter runtime with rivetkit-core, create a counter actor, call actions, and run the example e2e test.