### PR TITLE
Website: actors hero cleanup, changelog pill restyle, /docs/connect redirect fix, hide cookbooks + comparison guides from SEO

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -53,7 +53,13 @@ export default defineConfig({
 			applyBaseStyles: false,
 		}),
 		sitemap({
-			filter: (page) => !page.includes('/api/') && !page.includes('/internal/'),
+			// Cookbooks and comparison guides are intentionally hidden from the site
+			// and kept out of SEO, so exclude them from the sitemap.
+			filter: (page) =>
+				!page.includes('/api/') &&
+				!page.includes('/internal/') &&
+				!page.includes('/cookbook') &&
+				!page.includes('/compare'),
 		}),
 		sentry({
       		project: "website",

--- a/website/src/components/Footer.jsx
+++ b/website/src/components/Footer.jsx
@@ -37,9 +37,6 @@ const footer = {
 		{ name: "Status Page", href: "https://rivet.betteruptime.com/" },
 	],
 	resources: [
-		{ name: "Cookbooks", href: "/cookbook" },
-		{ name: "Rivet vs Cloudflare Durable Objects", href: "/compare/rivet-vs-cloudflare-durable-objects" },
-		{ name: "Rivet vs Temporal", href: "/compare/rivet-vs-temporal" },
 		{ name: "Blog", href: "/blog" },
 		{ name: "YC & Speedrun Deal", href: "/startups" },
 		{ name: "Open-Source Friends", href: "/oss-friends" },

--- a/website/src/components/marketing/sections/RedesignedHero.tsx
+++ b/website/src/components/marketing/sections/RedesignedHero.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect, useRef, useState, type MouseEvent } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Terminal, ArrowRight, Check } from 'lucide-react';
 import { AnimatePresence, motion, useScroll, useTransform } from 'framer-motion';
 import { HERO_H1_CLASS } from '../typography';
+import { GLOW_PILL_CLASS, handleGlowPillMouseMove } from '../glowPill';
 
 interface ThinkingImage {
   src: string;
@@ -226,12 +227,6 @@ export const RedesignedHero = ({ latestChangelogTitle, thinkingImages }: Redesig
   });
   const heroOpacity = useTransform(scrollYProgress, [0, 0.55], [1, 0]);
 
-  const handleChangelogPillMouseMove = (event: MouseEvent<HTMLAnchorElement>) => {
-    const rect = event.currentTarget.getBoundingClientRect();
-    event.currentTarget.style.setProperty('--pill-x', `${event.clientX - rect.left}px`);
-    event.currentTarget.style.setProperty('--pill-y', `${event.clientY - rect.top}px`);
-  };
-
   return (
     <motion.section
       ref={heroRef}
@@ -249,21 +244,19 @@ export const RedesignedHero = ({ latestChangelogTitle, thinkingImages }: Redesig
             >
               <a
                 href='/changelog'
-                className='changelog-pill-border group relative inline-flex rounded-full shadow-[0_8px_24px_-18px_rgba(27,25,22,0.45)] transition-opacity before:pointer-events-none before:absolute before:inset-0 before:rounded-full before:bg-[linear-gradient(120deg,rgba(27,25,22,0.08),rgba(27,25,22,0.26)_48%,rgba(255,255,255,0.88)_72%,rgba(27,25,22,0.1))] before:p-px before:[-webkit-mask:linear-gradient(#fff_0_0)_content-box,linear-gradient(#fff_0_0)] before:[-webkit-mask-composite:xor] before:[mask-composite:exclude] after:pointer-events-none after:absolute after:inset-0 after:rounded-full after:p-px after:opacity-0 after:transition-opacity after:duration-150 after:[-webkit-mask:linear-gradient(#fff_0_0)_content-box,linear-gradient(#fff_0_0)] after:[-webkit-mask-composite:xor] after:[mask-composite:exclude] hover:opacity-95 hover:after:opacity-100'
-                onMouseMove={handleChangelogPillMouseMove}
+                className={`${GLOW_PILL_CLASS} group inline-flex items-center gap-2 rounded-full border border-ink/12 bg-paper/45 px-2.5 py-1 text-[13px] text-ink-soft shadow-[0_8px_22px_-20px_rgba(27,25,22,0.45)] transition-colors hover:border-ink/25 hover:text-ink`}
+                onMouseMove={handleGlowPillMouseMove}
               >
-                <span className='relative z-10 inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium text-ink'>
-                  <span
-                    aria-hidden='true'
-                    className='h-1 w-1 rounded-full bg-accent'
-                    style={{
-                      boxShadow:
-                        '0 0 2px rgba(203, 90, 51, 0.9), 0 0 6px rgba(203, 90, 51, 0.5), 0 0 14px rgba(171, 69, 31, 0.35)',
-                    }}
-                  />
-                  <span>{latestChangelogTitle}</span>
-                  <ArrowRight className='h-3 w-3 text-ink-soft transition-transform group-hover:translate-x-0.5' />
-                </span>
+                <span
+                  aria-hidden='true'
+                  className='h-1 w-1 rounded-full bg-accent'
+                  style={{
+                    boxShadow:
+                      '0 0 2px rgba(203, 90, 51, 0.9), 0 0 6px rgba(203, 90, 51, 0.5), 0 0 14px rgba(171, 69, 31, 0.35)',
+                  }}
+                />
+                <span>{latestChangelogTitle}</span>
+                <ArrowRight className='h-3 w-3 text-ink-soft transition-transform group-hover:translate-x-0.5' />
               </a>
             </motion.div>
 

--- a/website/src/components/v2/Header.tsx
+++ b/website/src/components/v2/Header.tsx
@@ -559,14 +559,6 @@ export function Header({
 									</>
 								)}
 								{!isAgentOs && (
-									<TextNavItem
-										href="/cookbook"
-										ariaCurrent={active === "cookbook" ? "page" : undefined}
-									>
-										Cookbooks
-									</TextNavItem>
-								)}
-								{!isAgentOs && (
 									<TextNavItem href="/enterprise">
 										Enterprise
 									</TextNavItem>
@@ -671,12 +663,6 @@ export function Header({
 					>
 						Documentation
 					</TextNavItem>
-					<TextNavItem
-						href="/cookbook"
-						ariaCurrent={active === "cookbook" ? "page" : undefined}
-					>
-						Cookbooks
-					</TextNavItem>
 					<TextNavItem href="/enterprise">
 						Enterprise
 					</TextNavItem>
@@ -732,7 +718,6 @@ function DocsMobileNavigation({
 		]
 		: [
 			{ href: "/docs", label: "Documentation" },
-			{ href: "/cookbook", label: "Cookbooks" },
 			{ href: "/enterprise", label: "Enterprise" },
 			{ href: "/cloud", label: "Pricing" },
 		];

--- a/website/src/layouts/MarketingLayout.astro
+++ b/website/src/layouts/MarketingLayout.astro
@@ -10,13 +10,14 @@ interface Props {
 	ogImage?: string;
 	keywords?: string[];
 	active?: ComponentProps<typeof Header>['active'];
+	robots?: string;
 }
 
-const { title, description, canonicalUrl, ogImage, keywords, active } = Astro.props;
+const { title, description, canonicalUrl, ogImage, keywords, active, robots } = Astro.props;
 const pathname = Astro.url.pathname;
 ---
 
-<BaseLayout title={title} description={description} canonicalUrl={canonicalUrl} ogImage={ogImage} keywords={keywords}>
+<BaseLayout title={title} description={description} canonicalUrl={canonicalUrl} ogImage={ogImage} keywords={keywords} robots={robots}>
 	<Header variant="floating" initialPathname={pathname} active={active} client:load />
 	<slot />
 </BaseLayout>

--- a/website/src/pages/actors.astro
+++ b/website/src/pages/actors.astro
@@ -49,12 +49,12 @@ const useCases = [
 	<ScrollObserver client:load>
 		<div class="paper-grain min-h-screen font-sans text-ink-soft">
 			<main>
-				<!-- Hero: full-bleed oil painting fading down into ink, then grading into porcelain on scroll -->
-				<section id="actors-hero" class="relative flex min-h-[100svh] flex-col justify-end overflow-hidden pt-32 pb-16 md:pb-24" style="--actors-content-fade: 1;">
+				<!-- Hero: full-bleed oil painting fading down into ink behind the copy -->
+				<section id="actors-hero" class="relative flex min-h-[100svh] flex-col justify-end overflow-hidden pt-32 pb-16 md:pb-24">
 					<!-- Painting backdrop, a fixed crop inside the clipping box
-					     (overflow-hidden). The gradients sit over it so the
-					     dark fade can hand off to the porcelain gradient on scroll. -->
-					<div id="actors-hero-bg" class="absolute inset-0 z-0 overflow-hidden" aria-hidden="true" style="will-change: opacity;">
+					     (overflow-hidden). The dark gradients sit over it so the hero
+					     text reads against the artwork. -->
+					<div id="actors-hero-bg" class="absolute inset-0 z-0 overflow-hidden" aria-hidden="true">
 						<img
 							src="https://assets.rivet.dev/website/images/textures/actors-hero-degas-orchestra.webp"
 							alt=""
@@ -63,19 +63,12 @@ const useCases = [
 							decoding="async"
 							class="absolute inset-x-0 -top-[18%] h-[136%] w-full object-cover object-[center_28%]"
 						/>
-						<!-- Fade to ink at the bottom so the hero text reads before the paper gradient layers over it. -->
+						<!-- Fade to ink at the bottom so the hero text reads against the painting. -->
 						<div class="absolute inset-0 bg-gradient-to-t from-ink from-[18%] via-ink/70 via-[42%] to-transparent to-[78%]"></div>
 						<!-- Gentle left wash for extra legibility behind the copy -->
 						<div class="absolute inset-0 bg-gradient-to-r from-ink/60 via-ink/20 to-transparent"></div>
 					</div>
-					<!-- Scroll-driven porcelain wash: a static bottom-up porcelain gradient (solid rgb(234,234,234) at the seam, fading to transparent toward the top) whose opacity JS ramps in on scroll. Opacity-only, so there is no blur or per-frame mask raster to jank the scroll. -->
-					<div
-						id="actors-paper-wash"
-						class="pointer-events-none absolute inset-x-0 bottom-0 z-[1] h-[78svh]"
-						style="opacity: 0; will-change: opacity; background-image: linear-gradient(to top, rgb(234,234,234) 0%, rgb(234,234,234) 24%, rgba(234,234,234,0) 64%);"
-					></div>
-
-					<div class="relative z-10 mx-auto w-full max-w-7xl px-6" style="opacity: var(--actors-content-fade);">
+					<div class="relative z-10 mx-auto w-full max-w-7xl px-6">
 						<div class="max-w-xl">
 							<h1 class={`mb-4 ${HERO_H1_CLASS} !text-cream`}>
 								The primitive for<br />stateful workloads.
@@ -94,42 +87,6 @@ const useCases = [
 						</div>
 					</div>
 				</section>
-
-				<!-- As the hero scrolls away, ramp the porcelain gradient opacity and dim the painting and copy. Opacity-only animation, no blur or masks, keeps the scroll on the compositor. -->
-				<script>
-					const hero = document.getElementById('actors-hero');
-					const wash = document.getElementById('actors-paper-wash');
-					const bg = document.getElementById('actors-hero-bg');
-					if (hero) {
-						let ticking = false;
-						const smoothstep = (value: number) => value * value * (3 - 2 * value);
-						const update = () => {
-							const h = hero.offsetHeight || window.innerHeight;
-							const scrollRatio = window.scrollY / h;
-							// Ramp the porcelain in gently so it spreads toward the top at a
-							// measured pace while the painting and copy fade underneath it.
-							const progress = Math.min(1, Math.max(0, (scrollRatio - 0.04) / 0.55));
-							const eased = smoothstep(progress);
-							const bell = 1 - Math.pow(1 - eased, 3.2);
-							// Opacity-only animation keeps the scroll on the compositor (no blur, no
-							// per-frame mask raster). A static porcelain gradient fades in from the
-							// bottom, the painting dims, and the copy clears ahead of it.
-							if (wash) wash.style.opacity = bell.toFixed(3);
-							if (bg) bg.style.opacity = (1 - bell * 0.7).toFixed(3);
-							hero.style.setProperty('--actors-content-fade', Math.max(0, 1 - bell * 1.5).toFixed(3));
-							ticking = false;
-						};
-						const onScroll = () => {
-							if (!ticking) {
-								ticking = true;
-								requestAnimationFrame(update);
-							}
-						};
-						update();
-						window.addEventListener('scroll', onScroll, { passive: true });
-						window.addEventListener('resize', onScroll, { passive: true });
-					}
-				</script>
 
 				<!-- Use cases -->
 				<section class="bg-[#EAEAEA] px-6 py-16 md:py-32">

--- a/website/src/pages/compare/[slug].astro
+++ b/website/src/pages/compare/[slug].astro
@@ -52,6 +52,7 @@ const webPageSchema = {
 	description={entry.description}
 	canonicalUrl={canonicalUrl}
 	keywords={entry.keywords}
+	robots="noindex, nofollow"
 >
 	<script type="application/ld+json" set:html={jsonLdString(breadcrumbSchema)} />
 	<script type="application/ld+json" set:html={jsonLdString(webPageSchema)} />

--- a/website/src/pages/cookbook/[...slug].astro
+++ b/website/src/pages/cookbook/[...slug].astro
@@ -127,6 +127,7 @@ if (coverArt) {
 	description={description}
 	canonicalUrl={canonicalUrl}
 	active="cookbook"
+	robots="noindex, nofollow"
 >
 	<script type="application/ld+json" set:html={jsonLdString(breadcrumbSchema)} />
 	<script type="application/ld+json" set:html={jsonLdString(techArticleSchema)} />

--- a/website/src/pages/cookbook/index.astro
+++ b/website/src/pages/cookbook/index.astro
@@ -84,6 +84,7 @@ const allTechnologies = Array.from(new Set(pages.flatMap((p) => p.technologies))
 	description="Step-by-step guides that link to working Rivet templates and example code."
 	canonicalUrl="https://rivet.dev/cookbook/"
 	active="cookbook"
+	robots="noindex, nofollow"
 >
 	<CookbookPageContent pages={pages} allTags={allTags} allTechnologies={allTechnologies} client:load />
 </MarketingLayout>

--- a/website/src/pages/llms.txt.ts
+++ b/website/src/pages/llms.txt.ts
@@ -7,9 +7,8 @@ export const GET: APIRoute = async ({ site }) => {
 	const siteUrl = site?.toString().replace(/\/$/, '') || 'https://rivet.dev';
 
 	// Get all content collections
-	const [docs, cookbook, guides, posts] = await Promise.all([
+	const [docs, guides, posts] = await Promise.all([
 		getCollection('docs'),
-		getCollection('cookbook'),
 		getCollection('guides'),
 		getCollection('posts'),
 	]);
@@ -26,14 +25,6 @@ export const GET: APIRoute = async ({ site }) => {
 	// Build guides URLs
 	const guidesUrls = guides
 		.map(guide => `${siteUrl}/guides/${guide.id}/`)
-		.sort();
-
-	// Build cookbook URLs
-	const cookbookUrls = cookbook
-		.map(entry => {
-			const cleanPath = entry.id.replace(/\/index$/, '').replace(/^index$/, '');
-			return cleanPath ? `${siteUrl}/cookbook/${cleanPath}/` : `${siteUrl}/cookbook/`;
-		})
 		.sort();
 
 	// Build blog URLs (filter out unpublished)
@@ -58,7 +49,6 @@ export const GET: APIRoute = async ({ site }) => {
 	const staticUrls = [
 		`${siteUrl}/`,
 		`${siteUrl}/docs/`,
-		`${siteUrl}/cookbook/`,
 		`${siteUrl}/cloud/`,
 		`${siteUrl}/pricing/`,
 		`${siteUrl}/changelog/`,
@@ -78,7 +68,6 @@ export const GET: APIRoute = async ({ site }) => {
 	const allUrls = [...new Set([
 		...staticUrls,
 		...docsUrls,
-		...cookbookUrls,
 		...guidesUrls,
 		...blogUrls,
 		...changelogUrls,

--- a/website/src/styles/main.css
+++ b/website/src/styles/main.css
@@ -124,16 +124,6 @@
     animation: trace-around 1s linear infinite, dark-grow-outer 1s ease-in-out infinite;
   }
 
-  .changelog-pill-border::after {
-    background: radial-gradient(
-      42px 30px at var(--pill-x, 50%) var(--pill-y, 50%),
-      rgba(255, 255, 255, 0.95),
-      rgba(255, 255, 255, 0.55) 38%,
-      rgba(255, 255, 255, 0) 76%
-    );
-    filter: blur(2px);
-  }
-
   /* Cursor-following border glow for porcelain pills (deploy row, stack chips).
      Lights ONLY the pill's 1px border ring as the pointer moves — not the fill.
      `inset: -1px` grows the ::after out to the border-box so the masked ring


### PR DESCRIPTION
Bundles four self-contained website changes (one commit each) from this workspace.

### 1. Remove porcelain wash scroll transition on `/actors` hero
`website/src/pages/actors.astro` — drops the scroll-driven `#actors-paper-wash` overlay and the JS that drove it (wash fade-in + painting dim + copy fade), plus the now-dead `--actors-content-fade` / `will-change` plumbing. Keeps the static dark `from-ink` gradient over the painting.

### 2. Restyle landing changelog pill to the shared glow-pill
`RedesignedHero.tsx`, `main.css` — swaps the bespoke `changelog-pill-border` for the shared `GLOW_PILL_CLASS` + `handleGlowPillMouseMove` so the changelog pill matches the other landing-page pills; removes the now-unused `.changelog-pill-border::after` CSS. _(This change was already present in the workspace at the start of the session, not authored in it.)_

### 3. Break the `/docs/connect` redirect loop
`website/redirects.mjs` — prod loops `/docs/connect/ ⇄ /docs/deploy/` (leftover from the abandoned "rename Connect→Deploy"). Current `main` already lacks the bad rule, so a redeploy breaks the loop; this adds a safe **one-way** `/docs/deploy → /docs/connect/` so the renamed URL resolves and never bounces back.

### 4. Hide cookbooks + comparison guides from the site and SEO
- Nav: removed Cookbooks (Header ×3, Footer) and both `/compare/*` links (Footer).
- Sitemap: excluded `/cookbook` and `/compare` from the `@astrojs/sitemap` filter.
- `noindex, nofollow`: added via a new `robots` prop on `MarketingLayout` → `BaseLayout`, set on the compare page and both cookbook pages.
- `llms.txt`: removed all cookbook entries.
- `robots.txt` left untouched on purpose (a `Disallow` would hide the `noindex` from crawlers).
- Reversible: page files/content kept; only hidden + de-indexed.

> Note: 7 docs pages still have inline prose links into `/cookbook/*` (e.g. `docs/actors/connections.mdx`). They resolve (pages still exist) but point into the hidden section — left for a follow-up decision.

**Verification:** changes are mechanical and grep-verified; a full typecheck/build was not run (this workspace has no `node_modules`, and the running website dev server belongs to a different workspace).