### PR TITLE
docs(releasing): fix stale promote-prod.sh path

### DIFF
--- a/docs-internal/engine/RELEASING.md
+++ b/docs-internal/engine/RELEASING.md
@@ -7,7 +7,7 @@ Frontend services (including `dashboard.rivet.dev` and `inspect.rivet.dev`, but 
 To promote to production, run:
 
 ```sh
-./scripts/git/promote-prod.sh
+./scripts/frontend/promote-prod.sh
 ```
 
 This will validate that you're on the `main` branch and up to date with the remote before pushing.
@@ -15,7 +15,7 @@ This will validate that you're on the `main` branch and up to date with the remo
 To skip validation and push the current ref directly:
 
 ```sh
-./scripts/git/promote-prod.sh --force
+./scripts/frontend/promote-prod.sh --force
 ```
 
 <details>


### PR DESCRIPTION
## What

The frontend promote script moved from `scripts/git/promote-prod.sh` to `scripts/frontend/promote-prod.sh` (commit `168e06b2d3`), but `docs-internal/engine/RELEASING.md` still pointed at the old path. Following the release doc today would fail with "no such file."

This updates both references in the doc to the current path.

## Why

The script content is unchanged; only its location moved. The docs were left stale by the relocation.

https://claude.ai/code/session_01HMJ9uKH2n2s8ahMRtntVJe