### PR TITLE
fix(rivetkit): support custom local engine ports

### DIFF
--- a/rivetkit-typescript/packages/devtools/src/mod.tsx
+++ b/rivetkit-typescript/packages/devtools/src/mod.tsx
@@ -59,11 +59,14 @@ const openDevtools = () => {
 		console.error("RivetKit Devtools: No client config found");
 		return;
 	}
-	const url = new URL("http://localhost:6420/ui");
 	if (!config.endpoint) {
 		console.error("RivetKit Devtools: No endpoint found in client config");
 		return;
 	}
+	const url = new URL(config.endpoint);
+	url.pathname = `${url.pathname.replace(/\/$/, "")}/ui`;
+	url.search = "";
+	url.hash = "";
 	url.searchParams.set("u", config.endpoint);
 	if (config.token) {
 		url.searchParams.set("t", config.token);

--- a/rivetkit-typescript/packages/rivetkit/runtime/index.ts
+++ b/rivetkit-typescript/packages/rivetkit/runtime/index.ts
@@ -1,5 +1,5 @@
 import { convertRegistryConfigToClientConfig } from "@/client/config";
-import { ENGINE_ENDPOINT } from "@/common/engine";
+import { isLocalEngineEndpoint } from "@/common/engine";
 import { configureBaseLogger, configureDefaultLogger } from "@/common/log";
 import {
 	getDatacenters,
@@ -22,7 +22,7 @@ function logLine(label: string, value: string): void {
 }
 
 async function ensureLocalRunnerConfig(config: RegistryConfig): Promise<void> {
-	if (config.endpoint !== ENGINE_ENDPOINT) {
+	if (!config.endpoint || !isLocalEngineEndpoint(config.endpoint)) {
 		return;
 	}
 
@@ -136,10 +136,9 @@ export class Runtime<A extends RegistryActors> {
 		}
 
 		if (this.#config.endpoint) {
-			const endpointType =
-				this.#config.endpoint === ENGINE_ENDPOINT
-					? "local native"
-					: "remote";
+			const endpointType = isLocalEngineEndpoint(this.#config.endpoint)
+				? "local native"
+				: "remote";
 			logLine("Endpoint", `${this.#config.endpoint} (${endpointType})`);
 		}
 

--- a/rivetkit-typescript/packages/rivetkit/src/common/engine.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/common/engine.ts
@@ -1,2 +1,22 @@
 export const ENGINE_PORT = 6420;
 export const ENGINE_ENDPOINT = `http://127.0.0.1:${ENGINE_PORT}`;
+
+export function isLocalEngineEndpoint(endpoint: string): boolean {
+	let url: URL;
+	try {
+		url = new URL(endpoint);
+	} catch {
+		return false;
+	}
+
+	const hostname = url.hostname.toLowerCase();
+	return (
+		hostname === "localhost" ||
+		hostname === "0.0.0.0" ||
+		hostname === "::" ||
+		hostname === "[::]" ||
+		hostname === "::1" ||
+		hostname === "[::1]" ||
+		/^127(?:\.\d{1,3}){0,3}$/.test(hostname)
+	);
+}

--- a/rivetkit-typescript/packages/rivetkit/src/registry/config/index.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/config/index.ts
@@ -10,7 +10,7 @@ import {
 	queueMetadataKey,
 	workflowStoragePrefix,
 } from "@/actor/keys";
-import { ENGINE_ENDPOINT } from "@/common/engine";
+import { ENGINE_ENDPOINT, isLocalEngineEndpoint } from "@/common/engine";
 import { type Logger, LogLevelSchema } from "@/common/log";
 import { VERSION } from "@/utils";
 import { tryParseEndpoint } from "@/utils/endpoint-parser";
@@ -312,11 +312,16 @@ export const RegistryConfigSchema = z
 				})
 			: undefined;
 
-		// Can't start a local engine and connect to a remote endpoint.
-		if (config.startEngine && parsedEndpoint) {
+		// Starting a local engine with an explicit endpoint is supported for
+		// alternate local ports, but remote endpoints cannot be spawned locally.
+		if (
+			config.startEngine &&
+			parsedEndpoint &&
+			!isLocalEngineEndpoint(parsedEndpoint.endpoint)
+		) {
 			ctx.addIssue({
 				code: "custom",
-				message: "cannot specify both startEngine and endpoint",
+				message: "startEngine can only be used with a local endpoint",
 			});
 		}
 
@@ -329,10 +334,11 @@ export const RegistryConfigSchema = z
 			});
 		}
 
-		// Flatten the endpoint and apply defaults for namespace/token
-		// If startEngine is enabled, set endpoint to the engine endpoint.
+		// Flatten the endpoint and apply defaults for namespace/token.
+		// If startEngine is enabled, use an explicit local endpoint if provided
+		// so callers can choose the local engine port; otherwise use the default.
 		const endpoint = config.startEngine
-			? ENGINE_ENDPOINT
+			? (parsedEndpoint?.endpoint ?? ENGINE_ENDPOINT)
 			: (parsedEndpoint?.endpoint ??
 				(isDevEnv ? ENGINE_ENDPOINT : undefined));
 		const validateServerlessEndpoint = Boolean(
@@ -367,7 +373,7 @@ export const RegistryConfigSchema = z
 		// In dev mode, clients connect directly to the local Rivet Engine.
 		const publicEndpoint =
 			parsedPublicEndpoint?.endpoint ??
-			(isDevEnv && config.startEngine ? ENGINE_ENDPOINT : undefined);
+			(isDevEnv && config.startEngine ? endpoint : undefined);
 		// We extract publicNamespace to validate that it matches the backend
 		// namespace (see validation above), not for functional use.
 		const publicNamespace = parsedPublicEndpoint?.namespace;

--- a/rivetkit-typescript/packages/rivetkit/src/registry/index.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/index.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { ENGINE_ENDPOINT } from "@/common/engine";
+import { isLocalEngineEndpoint } from "@/common/engine";
 import { configureServerlessPool } from "@/serverless/configure";
 import { detectRuntime, VERSION } from "@/utils";
 import { crossPlatformServe, loadRuntimeServeStatic } from "@/utils/serve";
@@ -700,7 +700,9 @@ export class Registry<A extends RegistryActors> {
 
 		if (config.endpoint) {
 			const endpointType =
-				config.endpoint === ENGINE_ENDPOINT ? "local native" : "remote";
+				config.startEngine || isLocalEngineEndpoint(config.endpoint)
+					? "local native"
+					: "remote";
 			logLine("Endpoint", `${config.endpoint} (${endpointType})`);
 		}
 

--- a/rivetkit-typescript/packages/rivetkit/tests/registry-constructor.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/registry-constructor.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { actor, setup } from "@/mod";
+import { RegistryConfigSchema } from "@/registry/config";
 import { buildNativeRegistry } from "../src/registry/native";
 
 const testActor = actor({
@@ -67,5 +68,40 @@ describe("Registry constructor", () => {
 		);
 		expect(serveConfig.namespace).toBe("after-build");
 		expect(serveConfig.poolName).toBe("after-build-pool");
+	});
+
+	test("can start a local engine on an explicit endpoint port", () => {
+		const config = RegistryConfigSchema.parse({
+			use: {
+				test: testActor,
+			},
+			startEngine: true,
+			endpoint: "http://127.0.0.1:7654",
+		});
+
+		expect(config.endpoint).toBe("http://127.0.0.1:7654/");
+		expect(config.publicEndpoint).toBe("http://127.0.0.1:7654/");
+	});
+
+	test("rejects startEngine with a remote endpoint", () => {
+		const result = RegistryConfigSchema.safeParse({
+			use: {
+				test: testActor,
+			},
+			startEngine: true,
+			endpoint: "https://api.rivet.dev",
+		});
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						message:
+							"startEngine can only be used with a local endpoint",
+					}),
+				]),
+			);
+		}
 	});
 });

--- a/website/src/content/docs/general/environment-variables.mdx
+++ b/website/src/content/docs/general/environment-variables.mdx
@@ -8,7 +8,7 @@ skill: true
 
 | Environment Variable | Description |
 |---------------------|-------------|
-| `RIVET_ENDPOINT` | Endpoint URL to connect to Rivet Engine. Supports [URL auth syntax](/docs/general/endpoints#url-auth-syntax). |
+| `RIVET_ENDPOINT` | Endpoint URL to connect to Rivet Engine. Supports [URL auth syntax](/docs/general/endpoints#url-auth-syntax). When `RIVET_RUN_ENGINE=1`, a local endpoint here also controls which port the spawned local engine binds to. Use a separate `RIVETKIT_STORAGE_PATH` when running multiple local engines concurrently. |
 | `RIVET_TOKEN` | Authentication token for Rivet Engine |
 | `RIVET_NAMESPACE` | Namespace to use (default: "default") |
 
@@ -60,7 +60,7 @@ These variables configure how clients connect to your actors.
 | Environment Variable | Description |
 |---------------------|-------------|
 | `RIVETKIT_RUNTIME` | Runtime binding to use for RivetKit core: `auto`, `native`, or `wasm`. Defaults to `auto`. |
-| `RIVETKIT_STORAGE_PATH` | Overrides the default file-system storage path used by RivetKit when using the default driver. |
+| `RIVETKIT_STORAGE_PATH` | Overrides the default file-system storage path used by RivetKit when using the default driver. Set this alongside a custom local `RIVET_ENDPOINT` when running multiple local engines concurrently. |
 
 ## Logging
 


### PR DESCRIPTION
## Summary
- allow `startEngine: true` to use an explicit local `endpoint`, so local engines can bind to non-default ports
- keep rejecting `startEngine` with remote endpoints
- classify any local endpoint as local/native in runtime logging and open devtools against the configured endpoint instead of hardcoded `localhost:6420`
- document `RIVET_ENDPOINT` as the way to select the spawned local engine port when `RIVET_RUN_ENGINE=1`

## User stories
- As a developer running multiple local app checkouts, I can start each checkout with its own Rivet engine port instead of all colliding on 6420.
- As a RivetKit user, I can still rely on `startEngine` being local-only; remote endpoints remain rejected when trying to spawn a local engine.
- As a devtools user, opening devtools follows the configured local engine endpoint rather than assuming the default port.

## Why this approach
- The Rust engine already derives bind ports from the configured endpoint; the TypeScript config validation/defaulting was the blocker.
- Reusing `RIVET_ENDPOINT` keeps the public surface small and avoids overloading generic app `PORT` variables.
- The local-endpoint helper centralizes the distinction between local native and remote endpoints for validation and logging.
- Concurrent local engines also need separate storage roots because RocksDB takes an exclusive lock; this is documented via `RIVETKIT_STORAGE_PATH`.

## Validation
- `git diff --check`
- `pnpm --filter rivetkit run check-types`
- `pnpm --filter rivetkit run build`
- `pnpm --filter @rivetkit/rivetkit-napi run build:force`
- `cargo build -p rivet-engine`
- Smoke tested `examples/hello-world` with `RIVET_RUN_ENGINE=1`, `RIVET_ENDPOINT=http://127.0.0.1:7654`, `RIVET_ENGINE_BINARY=/Users/hamish/Developer/rivet/target/debug/rivet-engine`, and an isolated `RIVETKIT_STORAGE_PATH` while another engine was already listening on 6420:
  - `lsof` showed `rivet-engine` listening on `127.0.0.1:7654`, `7655`, and `7664`
  - `curl http://127.0.0.1:7654/health` returned `{"runtime":"engine","status":"ok","version":"2.3.0-rc.12"}`
  - a `rivetkit/client` call to the hello-world `counter` actor returned `increment 2` and `count 2`
- `pnpm --filter rivetkit exec vitest run tests/registry-constructor.test.ts` partially ran: the new tests passed, but the existing "reads config mutations made before the native registry is built" test is blocked in this checkout by missing `@rivetkit/rivetkit-napi-darwin-arm64` until the local NAPI artifact is built.

## Notes
- Direct push to `rivet-dev/rivet` was denied for my GitHub account, so this PR is opened from the `hami-sh/rivet` fork.
