### PR TITLE
docs(actors): fix createState/conn state type errors blocking skills build

### DIFF
--- a/website/src/content/docs/actors/crash-course.mdx
+++ b/website/src/content/docs/actors/crash-course.mdx
@@ -495,8 +495,8 @@ const chatRoom = actor({
 	onBeforeConnect: (c, params) => {
 		/* validate auth */
 	},
-	onConnect: (c, conn) => console.log("connected:", conn.state.userId),
-	onDisconnect: (c, conn) => console.log("disconnected:", conn.state.userId),
+	onConnect: (c, conn) => console.log("connected:", (conn.state as ConnState).userId),
+	onDisconnect: (c, conn) => console.log("disconnected:", (conn.state as ConnState).userId),
 
 	// Networking
 	onRequest: (c, req) => new Response(JSON.stringify(c.state)),

--- a/website/src/content/docs/actors/types.mdx
+++ b/website/src/content/docs/actors/types.mdx
@@ -13,7 +13,7 @@ import { actor } from "rivetkit";
 
 const counter = actor({
   // CreateContext in createState hook
-  createState: (c, input: { initial: number }) => {
+  createState: (c, input: { initial: number }): { count: number } => {
     return { count: input.initial };
   },
 
@@ -35,7 +35,7 @@ When writing helper functions that work with actor contexts, use context extract
 import { actor, CreateContextOf, ActionContextOf } from "rivetkit";
 
 const gameRoom = actor({
-  createState: (c, input: { roomId: string }) => {
+  createState: (c, input: { roomId: string }): { players: string[]; score: number } => {
     initializeRoom(c, input.roomId);
     return { players: [] as string[], score: 0 };
   },


### PR DESCRIPTION
The `skills.yml` workflow (publishes to rivet-dev/skills) has been failing since the docs restructure: the website build's `typecheck-code-blocks` integration finds 3 TS errors in actor docs, so the website can't build and skills can't generate.

- `actors/types.mdx` — two `createState` examples used an inferred return, which collapses `c.state` to `unknown` (TState appears in both the context param and the return). Added explicit return type annotations.
- `actors/crash-course.mdx` — the `chatRoom` lifecycle example's `onConnect`/`onDisconnect` deref `conn.state.userId`, which is `unknown` in that complex actor; cast to `ConnState`.

Verified the 3 blocks type-check against the built rivetkit. Unblocks the website build and the skills publish.