### PR TITLE
feat(pricing): add Rivet Compute pricing and calculator

### DIFF
--- a/frontend/src/app/billing/billing-page.tsx
+++ b/frontend/src/app/billing/billing-page.tsx
@@ -12,6 +12,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { endOfMonth, startOfMonth } from "date-fns";
 import { BillingPlans } from "@/app/billing/billing-plans";
 import { BillingStatus } from "@/app/billing/billing-status";
+import { ComputeUsageCard } from "@/app/billing/compute-card";
 import { CurrentBillTotal } from "@/app/billing/current-bill-card";
 import { useBilledMetrics } from "@/app/billing/hooks";
 import { ManageBillingButton } from "@/app/billing/manage-billing-button";
@@ -186,6 +187,7 @@ export function BillingBody() {
 					);
 				},
 			)}
+			<ComputeUsageCard />
 		</div>
 	);
 }

--- a/frontend/src/app/billing/compute-card.tsx
+++ b/frontend/src/app/billing/compute-card.tsx
@@ -1,0 +1,146 @@
+import {
+	faMemory,
+	faMicrochip,
+	faServer,
+	Icon,
+	type IconProp,
+} from "@rivet-gg/icons";
+import { cn } from "@/components";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { COMPUTE } from "@/content/billing";
+
+interface ComputeRate {
+	icon: IconProp;
+	label: string;
+	rate: number;
+	unit: string;
+}
+
+const COMPUTE_RATES: ComputeRate[] = [
+	{
+		icon: faMicrochip,
+		label: "CPU",
+		rate: COMPUTE.cpuPerVcpuSecond,
+		unit: "per vCPU-second",
+	},
+	{
+		icon: faMemory,
+		label: "Memory",
+		rate: COMPUTE.memoryPerGibSecond,
+		unit: "per GiB-second",
+	},
+];
+
+/** Renders the per-second compute rate, e.g. `$0.0000330`. */
+function formatRate(rate: number): string {
+	return `$${rate.toFixed(7)}`;
+}
+
+const CAPS_NOTE = `Billed per active second. Up to ${COMPUTE.maxVcpu} vCPU (Free plan is limited to ${COMPUTE.freeMaxVcpu} vCPU and capped at $5/month of compute). One vCPU is half a physical core. You can also bring your own compute and run your actors and applications on AWS, Vercel, Railway, or bare metal, paid directly to your provider.`;
+
+/** Full-page compute pricing card, matching the usage cards on the billing page. */
+export function ComputeUsageCard() {
+	return (
+		<Card className="w-full border border-border bg-card shadow-sm">
+			<CardHeader className="flex flex-row items-start justify-between space-y-0 pb-4">
+				<div className="flex items-start gap-3">
+					<div className="flex h-8 w-8 items-center justify-center rounded-full border border-border">
+						<Icon
+							icon={faServer}
+							className="h-4 w-4 text-foreground"
+						/>
+					</div>
+					<div>
+						<h3 className="text-base font-semibold text-foreground">
+							Compute
+						</h3>
+						<p className="text-sm text-muted-foreground">
+							Run your actors and applications on Rivet Compute,
+							billed per active second by configured CPU and
+							memory.
+						</p>
+					</div>
+				</div>
+			</CardHeader>
+			<CardContent className="pt-0">
+				<div className="rounded-lg border border-border bg-muted/30 divide-y divide-border">
+					{COMPUTE_RATES.map((rate) => (
+						<div
+							key={rate.label}
+							className="flex items-center justify-between px-5 py-3.5"
+						>
+							<div className="flex items-center gap-3">
+								<Icon
+									icon={rate.icon}
+									className="size-4 text-muted-foreground"
+								/>
+								<span className="text-sm font-medium text-foreground">
+									{rate.label}
+								</span>
+							</div>
+							<div className="text-right">
+								<span className="text-sm tabular-nums font-medium text-foreground">
+									{formatRate(rate.rate)}
+								</span>
+								<span className="ml-2 text-xs text-muted-foreground">
+									{rate.unit}
+								</span>
+							</div>
+						</div>
+					))}
+				</div>
+				<p className="mt-3 text-xs text-muted-foreground leading-relaxed">
+					{CAPS_NOTE}
+				</p>
+			</CardContent>
+		</Card>
+	);
+}
+
+/** Compact compute pricing rows for the settings billing drawer. */
+export function ComputeUsageRows() {
+	return (
+		<div>
+			<div className="px-5 pt-5 pb-4">
+				<h3 className="text-sm font-semibold text-foreground">
+					Compute
+				</h3>
+				<p className="mt-0.5 text-xs text-muted-foreground">
+					Billed per active second by configured CPU and memory.
+				</p>
+			</div>
+			<div className="border-t border-foreground/10">
+				{COMPUTE_RATES.map((rate, idx) => (
+					<div
+						key={rate.label}
+						className={cn(
+							"flex items-center justify-between px-5 py-3.5",
+							idx < COMPUTE_RATES.length - 1 &&
+								"border-b border-foreground/10",
+						)}
+					>
+						<div className="flex items-center gap-3">
+							<div className="flex size-7 items-center justify-center rounded-md border border-foreground/10">
+								<Icon icon={rate.icon} className="size-3.5" />
+							</div>
+							<span className="text-sm font-medium text-foreground">
+								{rate.label}
+							</span>
+						</div>
+						<div className="text-right">
+							<div className="text-sm tabular-nums font-medium text-foreground">
+								{formatRate(rate.rate)}
+							</div>
+							<div className="text-[11px] text-muted-foreground">
+								{rate.unit}
+							</div>
+						</div>
+					</div>
+				))}
+			</div>
+			<p className="px-5 pt-3 pb-4 text-[11px] text-muted-foreground leading-relaxed">
+				{CAPS_NOTE}
+			</p>
+		</div>
+	);
+}

--- a/frontend/src/app/billing/plan-card.tsx
+++ b/frontend/src/app/billing/plan-card.tsx
@@ -77,6 +77,8 @@ export const CommunityPlan = (props: Partial<PlanCardProps>) => {
 			title="Free"
 			price="$0"
 			features={[
+				{ icon: faCheck, label: "1 vCPU Max" },
+				{ icon: faCheck, label: "$5 /mo Compute Limit" },
 				{ icon: faCheck, label: "5 Million Writes /mo Limit" },
 				{ icon: faCheck, label: "200 Million Reads /mo Limit" },
 				{ icon: faCheck, label: "5GiB Storage Limit" },
@@ -96,6 +98,7 @@ export const ProPlan = (props: Partial<PlanCardProps>) => {
 			price="$20"
 			usageBased
 			features={[
+				{ icon: faPlus, label: "Up to 8 vCPU" },
 				{
 					icon: faPlus,
 					label: "25 Billion Read /mo included",
@@ -124,6 +127,7 @@ export const TeamPlan = (props: Partial<PlanCardProps>) => {
 			price="$200"
 			usageBased
 			features={[
+				{ icon: faPlus, label: "Up to 8 vCPU" },
 				{ icon: faPlus, label: "25 Billion Reads /mo included" },
 				{ icon: faPlus, label: "50 Million Writes /mo included" },
 				{ icon: faPlus, label: "5GiB Storage included" },

--- a/frontend/src/app/settings-pages/billing-panel.tsx
+++ b/frontend/src/app/settings-pages/billing-panel.tsx
@@ -14,6 +14,7 @@ import { useMatch } from "@tanstack/react-router";
 import { endOfMonth, startOfMonth } from "date-fns";
 import { Suspense, useState } from "react";
 import { BillingPlans } from "@/app/billing/billing-plans";
+import { ComputeUsageRows } from "@/app/billing/compute-card";
 import { useBilledMetrics } from "@/app/billing/hooks";
 import { ManageBillingButton } from "@/app/billing/manage-billing-button";
 import { formatMetricValue, type MetricType } from "@/app/billing/usage-card";
@@ -254,6 +255,12 @@ function BillingDrawerBody() {
 							/>
 						);
 					})}
+				</SettingsCard>
+			</div>
+
+			<div>
+				<SettingsCard divided>
+					<ComputeUsageRows />
 				</SettingsCard>
 			</div>
 		</div>

--- a/frontend/src/content/billing.ts
+++ b/frontend/src/content/billing.ts
@@ -87,3 +87,27 @@ export const BILLING = {
 		gateway_egress: 150n,
 	} satisfies Record<BilledMetrics, bigint>,
 };
+
+/**
+ * Rivet Compute pricing. Compute is billed per active second based on each
+ * actor's configured CPU and memory.
+ *
+ * cost = active_seconds × (vcpus × cpu_per_vcpu_second + memory_gib × memory_per_gib_second)
+ *
+ * One vCPU is half a physical core. The Free plan is limited to 1 vCPU; paid
+ * plans allow up to 8 vCPU.
+ */
+export const COMPUTE = {
+	cpuPerVcpuSecond: 0.000033,
+	memoryPerGibSecond: 0.0000029,
+	maxVcpu: 8,
+	freeMaxVcpu: 1,
+};
+
+/** Compute cost in dollars per active second for the given actor config. */
+export function computeCostPerSecond(vcpus: number, memoryMb: number): number {
+	return (
+		vcpus * COMPUTE.cpuPerVcpuSecond +
+		(memoryMb / 1024) * COMPUTE.memoryPerGibSecond
+	);
+}

--- a/website/src/components/marketing/pricing/PricingPageClient.tsx
+++ b/website/src/components/marketing/pricing/PricingPageClient.tsx
@@ -14,7 +14,10 @@ import {
   Command,
   Network,
   HardDrive,
-  Laptop
+  Laptop,
+  Cpu,
+  MemoryStick,
+  Clock
 } from 'lucide-react';
 import rivetLogoWhite from '@/images/rivet-logos/icon-white.svg';
 import imgYC from '@/images/logos/yc.svg';
@@ -358,11 +361,13 @@ const SelfHostingComparison = () => {
 
 const ComparisonTable = () => {
     const features = [
-      { name: "Awake Actor Hours", free: "100,000", hobby: "400,000", team: "400,000", ent: "Custom" },
-      { name: "Storage", free: "5GB", hobby: "5GB", team: "5GB", ent: "Custom" },
-      { name: "Reads / mo", free: "200 Million", hobby: "25 Billion", team: "25 Billion", ent: "Custom" },
-      { name: "Writes / mo", free: "5 Million", hobby: "50 Million", team: "50 Million", ent: "Custom" },
-      { name: "Egress", free: "100GB", hobby: "1TB", team: "1TB", ent: "Custom" },
+      { name: "Awake Actor Hours", free: "100,000 max", hobby: "400,000 included", team: "400,000 included", ent: "Custom" },
+      { name: "Compute", free: "$5 max", hobby: "Usage-based", team: "Usage-based", ent: "Custom" },
+      { name: "Max vCPU", free: "1", hobby: "8", team: "8", ent: "Custom" },
+      { name: "Storage", free: "5GB max", hobby: "5GB included", team: "5GB included", ent: "Custom" },
+      { name: "Reads / mo", free: "200 Million max", hobby: "25 Billion included", team: "25 Billion included", ent: "Custom" },
+      { name: "Writes / mo", free: "5 Million max", hobby: "50 Million included", team: "50 Million included", ent: "Custom" },
+      { name: "Egress", free: "100GB max", hobby: "1TB included", team: "1TB included", ent: "Custom" },
       { name: "Support", free: "Community", hobby: "Email", team: "Slack & Email", ent: "Slack & Email" },
       { name: "MFA", free: false, hobby: false, team: true, ent: true },
       { name: "Custom Regions", free: false, hobby: false, team: false, ent: true },
@@ -409,9 +414,157 @@ const ComparisonTable = () => {
                     </tbody>
                 </table>
             </div>
+            <p className="mt-6 text-xs text-zinc-500">
+                Free plan values are hard monthly limits. Hobby and Team include the listed amounts, then bill per usage; paid compute has no included amount and is billed per usage.
+            </p>
         </div>
     );
   };
+
+// Rivet Compute pricing. Cost is billed per active second based on each actor's
+// configured CPU and memory:
+//   cost = active_seconds × (vcpus × CPU_PER_VCPU_SECOND + memory_gib × MEMORY_PER_GIB_SECOND)
+// One vCPU is half a physical core. The Free plan is limited to 1 vCPU; paid plans
+// allow up to 8 vCPU.
+const COMPUTE = {
+    cpuPerVcpuSecond: 0.000033,
+    memoryPerGibSecond: 0.0000029,
+    maxVcpu: 8,
+    freeMaxVcpu: 1,
+};
+
+// Valid compute shapes. vCPU is continuous from 0.08 to 1, then exactly 2, 4,
+// or 8. Memory ranges from 128 MiB to 4096 MiB (4 GiB).
+const VCPU_STEPS = [0.08, 0.25, 0.5, 1, 2, 4, 8];
+const MEMORY_STEPS = [128, 256, 512, 1024, 2048, 4096]; // MiB
+
+const usd = (n, decimals = 2) =>
+    `$${n.toLocaleString("en-US", { minimumFractionDigits: decimals, maximumFractionDigits: decimals })}`;
+
+const ComputeCalculator = () => {
+    const [vcpuIdx, setVcpuIdx] = useState(3); // 1 vCPU
+    const [memIdx, setMemIdx] = useState(2); // 512 MiB
+    const [hours, setHours] = useState(100);
+
+    const vcpus = VCPU_STEPS[vcpuIdx];
+    const memoryMib = MEMORY_STEPS[memIdx];
+    const cpuPerSec = vcpus * COMPUTE.cpuPerVcpuSecond;
+    const memPerSec = (memoryMib / 1024) * COMPUTE.memoryPerGibSecond;
+    const perSecond = cpuPerSec + memPerSec;
+    const monthly = perSecond * hours * 3600;
+
+    const memLabel = memoryMib >= 1024 ? `${memoryMib / 1024} GiB` : `${memoryMib} MiB`;
+
+    return (
+        <div className="border-t border-white/10 pt-16 mt-12">
+            <h3 className="mb-3 text-2xl font-normal tracking-tight text-white">Estimate your compute</h3>
+            <p className="mb-8 max-w-2xl text-base leading-relaxed text-zinc-500">
+                Run your actors and applications on Rivet Compute and pay only for the seconds they are active.
+                Costs scale with the CPU and memory you configure.
+            </p>
+
+            <div className="grid gap-8 lg:grid-cols-2">
+                {/* Controls */}
+                <div className="space-y-8 rounded-lg border border-white/10 bg-black p-8">
+                    {/* vCPU */}
+                    <div>
+                        <div className="mb-3 flex items-center justify-between">
+                            <span className="flex items-center gap-2 text-sm text-zinc-300">
+                                <Cpu className="h-4 w-4 text-zinc-500" /> vCPU
+                            </span>
+                            <span className="font-mono text-sm text-white">{vcpus}</span>
+                        </div>
+                        <input
+                            type="range"
+                            min={0}
+                            max={VCPU_STEPS.length - 1}
+                            step={1}
+                            value={vcpuIdx}
+                            onChange={(e) => setVcpuIdx(Number(e.target.value))}
+                            className="w-full accent-[#FF4500]"
+                        />
+                        <p className="mt-2 text-xs text-zinc-500">
+                            1 vCPU = half a physical core. 0.08–1 vCPU, or exactly 2, 4, or 8.
+                        </p>
+                    </div>
+
+                    {/* Memory */}
+                    <div>
+                        <div className="mb-3 flex items-center justify-between">
+                            <span className="flex items-center gap-2 text-sm text-zinc-300">
+                                <MemoryStick className="h-4 w-4 text-zinc-500" /> Memory
+                            </span>
+                            <span className="font-mono text-sm text-white">{memLabel}</span>
+                        </div>
+                        <input
+                            type="range"
+                            min={0}
+                            max={MEMORY_STEPS.length - 1}
+                            step={1}
+                            value={memIdx}
+                            onChange={(e) => setMemIdx(Number(e.target.value))}
+                            className="w-full accent-[#FF4500]"
+                        />
+                        <p className="mt-2 text-xs text-zinc-500">
+                            128 MiB to 4 GiB.
+                        </p>
+                    </div>
+
+                    {/* Active time */}
+                    <div>
+                        <div className="mb-3 flex items-center justify-between">
+                            <span className="flex items-center gap-2 text-sm text-zinc-300">
+                                <Clock className="h-4 w-4 text-zinc-500" /> Active hours / month
+                            </span>
+                            <span className="font-mono text-sm text-white">{hours >= 730 ? "Always on" : `${hours} h`}</span>
+                        </div>
+                        <input
+                            type="range"
+                            min={1}
+                            max={730}
+                            step={1}
+                            value={hours}
+                            onChange={(e) => setHours(Number(e.target.value))}
+                            className="w-full accent-[#FF4500]"
+                        />
+                        <p className="mt-2 text-xs text-zinc-500">
+                            Sleeping actors are not billed for compute.
+                        </p>
+                    </div>
+                </div>
+
+                {/* Result */}
+                <div className="flex flex-col rounded-lg border border-[#FF4500]/30 bg-black p-8">
+                    <span className="text-xs font-medium uppercase tracking-wider text-zinc-500">Estimated compute</span>
+                    <div className="mt-2 flex items-baseline gap-2">
+                        <span className="text-4xl font-normal tracking-tight text-white">{usd(monthly)}</span>
+                        <span className="font-mono text-xs text-zinc-500">/mo</span>
+                    </div>
+
+                    <div className="mt-8 space-y-3 font-mono text-sm">
+                        <div className="flex items-center justify-between border-b border-white/5 py-2">
+                            <span className="text-zinc-500">CPU ({vcpus} vCPU)</span>
+                            <span className="text-zinc-300">{usd(cpuPerSec * hours * 3600)}</span>
+                        </div>
+                        <div className="flex items-center justify-between border-b border-white/5 py-2">
+                            <span className="text-zinc-500">Memory ({memLabel})</span>
+                            <span className="text-zinc-300">{usd(memPerSec * hours * 3600)}</span>
+                        </div>
+                        <div className="flex items-center justify-between py-2">
+                            <span className="text-zinc-500">Rate</span>
+                            <span className="text-zinc-300">{usd(perSecond, 7)}/s</span>
+                        </div>
+                    </div>
+
+                    <p className="mt-auto pt-8 text-xs leading-relaxed text-zinc-500">
+                        Estimate only. Or bring your own compute and run your actors and applications on AWS, Vercel,
+                        Railway, or bare metal, paid directly to your provider.
+                    </p>
+                </div>
+            </div>
+        </div>
+    );
+};
 
 const Pricing = () => {
     const [isCloud, setIsCloud] = useState(true);
@@ -424,6 +577,8 @@ const Pricing = () => {
             desc: "For prototyping and small projects.",
             features: [
                 "100,000 Awake Actor Hours /mo limit",
+                "$5 /mo Compute limit",
+                "1 vCPU Max",
                 "5GB Limit",
                 "5 Million Writes /mo Limit",
                 "200 Million Reads /mo Limit",
@@ -441,6 +596,7 @@ const Pricing = () => {
             desc: "For scaling applications.",
             features: [
                 "400,000 Awake Actor Hours Included",
+                "Up to 8 vCPU",
                 "25 Billion Reads /mo included",
                 "50 Million Writes /mo included",
                 "5GB Storage included",
@@ -458,6 +614,7 @@ const Pricing = () => {
             desc: "For growing teams and businesses.",
             features: [
                 "400,000 Awake Actor Hours Included",
+                "Up to 8 vCPU",
                 "25 Billion Reads /mo included",
                 "50 Million Writes /mo included",
                 "5GB Storage included",
@@ -539,7 +696,7 @@ const Pricing = () => {
         { resource: "Reads*", price: "$0.20", unit: "per million reads" },
         { resource: "Writes*", price: "$1", unit: "per million writes" },
         { resource: "Egress", price: "$0.15", unit: "per GB" },
-        { resource: "Compute", price: "BYO", unit: "Paid to your provider" },
+        { resource: "Compute", prefix: "From", price: "$0.0000330", unit: "per vCPU-second + $0.0000029/GiB-s" },
     ];
 
     return (
@@ -552,7 +709,7 @@ const Pricing = () => {
                         </h2>
                         <p className="mb-6 max-w-xl text-base leading-relaxed text-zinc-500">
                             {isCloud
-                                ? "Pay for coordination and state. Compute costs are billed directly by your chosen cloud provider."
+                                ? "Pay for coordination, state, and compute. Run your actors and applications on Rivet Compute, or bring your own and run them anywhere."
                                 : "Deploy Rivet inside your VPC, your customer's environment, or fully air-gapped. Use the compliance posture you already have."
                             }
                         </p>
@@ -673,13 +830,17 @@ const Pricing = () => {
                                     {usagePricing.map((item, i) => (
                                         <div key={i} className="border-t border-white/10 pt-6">
                                             <div className="mb-2 text-xs font-medium uppercase tracking-wider text-zinc-500">{item.resource}</div>
-                                            <div className={`mb-1 text-2xl font-normal ${item.price === "BYO" ? "text-zinc-500" : "text-white"}`}>{item.price}</div>
+                                            {item.prefix && <span className="text-zinc-500 text-[10px] font-medium uppercase tracking-wider block">{item.prefix}</span>}
+                                            <div className="mb-1 text-2xl font-normal text-white">{item.price}</div>
                                             <div className="text-xs text-zinc-500">{item.unit}</div>
                                         </div>
                                     ))}
                                 </div>
                                 <p className="mt-6 text-xs text-zinc-500">* Reads and writes to persisted actor state, not in-memory operations within an actor</p>
+                                <p className="mt-2 text-xs text-zinc-500">Compute runs on Rivet Compute, billed per active second. Or bring your own compute and run your actors and applications on AWS, Vercel, Railway, or bare metal, paid directly to your provider.</p>
                             </div>
+
+                            <ComputeCalculator />
 
                             <ComparisonTable />
                         </>


### PR DESCRIPTION
## What

Adds **Rivet Compute** pricing across the public pricing page and the dashboard billing section.

Pricing formula (billed per active second, per actor config):

```
cost = active_seconds × ( vCPUs × $0.0000330  +  (memoryMB / 1024) × $0.0000029 )
```

- **8 vCPU max** per actor; **Free plan capped at 1 vCPU**. One vCPU is half a physical core.
- CPU is the pricier coefficient, memory billed per GiB-second (matches the competitor comparison table).

## Pricing page (`website/.../PricingPageClient.tsx`)

- New interactive **compute calculator** ("Estimate your compute") with a **Free / Paid plan toggle**, vCPU / memory / active-hours sliders, a live monthly estimate, a CPU/memory breakdown, and the per-second rate. Selecting **Free clamps and disables the vCPU slider at 1**.
- Usage-pricing **Compute** card changed from `BYO` → `From $0.0000330 / per vCPU-second + $0.0000029/GiB-s`.
- **Plan cards** now list vCPU: Free → "1 vCPU Max per Actor"; Hobby/Team → "Up to 8 vCPU per Actor".
- **Compare Plans table** gains a "Max vCPU / Actor" row (Free 1, Hobby 8, Team 8, Enterprise Custom).
- Keeps BYO explicit: notes make clear you can still run actors on AWS, Vercel, Railway, or bare metal, paid to your provider.

## Dashboard billing

- `frontend/src/content/billing.ts` — new `COMPUTE` rate constant + `computeCostPerSecond()` helper (single source of truth).
- New `frontend/src/app/billing/compute-card.tsx` — `ComputeUsageCard` (billing page) and `ComputeUsageRows` (settings drawer), reusing existing card chrome, noting the 8 vCPU max / 1 vCPU Free cap.
- Plan cards (`plan-card.tsx`) list vCPU max for parity (Free 1, Hobby/Team up to 8).
- Wired into `billing-page.tsx` and `settings-pages/billing-panel.tsx`.

## Notes / follow-up

- The engine has **no `compute` metric** today (`engine/packages/namespace/src/keys/metric.rs` meters `actor_awake`, `kv_*`, `gateway_egress`). Compute is therefore shown as a **pricing reference**, not a live-usage/overage line item. Actually metering + charging config-aware compute needs a backend change and is out of scope here.

## Verification

- Dashboard files typecheck clean (remaining `pnpm check-types` errors are pre-existing, from the unbuilt `@rivetkit/engine-api-full` package).
- Verified live in the browser: Paid 8 vCPU + 512 MB × 100 h → **$95.56/mo**; Free clamps to 1 vCPU → **$12.40/mo**. Plan cards and comparison table render the vCPU caps.