### PR TITLE
docs(rivetkit): add rust quickstart preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6022,6 +6022,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rivetkit-rust-counter-example"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ciborium",
+ "portpicker",
+ "reqwest 0.12.22",
+ "rivetkit-core",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "rivetkit-shared-types"
 version = "2.3.0-rc.12"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,8 @@ members = [
   "rivetkit-typescript/packages/rivetkit-wasm",
   "engine/packages/perf",
   "engine/packages/profiling",
-  "engine/packages/ups-broadcast"
+  "engine/packages/ups-broadcast",
+  "examples/rust-counter"
 ]
 
   [workspace.package]

--- a/examples/rust-counter/Cargo.toml
+++ b/examples/rust-counter/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "rivetkit-rust-counter-example"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[dependencies]
+anyhow.workspace = true
+ciborium.workspace = true
+rivetkit-core.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+
+[dev-dependencies]
+portpicker.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+tempfile.workspace = true

--- a/examples/rust-counter/README.md
+++ b/examples/rust-counter/README.md
@@ -1,0 +1,51 @@
+# RivetKit Rust Counter
+
+Preview Rust counter actor built directly with `rivetkit-core`.
+
+## Run
+
+Build the local engine once:
+
+```bash
+cargo build -p rivet-engine
+```
+
+In one terminal, start the actor runtime and let it spawn/reuse a local engine:
+
+```bash
+cd examples/rust-counter
+RIVET_ENGINE_BINARY_PATH=../../target/debug/rivet-engine cargo run
+```
+
+In another terminal, create an actor and call it through the local engine API:
+
+```bash
+curl -s -X POST 'http://127.0.0.1:6420/namespaces' \
+  -H 'authorization: Bearer dev' \
+  -H 'content-type: application/json' \
+  -d '{"name":"default","display_name":"Default"}'
+
+ACTOR_ID=$(curl -s -X POST 'http://127.0.0.1:6420/actors?namespace=default' \
+  -H 'authorization: Bearer dev' \
+  -H 'content-type: application/json' \
+  -d '{"name":"counter","runner_name_selector":"rivetkit-rust","key":null,"input":null,"datacenter":null,"crash_policy":"destroy"}' \
+  | jq -r '.actor.actor_id')
+
+curl -s -X POST "http://127.0.0.1:6420/gateway/$ACTOR_ID/action/increment" \
+  -H 'x-rivet-encoding: json' \
+  -H 'content-type: application/json' \
+  -d '{"args":[]}'
+
+curl -s -X POST "http://127.0.0.1:6420/gateway/$ACTOR_ID/action/get" \
+  -H 'x-rivet-encoding: json' \
+  -H 'content-type: application/json' \
+  -d '{"args":[]}'
+```
+
+## Verify
+
+```bash
+cargo test -p rivetkit-rust-counter-example --test e2e -- --nocapture
+```
+
+The e2e test starts a temporary engine, serves the Rust registry, creates a counter actor, calls `increment` twice, and verifies `get` returns `2`.

--- a/examples/rust-counter/src/lib.rs
+++ b/examples/rust-counter/src/lib.rs
@@ -1,0 +1,133 @@
+use std::io::Cursor;
+
+use anyhow::{Result, anyhow};
+use rivetkit_core::{
+	ActorConfig, ActorEvent, ActorFactory, ActorStart, CoreRegistry, RequestSaveOpts,
+	SerializeStateReason, StateDelta,
+};
+use serde_json::{Value as JsonValue, json};
+
+pub const ACTOR_NAME: &str = "counter";
+
+pub fn registry() -> CoreRegistry {
+	let mut registry = CoreRegistry::new();
+	registry.register(ACTOR_NAME, counter_factory());
+	registry
+}
+
+pub fn counter_factory() -> ActorFactory {
+	ActorFactory::new(
+		ActorConfig {
+			name: Some(ACTOR_NAME.to_owned()),
+			..ActorConfig::default()
+		},
+		|start| Box::pin(run_counter(start)),
+	)
+}
+
+async fn run_counter(start: ActorStart) -> Result<()> {
+	let ActorStart {
+		ctx,
+		snapshot,
+		mut events,
+		..
+	} = start;
+	let mut count = snapshot
+		.as_deref()
+		.map(decode_count)
+		.transpose()?
+		.unwrap_or_default();
+
+	while let Some(event) = events.recv().await {
+		match event {
+			ActorEvent::Action {
+				name, args, reply, ..
+			} => match name.as_str() {
+				"increment" => {
+					let amount = decode_increment_amount(&args).unwrap_or(1);
+					count += amount;
+					ctx.request_save(RequestSaveOpts::default());
+					reply.send(Ok(encode_json(&json!(count))?));
+				}
+				"get" => {
+					reply.send(Ok(encode_json(&json!(count))?));
+				}
+				other => {
+					reply.send(Err(anyhow!("unknown action `{other}`")));
+				}
+			},
+			ActorEvent::SerializeState { reason, reply } => match reason {
+				SerializeStateReason::Save | SerializeStateReason::Inspector => {
+					reply.send(Ok(vec![StateDelta::ActorState(encode_count(count)?)]));
+				}
+			},
+			ActorEvent::RunGracefulCleanup { reply, .. } => {
+				ctx.save_state(vec![StateDelta::ActorState(encode_count(count)?)])
+					.await?;
+				reply.send(Ok(()));
+			}
+			ActorEvent::HttpRequest { reply, .. } => {
+				reply.send(Err(anyhow!("http requests are not handled")));
+			}
+			ActorEvent::QueueSend { reply, .. } => {
+				reply.send(Err(anyhow!("queues are not handled")));
+			}
+			ActorEvent::WebSocketOpen { reply, .. } => {
+				reply.send(Err(anyhow!("websockets are not handled")));
+			}
+			ActorEvent::ConnectionPreflight { reply, .. } => {
+				reply.send(Ok(()));
+			}
+			ActorEvent::ConnectionOpen { reply, .. } => {
+				reply.send(Ok(()));
+			}
+			ActorEvent::ConnectionClosed { .. } => {}
+			ActorEvent::SubscribeRequest { reply, .. } => {
+				reply.send(Err(anyhow!("subscriptions are not handled")));
+			}
+			ActorEvent::DisconnectConn { reply, .. } => {
+				reply.send(Ok(()));
+			}
+			ActorEvent::WorkflowHistoryRequested { reply } => {
+				reply.send(Ok(None));
+			}
+			ActorEvent::WorkflowReplayRequested { reply, .. } => {
+				reply.send(Ok(None));
+			}
+		}
+	}
+
+	Ok(())
+}
+
+fn decode_increment_amount(args: &[u8]) -> Option<i64> {
+	let value: JsonValue = ciborium::from_reader(Cursor::new(args)).ok()?;
+	if let Some(amount) = value.as_i64() {
+		return Some(amount);
+	}
+	value
+		.as_array()
+		.and_then(|items| items.first())
+		.and_then(JsonValue::as_i64)
+}
+
+fn encode_count(count: i64) -> Result<Vec<u8>> {
+	encode_json(&json!({ "count": count }))
+}
+
+fn decode_count(bytes: &[u8]) -> Result<i64> {
+	if bytes.is_empty() {
+		return Ok(0);
+	}
+	let value: JsonValue = ciborium::from_reader(Cursor::new(bytes))?;
+	Ok(value
+		.get("count")
+		.and_then(JsonValue::as_i64)
+		.unwrap_or_default())
+}
+
+fn encode_json(value: &JsonValue) -> Result<Vec<u8>> {
+	let mut out = Vec::new();
+	ciborium::into_writer(value, &mut out)?;
+	Ok(out)
+}

--- a/examples/rust-counter/src/main.rs
+++ b/examples/rust-counter/src/main.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+use rivetkit_core::ServeConfig;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+	let _ = tracing_subscriber::fmt().with_env_filter("info").try_init();
+
+	let config = ServeConfig::from_env();
+	let shutdown = CancellationToken::new();
+	let registry = rivetkit_rust_counter_example::registry();
+	let serve = tokio::spawn({
+		let shutdown = shutdown.clone();
+		async move { registry.serve_with_config(config, shutdown).await }
+	});
+
+	tokio::signal::ctrl_c().await?;
+	shutdown.cancel();
+	serve.await??;
+
+	Ok(())
+}

--- a/examples/rust-counter/tests/e2e.rs
+++ b/examples/rust-counter/tests/e2e.rs
@@ -1,0 +1,424 @@
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result, bail};
+use reqwest::StatusCode;
+use rivetkit_core::ServeConfig;
+use serde::Deserialize;
+use serde_json::{Value as JsonValue, json};
+use tempfile::TempDir;
+use tokio::process::{Child, Command};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+const TOKEN: &str = "dev";
+const NAMESPACE: &str = "default";
+const POOL_NAME: &str = "rivetkit-rust-counter";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn counter_actor_works_through_local_engine() -> Result<()> {
+	let engine = TestEngine::start().await?;
+	create_default_namespace(&engine).await?;
+
+	let shutdown = CancellationToken::new();
+	let registry_task = serve_registry(&engine, shutdown.clone());
+	wait_for_envoy_ready(&engine).await?;
+
+	let actor_id = create_counter_actor(&engine).await?;
+	let first = wait_for_action(&engine, &actor_id, "increment").await?;
+	let second = wait_for_action(&engine, &actor_id, "increment").await?;
+	let current = wait_for_action(&engine, &actor_id, "get").await?;
+
+	assert_eq!(action_output(&first)?, json!(1));
+	assert_eq!(action_output(&second)?, json!(2));
+	assert_eq!(action_output(&current)?, json!(2));
+
+	shutdown.cancel();
+	registry_task.await.context("join registry task")??;
+	engine.shutdown().await;
+
+	Ok(())
+}
+
+fn serve_registry(engine: &TestEngine, shutdown: CancellationToken) -> JoinHandle<Result<()>> {
+	let config = ServeConfig {
+		endpoint: engine.endpoint.clone(),
+		token: Some(TOKEN.to_owned()),
+		namespace: NAMESPACE.to_owned(),
+		pool_name: POOL_NAME.to_owned(),
+		engine_binary_path: None,
+		..ServeConfig::default()
+	};
+	tokio::spawn(async move {
+		rivetkit_rust_counter_example::registry()
+			.serve_with_config(config, shutdown)
+			.await
+	})
+}
+
+struct TestEngine {
+	_temp_dir: TempDir,
+	endpoint: String,
+	child: Child,
+	client: reqwest::Client,
+	stdout_path: PathBuf,
+	stderr_path: PathBuf,
+}
+
+impl TestEngine {
+	async fn start() -> Result<Self> {
+		let _ = tracing_subscriber::fmt()
+			.with_env_filter("info")
+			.with_ansi(false)
+			.with_test_writer()
+			.try_init();
+
+		let temp_dir = tempfile::tempdir().context("create temp dir")?;
+		let db_path = temp_dir.path().join("db");
+		std::fs::create_dir_all(&db_path).context("create engine db")?;
+		let guard_port = pick_port("guard")?;
+		let api_peer_port = pick_port("api-peer")?;
+		let metrics_port = pick_port("metrics")?;
+		let endpoint = format!("http://127.0.0.1:{guard_port}");
+		let stdout_path = temp_dir.path().join("engine.stdout.log");
+		let stderr_path = temp_dir.path().join("engine.stderr.log");
+		let stdout = File::create(&stdout_path).context("create engine stdout log")?;
+		let stderr = File::create(&stderr_path).context("create engine stderr log")?;
+		let binary_path = engine_binary_path()?;
+
+		let mut child = Command::new(&binary_path)
+			.arg("start")
+			.env("RIVET__GUARD__HOST", "127.0.0.1")
+			.env("RIVET__GUARD__PORT", guard_port.to_string())
+			.env("RIVET__API_PEER__HOST", "127.0.0.1")
+			.env("RIVET__API_PEER__PORT", api_peer_port.to_string())
+			.env("RIVET__METRICS__HOST", "127.0.0.1")
+			.env("RIVET__METRICS__PORT", metrics_port.to_string())
+			.env("RIVET__FILE_SYSTEM__PATH", &db_path)
+			.stdin(Stdio::null())
+			.stdout(Stdio::from(stdout))
+			.stderr(Stdio::from(stderr))
+			.spawn()
+			.with_context(|| format!("spawn engine `{}`", binary_path.display()))?;
+
+		let client = reqwest::Client::new();
+		wait_for_engine_health(&client, &endpoint, &mut child, &stderr_path).await?;
+
+		Ok(Self {
+			_temp_dir: temp_dir,
+			endpoint,
+			child,
+			client,
+			stdout_path,
+			stderr_path,
+		})
+	}
+
+	async fn shutdown(mut self) {
+		shutdown_child(&mut self.child).await;
+	}
+
+	fn stderr_tail(&self) -> String {
+		tail_file(&self.stderr_path)
+	}
+
+	fn stdout_tail(&self) -> String {
+		tail_file(&self.stdout_path)
+	}
+}
+
+impl Drop for TestEngine {
+	fn drop(&mut self) {
+		let _ = self.child.start_kill();
+	}
+}
+
+#[derive(Deserialize)]
+struct EnvoyList {
+	envoys: Vec<ApiEnvoy>,
+}
+
+#[derive(Deserialize)]
+struct ApiEnvoy {
+	pool_name: String,
+}
+
+#[derive(Deserialize)]
+struct RunnerConfigList {
+	runner_configs: std::collections::HashMap<String, RunnerConfigDatacenters>,
+}
+
+#[derive(Deserialize)]
+struct RunnerConfigDatacenters {
+	datacenters: std::collections::HashMap<String, RunnerConfigEntry>,
+}
+
+#[derive(Deserialize)]
+struct RunnerConfigEntry {
+	protocol_version: Option<u16>,
+}
+
+#[derive(Deserialize)]
+struct CreateActorResponse {
+	actor: ApiActor,
+}
+
+#[derive(Deserialize)]
+struct ApiActor {
+	actor_id: String,
+}
+
+async fn create_default_namespace(engine: &TestEngine) -> Result<()> {
+	let response = engine
+		.client
+		.post(format!("{}/namespaces", engine.endpoint))
+		.bearer_auth(TOKEN)
+		.json(&json!({
+			"name": NAMESPACE,
+			"display_name": "Default",
+		}))
+		.send()
+		.await
+		.context("create default namespace")?;
+	let status = response.status();
+	let body = response.text().await.context("read namespace response")?;
+	if !status.is_success()
+		&& !body.contains("\"code\":\"already_exists\"")
+		&& !body.contains("\"code\":\"name_not_unique\"")
+	{
+		bail!("create namespace failed with {status}: {body}");
+	}
+	Ok(())
+}
+
+async fn wait_for_envoy_ready(engine: &TestEngine) -> Result<()> {
+	let deadline = Instant::now() + Duration::from_secs(30);
+	let mut last_error = None;
+	while Instant::now() < deadline {
+		match envoy_ready(engine).await {
+			Ok(true) => return Ok(()),
+			Ok(false) => {}
+			Err(err) => last_error = Some(err),
+		}
+		tokio::time::sleep(Duration::from_millis(250)).await;
+	}
+	match last_error {
+		Some(err) => Err(err).context("timed out waiting for envoy readiness"),
+		None => bail!("timed out waiting for envoy readiness"),
+	}
+}
+
+async fn envoy_ready(engine: &TestEngine) -> Result<bool> {
+	let envoys_response = engine
+		.client
+		.get(format!("{}/envoys", engine.endpoint))
+		.query(&[
+			("namespace", NAMESPACE),
+			("name", POOL_NAME),
+			("limit", "1"),
+		])
+		.bearer_auth(TOKEN)
+		.send()
+		.await
+		.context("list envoys")?;
+	let status = envoys_response.status();
+	let body = envoys_response.text().await.context("read envoys")?;
+	if !status.is_success() {
+		bail!("list envoys failed with {status}: {body}");
+	}
+	let envoys: EnvoyList = serde_json::from_str(&body).context("decode envoys")?;
+	if !envoys
+		.envoys
+		.iter()
+		.any(|envoy| envoy.pool_name == POOL_NAME)
+	{
+		return Ok(false);
+	}
+
+	let runner_configs_response = engine
+		.client
+		.get(format!("{}/runner-configs", engine.endpoint))
+		.query(&[
+			("namespace", NAMESPACE),
+			("runner_name", POOL_NAME),
+			("limit", "1"),
+		])
+		.bearer_auth(TOKEN)
+		.send()
+		.await
+		.context("list runner configs")?;
+	let status = runner_configs_response.status();
+	let body = runner_configs_response
+		.text()
+		.await
+		.context("read runner configs")?;
+	if !status.is_success() {
+		bail!("list runner configs failed with {status}: {body}");
+	}
+	let runner_configs: RunnerConfigList =
+		serde_json::from_str(&body).context("decode runner configs")?;
+	Ok(runner_configs
+		.runner_configs
+		.get(POOL_NAME)
+		.map(|runner_config| {
+			runner_config
+				.datacenters
+				.values()
+				.any(|dc| dc.protocol_version.is_some())
+		})
+		.unwrap_or(false))
+}
+
+async fn create_counter_actor(engine: &TestEngine) -> Result<String> {
+	let response = engine
+		.client
+		.post(format!("{}/actors", engine.endpoint))
+		.query(&[("namespace", NAMESPACE)])
+		.bearer_auth(TOKEN)
+		.json(&json!({
+			"name": rivetkit_rust_counter_example::ACTOR_NAME,
+			"runner_name_selector": POOL_NAME,
+			"key": null,
+			"input": null,
+			"datacenter": null,
+			"crash_policy": "destroy",
+		}))
+		.send()
+		.await
+		.context("create counter actor")?;
+	let status = response.status();
+	let body = response.text().await.context("read actor response")?;
+	if !status.is_success() {
+		bail!("create actor failed with {status}: {body}");
+	}
+	let response: CreateActorResponse = serde_json::from_str(&body).context("decode actor")?;
+	Ok(response.actor.actor_id)
+}
+
+async fn wait_for_action(engine: &TestEngine, actor_id: &str, action: &str) -> Result<String> {
+	let deadline = Instant::now() + Duration::from_secs(30);
+	let mut last_error = None;
+	while Instant::now() < deadline {
+		match send_action(engine, actor_id, action).await {
+			Ok(body) => return Ok(body),
+			Err(err) => {
+				let message = err.to_string();
+				if !message.contains("actor_ready_timeout")
+					&& !message.contains("Service Unavailable")
+				{
+					return Err(err).context("actor action returned non-readiness error");
+				}
+				last_error = Some(err);
+				tokio::time::sleep(Duration::from_millis(250)).await;
+			}
+		}
+	}
+	match last_error {
+		Some(err) => Err(err).context("timed out waiting for action"),
+		None => bail!("timed out waiting for action"),
+	}
+}
+
+async fn send_action(engine: &TestEngine, actor_id: &str, action: &str) -> Result<String> {
+	let response = engine
+		.client
+		.post(format!(
+			"{}/gateway/{}/action/{}",
+			engine.endpoint, actor_id, action
+		))
+		.header("x-rivet-encoding", "json")
+		.header("content-type", "application/json")
+		.body(r#"{"args":[]}"#)
+		.send()
+		.await
+		.context("send action")?;
+	let status = response.status();
+	let body = response.text().await.context("read action response")?;
+	if !status.is_success() {
+		bail!(
+			"action failed with {status}: {body}\n\nengine stdout:\n{}\n\nengine stderr:\n{}",
+			engine.stdout_tail(),
+			engine.stderr_tail()
+		);
+	}
+	Ok(body)
+}
+
+fn action_output(body: &str) -> Result<JsonValue> {
+	let value: JsonValue = serde_json::from_str(body).context("decode action response")?;
+	Ok(value.get("output").cloned().unwrap_or(JsonValue::Null))
+}
+
+fn engine_binary_path() -> Result<PathBuf> {
+	if let Some(path) = std::env::var_os("RIVET_ENGINE_BINARY_PATH").map(PathBuf::from) {
+		return Ok(path);
+	}
+
+	let path = workspace_root().join("target/debug/rivet-engine");
+	if path.exists() {
+		return Ok(path);
+	}
+
+	bail!(
+		"engine binary not found at {}; run `cargo build -p rivet-engine` or set RIVET_ENGINE_BINARY_PATH",
+		path.display()
+	)
+}
+
+fn workspace_root() -> PathBuf {
+	Path::new(env!("CARGO_MANIFEST_DIR"))
+		.ancestors()
+		.nth(2)
+		.expect("example should live under examples/rust-counter")
+		.to_path_buf()
+}
+
+fn pick_port(label: &str) -> Result<u16> {
+	portpicker::pick_unused_port().with_context(|| format!("pick {label} port"))
+}
+
+async fn wait_for_engine_health(
+	client: &reqwest::Client,
+	endpoint: &str,
+	child: &mut Child,
+	stderr_path: &Path,
+) -> Result<()> {
+	let deadline = Instant::now() + Duration::from_secs(60);
+	let health_url = format!("{endpoint}/health");
+	while Instant::now() < deadline {
+		if let Some(status) = child.try_wait().context("poll engine child")? {
+			let stderr = tail_file(stderr_path);
+			bail!("engine exited before health check passed with {status}: {stderr}");
+		}
+
+		match client.get(&health_url).send().await {
+			Ok(response) if response.status() == StatusCode::OK => return Ok(()),
+			Ok(_) | Err(_) => tokio::time::sleep(Duration::from_millis(250)).await,
+		}
+	}
+
+	bail!(
+		"timed out waiting for engine health: {}",
+		tail_file(stderr_path)
+	)
+}
+
+async fn shutdown_child(child: &mut Child) {
+	if child.try_wait().ok().flatten().is_some() {
+		return;
+	}
+
+	let _ = child.start_kill();
+	let _ = tokio::time::timeout(Duration::from_secs(5), child.wait()).await;
+}
+
+fn tail_file(path: &Path) -> String {
+	let Ok(contents) = std::fs::read_to_string(path) else {
+		return String::new();
+	};
+	let mut lines = contents.lines().rev().take(80).collect::<Vec<_>>();
+	lines.reverse();
+	lines.join("\n")
+}

--- a/website/src/content/docs/actors/quickstart/index.mdx
+++ b/website/src/content/docs/actors/quickstart/index.mdx
@@ -10,6 +10,7 @@ import {
 	faNodeJs,
 	faReact,
 	faNextjs,
+	faRust,
 } from "@rivet-gg/icons";
 
 <Note>
@@ -40,6 +41,13 @@ npx skills add rivet-dev/skills
 		icon={faNextjs}
 	>
 		Build server-rendered Next.js experiences backed by actors
+	</Card>
+	<Card
+		title="Rust Quickstart (Preview)"
+		href="/docs/actors/quickstart/rust"
+		icon={faRust}
+	>
+		Run a RivetKit Rust counter actor with `rivetkit-core`
 	</Card>
 	<Card
 		title="Cloudflare Workers"

--- a/website/src/content/docs/actors/quickstart/rust.mdx
+++ b/website/src/content/docs/actors/quickstart/rust.mdx
@@ -1,0 +1,120 @@
+---
+title: "Rust Quickstart (Preview)"
+description: "Run a RivetKit Rust counter actor with rivetkit-core"
+skill: true
+---
+
+<Note>
+RivetKit Rust is in preview. This quickstart uses the low-level `rivetkit-core` API directly.
+</Note>
+
+## Steps
+
+<Steps>
+<Step title="Build The Local Engine">
+
+The Rust runtime connects to the Rivet Engine. Build the local engine binary once:
+
+```sh
+cargo build -p rivet-engine
+```
+
+</Step>
+
+<Step title="Run The Rust Counter">
+
+Start the example actor runtime. `RIVET_ENGINE_BINARY_PATH` tells `rivetkit-core` where to find `rivet-engine`; the runtime will spawn or reuse a local engine at `http://127.0.0.1:6420`.
+
+```sh
+cd examples/rust-counter
+RIVET_ENGINE_BINARY_PATH=../../target/debug/rivet-engine cargo run
+```
+
+If you prefer to run the engine yourself, start `rivet-engine start` separately and run the example with `RIVET_ENDPOINT` pointing at that engine.
+
+</Step>
+
+<Step title="Create A Counter Actor">
+
+In another terminal, create the default namespace and a `counter` actor. These examples use the local dev token `dev`.
+
+```sh
+curl -s -X POST 'http://127.0.0.1:6420/namespaces' \
+  -H 'authorization: Bearer dev' \
+  -H 'content-type: application/json' \
+  -d '{"name":"default","display_name":"Default"}'
+```
+
+```sh
+ACTOR_ID=$(curl -s -X POST 'http://127.0.0.1:6420/actors?namespace=default' \
+  -H 'authorization: Bearer dev' \
+  -H 'content-type: application/json' \
+  -d '{"name":"counter","runner_name_selector":"rivetkit-rust","key":null,"input":null,"datacenter":null,"crash_policy":"destroy"}' \
+  | jq -r '.actor.actor_id')
+```
+
+</Step>
+
+<Step title="Call Actions">
+
+Call `increment` to update the actor state:
+
+```sh
+curl -s -X POST "http://127.0.0.1:6420/gateway/$ACTOR_ID/action/increment" \
+  -H 'x-rivet-encoding: json' \
+  -H 'content-type: application/json' \
+  -d '{"args":[]}'
+```
+
+Read the current count:
+
+```sh
+curl -s -X POST "http://127.0.0.1:6420/gateway/$ACTOR_ID/action/get" \
+  -H 'x-rivet-encoding: json' \
+  -H 'content-type: application/json' \
+  -d '{"args":[]}'
+```
+
+</Step>
+
+<Step title="Inspect The Actor Code">
+
+The example registers a `counter` actor factory with `rivetkit-core` and handles action events in a receive loop:
+
+```rust examples/rust-counter/src/main.rs
+use anyhow::Result;
+use rivetkit_core::ServeConfig;
+use tokio_util::sync::CancellationToken;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+	let config = ServeConfig::from_env();
+	let shutdown = CancellationToken::new();
+	let registry = rivetkit_rust_counter_example::registry();
+	let serve = tokio::spawn({
+		let shutdown = shutdown.clone();
+		async move { registry.serve_with_config(config, shutdown).await }
+	});
+
+	tokio::signal::ctrl_c().await?;
+	shutdown.cancel();
+	serve.await??;
+
+	Ok(())
+}
+```
+
+Full source: [`examples/rust-counter`](https://github.com/rivet-dev/rivet/tree/main/examples/rust-counter).
+
+</Step>
+
+<Step title="Run The E2E Test">
+
+The example includes an e2e test that starts a temporary engine, serves the Rust registry, creates a counter actor, calls `increment` twice, and verifies `get` returns `2`.
+
+```sh
+cargo test -p rivetkit-rust-counter-example --test e2e -- --nocapture
+```
+
+</Step>
+</Steps>

--- a/website/src/content/docs/quickstart/index.mdx
+++ b/website/src/content/docs/quickstart/index.mdx
@@ -10,6 +10,7 @@ import {
 	faNodeJs,
 	faReact,
 	faNextjs,
+	faRust,
 } from "@rivet-gg/icons";
 
 <CardGroup cols={2}>
@@ -33,6 +34,13 @@ import {
 		icon={faNextjs}
 	>
 		Build server-rendered Next.js experiences backed by actors
+	</Card>
+	<Card
+		title="Rust Quickstart (Preview)"
+		href="/docs/actors/quickstart/rust"
+		icon={faRust}
+	>
+		Run a RivetKit Rust counter actor with `rivetkit-core`
 	</Card>
 	<Card
 		title="Cloudflare Workers"

--- a/website/src/sitemap/mod.ts
+++ b/website/src/sitemap/mod.ts
@@ -133,6 +133,11 @@ export const sitemap = [
 								href: "/docs/actors/quickstart/next-js",
 								icon: faNextjs,
 							},
+							{
+								title: "Rust (Preview)",
+								href: "/docs/actors/quickstart/rust",
+								icon: faRust,
+							},
 						],
 					},
 				]


### PR DESCRIPTION
Adds a dedicated RivetKit Rust quickstart marked as preview.

Documents how to build/run the local rivet-engine, start the examples/rust-counter runtime with rivetkit-core, create a counter actor, call actions, and run the example e2e test.