### PR TITLE
Website: Introducing Rivet 2.3 blog post

### DIFF
--- a/website/src/components/BlogArticle.astro
+++ b/website/src/components/BlogArticle.astro
@@ -239,9 +239,26 @@ const otherArticles = allPosts
 		margin-bottom: 2.75rem;
 	}
 
+	.blog-article .blog-prose ul,
+	.blog-article .blog-prose ol {
+		padding-left: 1.4em;
+	}
+
+	.blog-article .blog-prose ul {
+		list-style-type: disc;
+	}
+
+	.blog-article .blog-prose ol {
+		list-style-type: decimal;
+	}
+
 	.blog-article .blog-prose li {
 		margin-top: 0.4em;
 		margin-bottom: 0.4em;
+	}
+
+	.blog-article .blog-prose li::marker {
+		color: #1b1916;
 	}
 
 	.blog-article .blog-prose h2 a,

--- a/website/src/content/posts/2026-06-15-introducing-rivet-2-3/page.mdx
+++ b/website/src/content/posts/2026-06-15-introducing-rivet-2-3/page.mdx
@@ -1,0 +1,66 @@
+---
+image: true
+author: nathan-flurry
+published: "2026-06-15"
+category: changelog
+keywords: ["rivet", "rust", "actors", "wasm", "dashboard", "cli"]
+title: "Introducing Rivet 2.3"
+description: "A native Rust rewrite of RivetKit, a reimagined dashboard, fine-grained control over actor lifecycle, and more."
+---
+
+Today we're releasing **Rivet 2.3**: a native Rust rewrite of RivetKit, a reimagined dashboard, and fine-grained control over actor lifecycle.
+
+## RivetKit rewritten in Rust
+
+RivetKit is the runtime that runs your actor code: it manages state, lifecycle, networking, and storage for every actor. In 2.3 it's rewritten from JavaScript to Rust.
+
+- **Native performance**: state persistence, SQLite, and networking now run in native Rust instead of on the JavaScript runtime, cutting overhead on the hot paths every actor hits
+- **New SQLite engine**: per-actor SQLite is backed by a new native engine for faster reads and writes and higher throughput
+- **Background runtime**: all RivetKit runtime work now runs in the background instead of on the main Node.js thread, so it doesn't block your application logic
+- **Same actor API**: nothing changes in your actor code, the rewrite is entirely under the hood
+- **A foundation for more languages**: with the core logic in a language-agnostic runtime, we can build first-class SDKs beyond TypeScript instead of reimplementing the runtime per language
+
+## A whole new dashboard
+
+We reimagined the entire dashboard. It now ships with light and dark mode, a bigger inspector with space reserved for upcoming custom inspector tabs, and reorganized settings that make the setting you need easier to find.
+
+![Rivet dashboard](https://assets.rivet.dev/website/blog/2026-06-15-introducing-rivet-2-3/dashboard.png)
+
+## Built for work that can't be interrupted
+
+2.3 adds fine-grained control over when an actor is allowed to sleep or move, so in-flight work runs to completion instead of being cut off.
+
+- **Finish in-flight work**: an actor completes its current work before sleeping, moving, or upgrading
+- **`c.keepAwake`**: explicitly hold an actor awake through a long operation so it isn't put to sleep partway through
+- **Configurable sleep grace period**: control how long an actor stays awake after its last activity, so work has time to run to completion before the actor sleeps
+
+This matters for anything that can't be cut off partway through: **agent turns** that need to finish, **game servers** mid-match, and **expensive jobs** like image or video conversion.
+
+## WebAssembly support
+
+RivetKit now runs as either a native Node.js module or as WebAssembly, so it can support more platforms like Cloudflare Workers and Supabase Functions.
+
+## Reschedule & Sleep
+
+Restart or sleep an actor the way you'd restart a container, from the dashboard, over the API, or from an agent. Useful for debugging how an actor behaves across its lifecycle, or forcing a fresh start after a bad state.
+
+## Rivet CLI
+
+A new Rivet CLI:
+
+- **`npx @rivetkit/cli dev`**: run a local Rivet Engine, with presets for Cloudflare Workers and Supabase Functions
+- **`npx @rivetkit/cli deploy`**: build, push, and deploy your project to Rivet Compute
+- **`npx @rivetkit/cli setup-ci`**: scaffold a GitHub Actions workflow that deploys to Rivet Compute on every push, including preview branches
+
+## More improvements
+
+- **Prometheus metrics**: RivetKit exposes runtime metrics in Prometheus format, so you can scrape and monitor your app with the tools you already run
+- **Faster actor connection**: connecting to an actor now resolves and connects in a single round trip instead of two, cutting latency on every `getOrCreate` and `get`
+- **Skip ready wait**: `skipReadyWait` sends a request through immediately instead of waiting for the actor to finish starting up
+- **Actor eviction drain period**: tune how quickly actors reschedule when an Envoy shuts down, trading off drain speed against disruption
+
+## Get started
+
+- [Documentation](/docs)
+- [GitHub](https://github.com/rivet-dev/rivet)
+- [Discord](https://rivet.dev/discord)


### PR DESCRIPTION
Adds the "Introducing Rivet 2.3" changelog/blog post (published 2026-06-15) covering the Rust rewrite, new dashboard, sleep/lifecycle control, WebAssembly support, and the new CLI. Hero and inline dashboard screenshot are served from the `rivet-assets` R2 bucket.

Also fixes blog-prose list styling: `BlogArticle.astro` rendered prose with the default `surface="ink"` (`prose-invert`), whose bullet color is white, but blog posts sit on the light `paper` background. Added explicit `list-style-type`, list padding, and an `li::marker` color so bullets match the light theme.