### PR TITLE
Dashboard: light-only (remove dark mode toggle)

### DIFF
--- a/frontend/apps/inspector-ui/index.html
+++ b/frontend/apps/inspector-ui/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/frontend/apps/inspector-ui/src/main.tsx
+++ b/frontend/apps/inspector-ui/src/main.tsx
@@ -137,16 +137,6 @@ function BootGate({ bridge }: { bridge: BridgeClient }) {
 		bridge.start();
 		const unsubInit = bridge.onInit((msg) => {
 			setInit(msg);
-			// Mirror the dashboard's active theme on the SPA's own
-			// <html>. Without this the SPA stays pinned to the
-			// `class="dark"` baked into index.html and built-in tabs
-			// (Connections, State, etc.) render in dark even when the
-			// dashboard is in light mode. The dashboard re-issues init
-			// on every theme toggle, so this fires automatically.
-			document.documentElement.classList.toggle(
-				"dark",
-				(msg.theme ?? "dark") === "dark",
-			);
 			// Seed activeTab from the first init; ignore activeTab on
 			// subsequent inits (e.g. token refresh) so we don't clobber
 			// any tab switches the shell sent in between.

--- a/frontend/apps/inspector/index.html
+++ b/frontend/apps/inspector/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en">
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en">
 	<head>
 		<script src="https://analytics.ahrefs.com/analytics.js" data-key="wQAsHie9RgJMLNhmUbr/fQ" async></script>
 

--- a/frontend/packages/components/public/theme.css
+++ b/frontend/packages/components/public/theme.css
@@ -1,8 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap');
 
 :root {
-	/* Light tokens — kept as a fallback. App pins `<html class="dark">`
-	   in index.html so these only render if dark is ever removed. */
+	/* Light tokens. The dashboard is light-only. */
 	--background: 0 0% 100%;
 	--foreground: 240 10% 4%;
 	--card: 0 0% 100%;
@@ -19,10 +18,12 @@
 	--accent-foreground: 240 10% 4%;
 	--destructive: 0 84.2% 60.2%;
 	--destructive-foreground: 0 0% 100%;
+	--warning: 47.9 95.8% 53.1%;
 	--border: 240 6% 90%;
 	--input: 240 6% 90%;
 	--ring: 18.5 100% 50%;
 	--radius: 0.5rem;
+	--background-main: 0 0% 98%;
 }
 :root[class~="dark"] {
 	/* Cool zinc neutrals — mirrors Foundry's #09090b / #0c0c0e / #0f0f11. */

--- a/frontend/src/app/user-dropdown.tsx
+++ b/frontend/src/app/user-dropdown.tsx
@@ -3,11 +3,9 @@ import {
 	faChevronDown,
 	faCreditCard,
 	faGear,
-	faMoon,
 	faPlus,
 	faRightLeft,
 	faSparkles,
-	faSun,
 	faUserCircle,
 	Icon,
 } from "@rivet-gg/icons";
@@ -39,7 +37,6 @@ import {
 import { useCloudDataProvider } from "@/components/actors";
 import { authClient } from "@/lib/auth";
 import { orgConicGradient, paletteForLetter } from "@/lib/org-palette";
-import { useTheme } from "@/lib/theme";
 import { queryClient } from "@/queries/global";
 import { BillingPlanBadge } from "./billing/billing-plan-badge";
 import { BillingUsageGauge } from "./billing/billing-usage-gauge";
@@ -53,7 +50,6 @@ export function UserDropdown({ children }: { children?: React.ReactNode }) {
 	const { data: session } = authClient.useSession();
 	const navigate = useNavigate();
 	const match = useMatchRoute();
-	const { theme, toggle: toggleTheme } = useTheme();
 	const [open, setOpen] = useState(false);
 
 	const isMatchingProjectRoute = match({
@@ -189,18 +185,6 @@ export function UserDropdown({ children }: { children?: React.ReactNode }) {
 						className="mr-2 size-3.5 text-muted-foreground"
 					/>
 					What's new
-				</DropdownMenuItem>
-				<DropdownMenuItem
-					onSelect={(e) => {
-						e.preventDefault();
-						toggleTheme();
-					}}
-				>
-					<Icon
-						icon={theme === "dark" ? faSun : faMoon}
-						className="mr-2 size-3.5 text-muted-foreground"
-					/>
-					{theme === "dark" ? "Light mode" : "Dark mode"}
 				</DropdownMenuItem>
 				<DropdownMenuSeparator />
 				<DropdownMenuItem

--- a/frontend/src/components/code-mirror/index.tsx
+++ b/frontend/src/components/code-mirror/index.tsx
@@ -1,18 +1,12 @@
 import { json, jsonParseLinter } from "@codemirror/lang-json";
 import { linter } from "@codemirror/lint";
 import { Annotation } from "@codemirror/state";
-import {
-	githubDark,
-	githubDarkInit,
-	githubLight,
-	githubLightInit,
-} from "@uiw/codemirror-theme-github";
+import { githubLight, githubLightInit } from "@uiw/codemirror-theme-github";
 import ReactCodeMirror, {
 	type ReactCodeMirrorProps,
 	type ReactCodeMirrorRef,
 } from "@uiw/react-codemirror";
 import { forwardRef } from "react";
-import { useTheme } from "@/lib/theme";
 
 const transparentSettings = {
 	background: "transparent",
@@ -20,22 +14,16 @@ const transparentSettings = {
 	fontSize: "12px",
 };
 
-const transparentDarkTheme = githubDarkInit({ settings: transparentSettings });
 const transparentLightTheme = githubLightInit({
 	settings: transparentSettings,
 });
 
 export const CodeMirror = forwardRef<ReactCodeMirrorRef, ReactCodeMirrorProps>(
 	(props, ref) => {
-		const { theme } = useTheme();
 		return (
 			<ReactCodeMirror
 				ref={ref}
-				theme={
-					theme === "dark"
-						? transparentDarkTheme
-						: transparentLightTheme
-				}
+				theme={transparentLightTheme}
 				{...props}
 			/>
 		);
@@ -46,7 +34,6 @@ interface JsonCodeProps extends ReactCodeMirrorProps {}
 
 export const JsonCode = forwardRef<ReactCodeMirrorRef, JsonCodeProps>(
 	({ value, extensions = [], ...props }, ref) => {
-		const { theme } = useTheme();
 		return (
 			<ReactCodeMirror
 				ref={ref}
@@ -63,7 +50,7 @@ export const JsonCode = forwardRef<ReactCodeMirrorRef, JsonCodeProps>(
 					}),
 					...extensions,
 				]}
-				theme={theme === "dark" ? githubDark : githubLight}
+				theme={githubLight}
 				value={value}
 			/>
 		);

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -5,7 +5,7 @@ type ToasterProps = React.ComponentProps<typeof Sonner>;
 const Toaster = ({ ...props }: ToasterProps) => {
 	return (
 		<Sonner
-			theme="dark"
+			theme="light"
 			className="toaster group right-8"
 			toastOptions={{
 				classNames: {

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -1,81 +1,17 @@
-import { useCallback, useSyncExternalStore } from "react";
+export type Theme = "light";
 
-export type Theme = "light" | "dark";
-
-const STORAGE_KEY = "rivet:theme";
-
-function applyTheme(theme: Theme) {
-	const root = document.documentElement;
-	if (theme === "dark") {
-		root.classList.add("dark");
-	} else {
-		root.classList.remove("dark");
-	}
-}
-
-function readStoredTheme(): Theme {
-	if (typeof window === "undefined") return "dark";
-	const stored = window.localStorage.getItem(STORAGE_KEY);
-	if (stored === "light" || stored === "dark") return stored;
-	return "dark";
-}
-
-// One-time bootstrap: ensure the DOM matches the persisted preference on
-// first import. Done lazily so SSR doesn't crash on a missing `document`.
+// The dashboard is light-only. Keep the `useTheme` hook surface so consumers
+// that read the active theme (CodeMirror, the actor detail iframe) keep
+// working, but there is no dark mode and no toggle.
 let bootstrapped = false;
 function bootstrap() {
 	if (bootstrapped) return;
 	if (typeof document === "undefined") return;
 	bootstrapped = true;
-	applyTheme(readStoredTheme());
-}
-
-// `<html>` carries the active theme as a class. Every `useTheme()` caller
-// reads from the live DOM via `useSyncExternalStore`, so when one caller
-// flips the class every other subscriber re-renders immediately — no
-// stale per-`useState` copies.
-function getSnapshot(): Theme {
-	if (typeof document === "undefined") return "dark";
-	return document.documentElement.classList.contains("dark")
-		? "dark"
-		: "light";
-}
-
-function getServerSnapshot(): Theme {
-	return "dark";
-}
-
-function subscribe(callback: () => void): () => void {
-	if (typeof document === "undefined") return () => {};
-	const observer = new MutationObserver(callback);
-	observer.observe(document.documentElement, {
-		attributes: true,
-		attributeFilter: ["class"],
-	});
-	return () => observer.disconnect();
+	document.documentElement.classList.remove("dark");
 }
 
 export function useTheme() {
 	bootstrap();
-	const theme = useSyncExternalStore(
-		subscribe,
-		getSnapshot,
-		getServerSnapshot,
-	);
-
-	const setTheme = useCallback((next: Theme) => {
-		applyTheme(next);
-		try {
-			window.localStorage.setItem(STORAGE_KEY, next);
-		} catch {
-			// Storage might be unavailable (private mode, quota).
-			// Best-effort only.
-		}
-	}, []);
-
-	const toggle = useCallback(() => {
-		setTheme(getSnapshot() === "dark" ? "light" : "dark");
-	}, [setTheme]);
-
-	return { theme, setTheme, toggle };
+	return { theme: "light" as Theme };
 }


### PR DESCRIPTION
## Summary

Makes the dashboard **light-only** by removing the dark-mode toggle and all dark theme code paths.

## Changes

- Drop `class="dark"` from the app shells (`frontend/index.html`, `frontend/apps/inspector/index.html`, `frontend/apps/inspector-ui/index.html`).
- Remove the **Light/Dark mode** item from the user dropdown.
- Collapse `useTheme()` (`frontend/src/lib/theme.ts`) to always return `{ theme: "light" }`, keeping the hook surface so read-only consumers (CodeMirror, the actor-detail iframe) keep working. No `localStorage`, `MutationObserver`, or toggle.
- CodeMirror / `JsonCode` always use the light GitHub theme.
- Sonner toaster pinned to `light`.
- `inspector-ui` no longer mirrors the dashboard theme onto its own `<html>`.
- `theme.css`: light tokens are the only active set; add `--warning` and `--background-main` tokens; tidy comments.

## Notes

- Verified there are no remaining consumers of the removed `setTheme` / `toggle` API.
- Not build/typechecked locally.
