### PR TITLE
fix(cli): strip protocol from registry endpoint for Docker tags

### DIFF
--- a/engine/packages/cli/src/cloud.rs
+++ b/engine/packages/cli/src/cloud.rs
@@ -257,7 +257,9 @@ pub async fn wait_for_pool(
 }
 
 pub fn registry_endpoint(cloud_api: &str) -> Result<String> {
-	derive_endpoint(cloud_api, "registry")
+	let url = derive_endpoint(cloud_api, "registry")?;
+	// Strip the scheme for Docker image references
+	Ok(url.trim_start_matches("https://").trim_start_matches("http://").to_string())
 }
 
 pub fn dashboard_endpoint(cloud_api: &str) -> Result<String> {


### PR DESCRIPTION
## Summary
- Fixes Docker deployment failing with "invalid reference format" error
- The `registry_endpoint` function was returning full URLs like `https://registry.rivet.dev`
- Docker image tags cannot contain `://`, so this strips the protocol prefix

## Test plan
- [x] Tested locally with `rivet deploy --token` - deployment now succeeds
- Docker now receives valid image references like `registry.rivet.dev/project:tag`