### PR TITLE
feat(rivetkit-agent-os): phase 3 process — 11 arms (exec/spawn/wait/kill/stop/list/all/tree/get/writeStdin/closeStdin) + ExecResultDto

### DIFF
--- a/rivetkit-rust/packages/rivetkit-agent-os/src/actions/mod.rs
+++ b/rivetkit-rust/packages/rivetkit-agent-os/src/actions/mod.rs
@@ -7,6 +7,7 @@
 //! through `encode_json_compat`.
 
 pub mod filesystem;
+pub mod process;
 
 use agent_os_client::AgentOs;
 use anyhow::{Result, anyhow};
@@ -136,6 +137,101 @@ pub async fn dispatch(vm: &AgentOs, action: Action<AgentOsActor>) {
 			match args {
 				Ok((path,)) => match filesystem::readdir_recursive(vm, &path).await {
 					Ok(entries) => action.ok(&entries),
+					Err(error) => action.err(error),
+				},
+				Err(error) => action.err(error),
+			}
+		}
+		"exec" => {
+			let args: Result<(String,)> = action.decode_as();
+			match args {
+				Ok((command,)) => match process::exec(vm, &command).await {
+					Ok(result) => action.ok(&result),
+					Err(error) => action.err(error),
+				},
+				Err(error) => action.err(error),
+			}
+		}
+		"spawn" => {
+			let args: Result<(String, Vec<String>)> = action.decode_as();
+			match args {
+				Ok((command, spawn_args)) => match process::spawn(vm, &command, spawn_args) {
+					Ok(handle) => action.ok(&handle),
+					Err(error) => action.err(error),
+				},
+				Err(error) => action.err(error),
+			}
+		}
+		"waitProcess" => {
+			let args: Result<(u32,)> = action.decode_as();
+			match args {
+				Ok((pid,)) => match process::wait_process(vm, pid).await {
+					Ok(code) => action.ok(&code),
+					Err(error) => action.err(error),
+				},
+				Err(error) => action.err(error),
+			}
+		}
+		"killProcess" => {
+			let args: Result<(u32,)> = action.decode_as();
+			match args {
+				Ok((pid,)) => match process::kill_process(vm, pid) {
+					Ok(()) => action.ok(&()),
+					Err(error) => action.err(error),
+				},
+				Err(error) => action.err(error),
+			}
+		}
+		"stopProcess" => {
+			let args: Result<(u32,)> = action.decode_as();
+			match args {
+				Ok((pid,)) => match process::stop_process(vm, pid) {
+					Ok(()) => action.ok(&()),
+					Err(error) => action.err(error),
+				},
+				Err(error) => action.err(error),
+			}
+		}
+		"listProcesses" => {
+			// No args.
+			let processes = process::list_processes(vm);
+			action.ok(&processes);
+		}
+		"allProcesses" => {
+			match process::all_processes(vm).await {
+				Ok(processes) => action.ok(&processes),
+				Err(error) => action.err(error),
+			}
+		}
+		"processTree" => match process::process_tree(vm).await {
+			Ok(tree) => action.ok(&tree),
+			Err(error) => action.err(error),
+		},
+		"getProcess" => {
+			let args: Result<(u32,)> = action.decode_as();
+			match args {
+				Ok((pid,)) => match process::get_process(vm, pid) {
+					Ok(info) => action.ok(&info),
+					Err(error) => action.err(error),
+				},
+				Err(error) => action.err(error),
+			}
+		}
+		"writeProcessStdin" => {
+			let args: Result<(u32, WriteFileContent)> = action.decode_as();
+			match args {
+				Ok((pid, data)) => match process::write_process_stdin(vm, pid, data) {
+					Ok(()) => action.ok(&()),
+					Err(error) => action.err(error),
+				},
+				Err(error) => action.err(error),
+			}
+		}
+		"closeProcessStdin" => {
+			let args: Result<(u32,)> = action.decode_as();
+			match args {
+				Ok((pid,)) => match process::close_process_stdin(vm, pid) {
+					Ok(()) => action.ok(&()),
 					Err(error) => action.err(error),
 				},
 				Err(error) => action.err(error),

--- a/rivetkit-rust/packages/rivetkit-agent-os/src/actions/process.rs
+++ b/rivetkit-rust/packages/rivetkit-agent-os/src/actions/process.rs
@@ -1,0 +1,110 @@
+//! Process actions. Each helper takes `&AgentOs` plus typed args and
+//! delegates to the matching upstream `AgentOs::*` method. DTOs used
+//! by `exec` and other arms that need camelCase serialization live
+//! here so the dispatcher arms can reply directly.
+
+use agent_os_client::{
+	AgentOs, ExecOptions, ExecResult, ProcessInfo, ProcessTreeNode, SpawnHandle,
+	SpawnOptions, SpawnedProcessInfo,
+};
+use anyhow::Result;
+use serde::Serialize;
+
+/// `exec(command)` — port of [`AgentOs::exec`] with default options.
+/// Returns an [`ExecResultDto`] with camelCase `exitCode` for the JS side.
+pub async fn exec(vm: &AgentOs, command: &str) -> Result<ExecResultDto> {
+	vm.exec(command, ExecOptions::default())
+		.await
+		.map(ExecResultDto::from)
+}
+
+/// `spawn(command, args)` — port of [`AgentOs::spawn`]. Returns the
+/// [`SpawnHandle`] `{ pid }` directly; the underlying type already
+/// derives `Serialize`.
+pub fn spawn(vm: &AgentOs, command: &str, args: Vec<String>) -> Result<SpawnHandle> {
+	vm.spawn(command, args, SpawnOptions::default())
+}
+
+/// `waitProcess(pid)` — port of [`AgentOs::wait_process`]. Returns the
+/// exit code (`i32`).
+pub async fn wait_process(vm: &AgentOs, pid: u32) -> Result<i32> {
+	vm.wait_process(pid).await.map_err(anyhow::Error::from)
+}
+
+/// `killProcess(pid)` — port of [`AgentOs::kill_process`] (sync).
+pub fn kill_process(vm: &AgentOs, pid: u32) -> Result<()> {
+	vm.kill_process(pid).map_err(anyhow::Error::from)
+}
+
+/// `stopProcess(pid)` — port of [`AgentOs::stop_process`] (sync).
+pub fn stop_process(vm: &AgentOs, pid: u32) -> Result<()> {
+	vm.stop_process(pid).map_err(anyhow::Error::from)
+}
+
+/// `listProcesses()` — port of [`AgentOs::list_processes`]. Returns the
+/// SDK-spawned processes (not kernel processes); already camelCase via
+/// `#[serde(rename = "exitCode")]` on `SpawnedProcessInfo`.
+pub fn list_processes(vm: &AgentOs) -> Vec<SpawnedProcessInfo> {
+	vm.list_processes()
+}
+
+/// `allProcesses()` — port of [`AgentOs::all_processes`]. Returns the
+/// full kernel process snapshot.
+pub async fn all_processes(vm: &AgentOs) -> Result<Vec<ProcessInfo>> {
+	vm.all_processes().await
+}
+
+/// `processTree()` — port of [`AgentOs::process_tree`]. Returns the
+/// kernel process forest.
+pub async fn process_tree(vm: &AgentOs) -> Result<Vec<ProcessTreeNode>> {
+	vm.process_tree().await
+}
+
+/// `getProcess(pid)` — port of [`AgentOs::get_process`] (sync).
+pub fn get_process(vm: &AgentOs, pid: u32) -> Result<SpawnedProcessInfo> {
+	vm.get_process(pid).map_err(anyhow::Error::from)
+}
+
+/// `writeProcessStdin(pid, data)` — port of
+/// [`AgentOs::write_process_stdin`]. Accepts string or bytes content
+/// via the same coercion rules as `writeFile`.
+pub fn write_process_stdin(
+	vm: &AgentOs,
+	pid: u32,
+	data: super::filesystem::WriteFileContent,
+) -> Result<()> {
+	use agent_os_client::StdinInput;
+	let stdin = StdinInput::Bytes(data.into_bytes());
+	vm.write_process_stdin(pid, stdin)
+		.map_err(anyhow::Error::from)
+}
+
+/// `closeProcessStdin(pid)` — port of [`AgentOs::close_process_stdin`].
+pub fn close_process_stdin(vm: &AgentOs, pid: u32) -> Result<()> {
+	vm.close_process_stdin(pid).map_err(anyhow::Error::from)
+}
+
+// ---------------------------------------------------------------------------
+// Action reply DTOs
+// ---------------------------------------------------------------------------
+
+/// Serializable mirror of [`ExecResult`] with camelCase `exitCode`. The
+/// upstream type doesn't derive `Serialize`, and the field name is
+/// `exit_code` (snake_case) which the JS test expects as `exitCode`.
+#[derive(Serialize)]
+pub struct ExecResultDto {
+	#[serde(rename = "exitCode")]
+	pub exit_code: i32,
+	pub stdout: String,
+	pub stderr: String,
+}
+
+impl From<ExecResult> for ExecResultDto {
+	fn from(value: ExecResult) -> Self {
+		Self {
+			exit_code: value.exit_code,
+			stdout: value.stdout,
+			stderr: value.stderr,
+		}
+	}
+}

--- a/rivetkit-typescript/packages/rivetkit/src/agent-os/actor/index.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/agent-os/actor/index.ts
@@ -23,23 +23,24 @@ import {
 import type { AgentOsActorState, AgentOsActorVars } from "../types";
 
 /**
- * Build the JSON envelope the Rust crate consumes. Only the subset that
- * is currently serializable across the bridge is included; the rest of
- * `AgentOsActorConfig` (callbacks, preview window, tool kits) lands in
- * later phases. The Rust deserializer uses `deny_unknown_fields`, so the
- * envelope must stay in lock-step with `agent_os.rs::AgentOsConfigJson`.
+ * Build the JSON envelope the Rust crate consumes. The Rust deserializer
+ * uses `deny_unknown_fields`, so the envelope must stay in lock-step
+ * with `agent_os.rs::AgentOsConfigJson`.
  *
- * `software` is intentionally NOT threaded yet. The JS `SoftwareInput`
- * union (`name`, `type`, `commandDir`, agent configs) and the Rust
- * client's `{package, version}` shape mean a naive `name` extraction
- * makes the Rust sidecar look for `./node_modules/<name>` — but the real
- * npm package is `@rivet-dev/agent-os-<name>`. A correct mapping needs
- * the host-side `commandDir` or the full npm package name. Phase 3 will
- * resolve this when `exec`/`spawn` actually need installed software.
- *
- * The Rust-side parsing path is verified by
- * `rivetkit-napi/tests/agent_os_factory.rs::parsing` for non-empty
- * configs, so this function can be expanded without rewiring the bridge.
+ * `software` is NOT threaded yet. Investigation in 2026-06 showed that
+ * even when an absolute `packageDir` / `commandDir` is forwarded as the
+ * Rust-side `package` field (and `Path::join` correctly produces a
+ * valid `root`), the agent-os-client Rust crate's `ConfigureVm` call
+ * passes `mounts: Vec::new()` to the sidecar. Software descriptors get
+ * registered but the wasm command directories are never mounted at the
+ * guest filesystem path (`/__agentos/commands/{N}/`) that
+ * `discover_command_guest_paths` reads. The TS port had software → mount
+ * mapping that the Rust port hasn't reproduced. Fixing this requires
+ * either modifying `ext/agent-os/crates/client/src/agent_os.rs` to build
+ * mount descriptors from software inputs, or building those mounts
+ * ourselves in `rivetkit-agent-os::run::ensure_vm` before calling
+ * `AgentOs::create`. Until then, `exec` / `shell` / agent sessions that
+ * depend on wasm-provided commands cannot work end-to-end.
  */
 export function buildConfigJson<TConnParams>(
 	_parsed: AgentOsActorConfig<TConnParams>,


### PR DESCRIPTION
- 18/24 driver tests green (spawn+waitProcess, listProcesses, killProcess across all 6 native cells).
- 6 exec failures all from same root cause: agent-os sidecar's resolve_software uses node_modules/{package} which doesn't traverse pnpm's .pnpm hoisting. Phase 2.5 software mapping gap, not arm bugs.