### PR TITLE
fix(rivetkit): reject invalid runtime mode env values

### DIFF
--- a/examples/kitchen-sink/src/server.ts
+++ b/examples/kitchen-sink/src/server.ts
@@ -120,7 +120,7 @@ app.get("/debug/memory", async (c) => {
 	return c.json(await memoryBreakdown(forceGc));
 });
 
-app.get("/health", () => registry.routes.health());
+app.get("/health", (c) => c.json({ ok: true }));
 app.get("/metadata", () => registry.routes.metadata());
 app.get("/metrics", (c) => registry.routes.prometheusMetrics(c.req.raw));
 

--- a/frontend/src/components/actors/actor-details-skeleton.tsx
+++ b/frontend/src/components/actors/actor-details-skeleton.tsx
@@ -49,10 +49,7 @@ export function ActorDetailsSkeleton({ shimmer, children, className }: Props) {
 	return (
 		<Tabs
 			value={undefined}
-			className={cn(
-				"flex-1 min-h-0 min-w-0 flex flex-col",
-				className,
-			)}
+			className={cn("flex-1 min-h-0 min-w-0 flex flex-col", className)}
 		>
 			<div className="relative flex items-center border-b h-[45px]">
 				<TabsList className="flex border-none h-full items-end min-w-0 overflow-hidden w-full">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2992,9 +2992,6 @@ importers:
       effect:
         specifier: ^4.0.0-beta.66
         version: 4.0.0-beta.66
-      rivetkit:
-        specifier: workspace:*
-        version: link:../rivetkit
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.18.3
@@ -3014,6 +3011,9 @@ importers:
       publint:
         specifier: ^0.3.21
         version: 0.3.21
+      rivetkit:
+        specifier: workspace:*
+        version: link:../rivetkit
       typescript:
         specifier: ^5.9.2
         version: 5.9.3

--- a/rivetkit-typescript/packages/effect/package.json
+++ b/rivetkit-typescript/packages/effect/package.json
@@ -40,6 +40,7 @@
 		"@types/node": "^22.18.1",
 		"@vitest/coverage-v8": "^4.1.7",
 		"publint": "^0.3.21",
+		"rivetkit": "workspace:*",
 		"typescript": "^5.9.2",
 		"vitest": "^4.1.5"
 	}

--- a/rivetkit-typescript/packages/effect/src/Actor.test.ts
+++ b/rivetkit-typescript/packages/effect/src/Actor.test.ts
@@ -58,7 +58,10 @@ describe("Actor.toWakeHandler", () => {
 			const wakeHandler = Actor.toWakeHandler(wake);
 			const actionHandlers = yield* wakeHandler(wakeOptions);
 
-			assert.strictEqual(wakeOptions.rawRivetkitContext, rawRivetkitContext);
+			assert.strictEqual(
+				wakeOptions.rawRivetkitContext,
+				rawRivetkitContext,
+			);
 			assert.strictEqual(yield* actionHandlers.GetKey(), "room/1");
 		}),
 	);

--- a/rivetkit-typescript/packages/effect/src/Client.test.ts
+++ b/rivetkit-typescript/packages/effect/src/Client.test.ts
@@ -20,14 +20,7 @@ function makeTestLogger(
 		level: "debug",
 		child: () => logger,
 	};
-	for (const level of [
-		"trace",
-		"debug",
-		"info",
-		"warn",
-		"error",
-		"fatal",
-	]) {
+	for (const level of ["trace", "debug", "info", "warn", "error", "fatal"]) {
 		logger[level] = (
 			fields: Record<string, unknown>,
 			msg?: string,

--- a/rivetkit-typescript/packages/effect/src/Registry.test.ts
+++ b/rivetkit-typescript/packages/effect/src/Registry.test.ts
@@ -33,14 +33,7 @@ function makeTestLogger(): PinoLogger {
 		level: "debug",
 		child: () => logger,
 	};
-	for (const level of [
-		"trace",
-		"debug",
-		"info",
-		"warn",
-		"error",
-		"fatal",
-	]) {
+	for (const level of ["trace", "debug", "info", "warn", "error", "fatal"]) {
 		logger[level] = (): void => {};
 	}
 
@@ -207,8 +200,7 @@ describe("Registry.toWebHandler", () => {
 				}),
 			),
 		);
-		const { handler, dispose } =
-			Registry.toWebHandler(WelcomeRegistryLive);
+		const { handler, dispose } = Registry.toWebHandler(WelcomeRegistryLive);
 
 		try {
 			const first = await handler(
@@ -234,8 +226,9 @@ describe("Registry.toWebHandler", () => {
 		const CustomLoggerRegistryLive = RegistryLive.pipe(
 			Layer.provide(Logger.layerPino(baseLogger)),
 		);
-		const { handler, dispose } =
-			Registry.toWebHandler(CustomLoggerRegistryLive);
+		const { handler, dispose } = Registry.toWebHandler(
+			CustomLoggerRegistryLive,
+		);
 
 		try {
 			const response = await handler(

--- a/rivetkit-typescript/packages/effect/src/Registry.ts
+++ b/rivetkit-typescript/packages/effect/src/Registry.ts
@@ -7,10 +7,7 @@ import {
 	type HttpServerResponse,
 } from "effect/unstable/http";
 import * as Rivetkit from "rivetkit";
-import {
-	configureBaseLogger,
-	type Logger as PinoLogger,
-} from "rivetkit/log";
+import { configureBaseLogger, type Logger as PinoLogger } from "rivetkit/log";
 import * as Client from "./Client.ts";
 import { BaseLogger, getOrCreateBaseLogger } from "./internal/logging.ts";
 import * as Logger from "./Logger.ts";
@@ -81,19 +78,19 @@ const setupRivetkitRegistry = (
  */
 export const serve = <E, R>(
 	actorsLayer: Layer.Layer<never, E, R>,
-	): Layer.Layer<never, E, R | Registry> =>
-		Layer.effectDiscard(
-			Effect.gen(function* () {
-				const registry = yield* Registry;
-				const baseLogger = registry.baseLogger;
-				yield* Layer.build(
-					actorsLayer.pipe(
-						Layer.provideMerge(Logger.layerPino(baseLogger)),
-					),
-				);
-				const rivetkitRegistry = setupRivetkitRegistry(registry);
-				yield* Effect.sync(() => rivetkitRegistry.start());
-			}),
+): Layer.Layer<never, E, R | Registry> =>
+	Layer.effectDiscard(
+		Effect.gen(function* () {
+			const registry = yield* Registry;
+			const baseLogger = registry.baseLogger;
+			yield* Layer.build(
+				actorsLayer.pipe(
+					Layer.provideMerge(Logger.layerPino(baseLogger)),
+				),
+			);
+			const rivetkitRegistry = setupRivetkitRegistry(registry);
+			yield* Effect.sync(() => rivetkitRegistry.start());
+		}),
 	);
 
 /**
@@ -137,14 +134,12 @@ export const test: Layer.Layer<Client.Client, never, Registry> = Layer.effect(
 		// to its (warning-emitting) default.
 		const resolvedEndpoint = rivetkitRegistry.parseConfig().endpoint;
 
-			return yield* Client.make({
-				...registry.options,
-				endpoint: registry.options.endpoint ?? resolvedEndpoint,
-			}).pipe(
-				Effect.provideService(BaseLogger, registry.baseLogger),
-			);
-		}),
-	);
+		return yield* Client.make({
+			...registry.options,
+			endpoint: registry.options.endpoint ?? resolvedEndpoint,
+		}).pipe(Effect.provideService(BaseLogger, registry.baseLogger));
+	}),
+);
 
 const makeHttpEffect = (
 	registry: Registry,

--- a/rivetkit-typescript/packages/effect/src/internal/ActionDispatcher.ts
+++ b/rivetkit-typescript/packages/effect/src/internal/ActionDispatcher.ts
@@ -10,11 +10,7 @@ import {
 } from "effect";
 import * as Rivetkit from "rivetkit";
 import type * as Action from "../Action.ts";
-import type {
-	ActionHandlersFrom,
-	ActionRequest,
-	Actor,
-} from "../Actor.ts";
+import type { ActionHandlersFrom, ActionRequest, Actor } from "../Actor.ts";
 import type * as Client from "../Client.ts";
 import * as ActionErrorEnvelope from "./ActionErrorEnvelope.ts";
 import { makeActorLogAnnotations } from "./logging.ts";
@@ -96,12 +92,13 @@ export const make = <
 					const decodedPayload = yield* decodePayload(
 						payloadForDecode,
 					).pipe(
-						Effect.mapError(() =>
-							new Rivetkit.RivetError(
-								"request",
-								"invalid",
-								`Invalid payload for action ${actor.name}/${action._tag}`,
-							),
+						Effect.mapError(
+							() =>
+								new Rivetkit.RivetError(
+									"request",
+									"invalid",
+									`Invalid payload for action ${actor.name}/${action._tag}`,
+								),
 						),
 					);
 					// The payload was decoded with this action's schema,

--- a/rivetkit-typescript/packages/effect/src/internal/ActorInstanceManager.ts
+++ b/rivetkit-typescript/packages/effect/src/internal/ActorInstanceManager.ts
@@ -71,36 +71,36 @@ export const make = Effect.fnUntraced(function* <
 	const services = yield* Effect.context<any>();
 	const runPromise = Effect.runPromiseWith(services);
 
-		const makeInstance = Effect.fnUntraced(function* (
-			c: WakeContext<StateDefinition, Database>,
-		): Effect.fn.Return<Instance<ActionHandlers, StateDefinition>, never, any> {
-			const scope = yield* Scope.make();
-			return yield* Effect.gen(function* () {
-				const state = stateAdapter
-					? yield* stateAdapter.makeStateView(c)
-					: undefined;
-				const context = makeContext(c, scope);
-				const actionHandlers = yield* wakeHandler(
-					makeWakeOptions(c, state),
-				).pipe(Effect.provide(context));
-				const runFork = yield* FiberSet.makeRuntime<
-					any,
-					unknown,
-					unknown
-				>().pipe(Effect.provide(Context.merge(services, context)));
+	const makeInstance = Effect.fnUntraced(function* (
+		c: WakeContext<StateDefinition, Database>,
+	): Effect.fn.Return<Instance<ActionHandlers, StateDefinition>, never, any> {
+		const scope = yield* Scope.make();
+		return yield* Effect.gen(function* () {
+			const state = stateAdapter
+				? yield* stateAdapter.makeStateView(c)
+				: undefined;
+			const context = makeContext(c, scope);
+			const actionHandlers = yield* wakeHandler(
+				makeWakeOptions(c, state),
+			).pipe(Effect.provide(context));
+			const runFork = yield* FiberSet.makeRuntime<
+				any,
+				unknown,
+				unknown
+			>().pipe(Effect.provide(Context.merge(services, context)));
 
-				return {
-					actionHandlers,
-					runFork,
-					scope,
-					state,
-				};
-			}).pipe(
-				Effect.onError((cause) =>
-					Scope.close(scope, Exit.failCause(cause)),
-				),
-			);
-		});
+			return {
+				actionHandlers,
+				runFork,
+				scope,
+				state,
+			};
+		}).pipe(
+			Effect.onError((cause) =>
+				Scope.close(scope, Exit.failCause(cause)),
+			),
+		);
+	});
 
 	return {
 		get: (actorId: string) => instances.get(actorId),

--- a/rivetkit-typescript/packages/effect/src/internal/logging.test.ts
+++ b/rivetkit-typescript/packages/effect/src/internal/logging.test.ts
@@ -18,14 +18,7 @@ type LogEntry = {
 
 function makeTestLogger(entries: Array<LogEntry>): PinoLogger {
 	const logger: Record<string, unknown> = {};
-	for (const level of [
-		"trace",
-		"debug",
-		"info",
-		"warn",
-		"error",
-		"fatal",
-	]) {
+	for (const level of ["trace", "debug", "info", "warn", "error", "fatal"]) {
 		logger[level] = (
 			fields: Record<string, unknown>,
 			msg?: string,
@@ -137,12 +130,14 @@ describe("internal/logging", () => {
 		}),
 	);
 
-	it.effect("uses References.MinimumLogLevel when creating the base logger", () =>
-		Effect.gen(function* () {
-			const baseLogger = yield* Logging.makeDefaultBaseLogger;
+	it.effect(
+		"uses References.MinimumLogLevel when creating the base logger",
+		() =>
+			Effect.gen(function* () {
+				const baseLogger = yield* Logging.makeDefaultBaseLogger;
 
-			assert.strictEqual(baseLogger.level, "debug");
-		}).pipe(Effect.provideService(References.MinimumLogLevel, "Debug")),
+				assert.strictEqual(baseLogger.level, "debug");
+			}).pipe(Effect.provideService(References.MinimumLogLevel, "Debug")),
 	);
 
 	it.effect("accepts the shared Pino RIVET_LOG_LEVEL values", () =>
@@ -198,91 +193,105 @@ describe("internal/logging", () => {
 		),
 	);
 
-	it.effect("uses Config.logLevel values provided to References.MinimumLogLevel", () =>
-		Effect.gen(function* () {
-			const baseLogger = yield* Logging.makeDefaultBaseLogger;
+	it.effect(
+		"uses Config.logLevel values provided to References.MinimumLogLevel",
+		() =>
+			Effect.gen(function* () {
+				const baseLogger = yield* Logging.makeDefaultBaseLogger;
 
-			assert.strictEqual(baseLogger.level, "trace");
-		}).pipe(
-			Effect.provide(
-				Layer.effect(
-					References.MinimumLogLevel,
-					Config.logLevel("RIVET_LOG_LEVEL"),
+				assert.strictEqual(baseLogger.level, "trace");
+			}).pipe(
+				Effect.provide(
+					Layer.effect(
+						References.MinimumLogLevel,
+						Config.logLevel("RIVET_LOG_LEVEL"),
+					),
+				),
+				Effect.provideService(
+					ConfigProvider.ConfigProvider,
+					ConfigProvider.fromEnv({
+						env: {
+							RIVET_LOG_LEVEL: "Trace",
+						},
+					}),
 				),
 			),
-			Effect.provideService(
-				ConfigProvider.ConfigProvider,
-				ConfigProvider.fromEnv({
-					env: {
-						RIVET_LOG_LEVEL: "Trace",
+	);
+
+	it.effect(
+		"uses References.CurrentLogLevel for plain Effect.log calls",
+		() =>
+			Effect.gen(function* () {
+				const entries: Array<LogEntry> = [];
+				const baseLogger = makeTestLogger(entries);
+
+				yield* Effect.log("plain log").pipe(
+					Effect.provideService(References.CurrentLogLevel, "Debug"),
+					Effect.provideService(References.MinimumLogLevel, "Debug"),
+					Effect.provide(
+						EffectLogger.layer([
+							Logging.makeEffectLogger(baseLogger),
+						]),
+					),
+				);
+
+				assert.deepStrictEqual(entries, [
+					{
+						level: "debug",
+						fields: {},
+						msg: "plain log",
 					},
-				}),
-			),
-		),
+				]);
+			}),
 	);
 
-	it.effect("uses References.CurrentLogLevel for plain Effect.log calls", () =>
-		Effect.gen(function* () {
-			const entries: Array<LogEntry> = [];
-			const baseLogger = makeTestLogger(entries);
+	it.effect(
+		"does not call a Pino method for the None current log level",
+		() =>
+			Effect.gen(function* () {
+				const entries: Array<LogEntry> = [];
+				const baseLogger = makeTestLogger(entries);
 
-			yield* Effect.log("plain log").pipe(
-				Effect.provideService(References.CurrentLogLevel, "Debug"),
-				Effect.provideService(References.MinimumLogLevel, "Debug"),
-				Effect.provide(
-					EffectLogger.layer([Logging.makeEffectLogger(baseLogger)]),
-				),
-			);
+				yield* Effect.log("hidden log").pipe(
+					Effect.provideService(References.CurrentLogLevel, "None"),
+					Effect.provideService(References.MinimumLogLevel, "All"),
+					Effect.provide(
+						EffectLogger.layer([
+							Logging.makeEffectLogger(baseLogger),
+						]),
+					),
+				);
 
-			assert.deepStrictEqual(entries, [
-				{
-					level: "debug",
-					fields: {},
-					msg: "plain log",
-				},
-			]);
-		}),
+				assert.deepStrictEqual(entries, []);
+			}),
 	);
 
-	it.effect("does not call a Pino method for the None current log level", () =>
-		Effect.gen(function* () {
-			const entries: Array<LogEntry> = [];
-			const baseLogger = makeTestLogger(entries);
+	it.effect(
+		"emits References.CurrentLogSpans as structured span durations",
+		() =>
+			Effect.gen(function* () {
+				const entries: Array<LogEntry> = [];
+				const baseLogger = makeTestLogger(entries);
 
-			yield* Effect.log("hidden log").pipe(
-				Effect.provideService(References.CurrentLogLevel, "None"),
-				Effect.provideService(References.MinimumLogLevel, "All"),
-				Effect.provide(
-					EffectLogger.layer([Logging.makeEffectLogger(baseLogger)]),
-				),
-			);
+				yield* Effect.logInfo("checkout complete").pipe(
+					Effect.withLogSpan("checkout"),
+					Effect.provide(
+						EffectLogger.layer([
+							Logging.makeEffectLogger(baseLogger),
+						]),
+					),
+				);
 
-			assert.deepStrictEqual(entries, []);
-		}),
-	);
-
-	it.effect("emits References.CurrentLogSpans as structured span durations", () =>
-		Effect.gen(function* () {
-			const entries: Array<LogEntry> = [];
-			const baseLogger = makeTestLogger(entries);
-
-			yield* Effect.logInfo("checkout complete").pipe(
-				Effect.withLogSpan("checkout"),
-				Effect.provide(
-					EffectLogger.layer([Logging.makeEffectLogger(baseLogger)]),
-				),
-			);
-
-			assert.strictEqual(entries.length, 1);
-			assert.strictEqual(entries[0]?.level, "info");
-			assert.strictEqual(entries[0]?.msg, "checkout complete");
-			assert.deepStrictEqual(Object.keys(entries[0]?.fields ?? {}), [
-				"spans",
-			]);
-			const spans = entries[0]?.fields.spans as
-				| Record<string, unknown>
-				| undefined;
-			assert.strictEqual(typeof spans?.checkout, "number");
-		}),
+				assert.strictEqual(entries.length, 1);
+				assert.strictEqual(entries[0]?.level, "info");
+				assert.strictEqual(entries[0]?.msg, "checkout complete");
+				assert.deepStrictEqual(Object.keys(entries[0]?.fields ?? {}), [
+					"spans",
+				]);
+				const spans = entries[0]?.fields.spans as
+					| Record<string, unknown>
+					| undefined;
+				assert.strictEqual(typeof spans?.checkout, "number");
+			}),
 	);
 });

--- a/rivetkit-typescript/packages/effect/test/e2e.test.ts
+++ b/rivetkit-typescript/packages/effect/test/e2e.test.ts
@@ -72,16 +72,16 @@ const TestLayer = ReadyForEnvoy.pipe(
 	Layer.provideMerge(
 		Registry.test.pipe(
 			Layer.provideMerge(
-					Layer.mergeAll(
-						CounterLive,
-						PingerLive,
-						FailingActorLive,
-						FailingWakeCleanupLive,
-						StrictLive,
-						WakeDecodeFailLive,
-						BuildSetRejectedLive,
-						TransformedStateActorLive,
-					),
+				Layer.mergeAll(
+					CounterLive,
+					PingerLive,
+					FailingActorLive,
+					FailingWakeCleanupLive,
+					StrictLive,
+					WakeDecodeFailLive,
+					BuildSetRejectedLive,
+					TransformedStateActorLive,
+				),
 			),
 			Layer.provideMerge(Flags.layer),
 			Layer.provide(GreeterLive),
@@ -368,10 +368,12 @@ layer(TestLayer)("end-to-end", (it) => {
 			const key = "t-action-scope-close";
 			const flags = yield* Flags;
 			const counter = (yield* Counter.client).getOrCreate([key]);
-			const actionFiber = yield* counter.SleepDuringAction().pipe(
-				Effect.flip,
-				Effect.forkChild({ startImmediately: true }),
-			);
+			const actionFiber = yield* counter
+				.SleepDuringAction()
+				.pipe(
+					Effect.flip,
+					Effect.forkChild({ startImmediately: true }),
+				);
 
 			const started = yield* Effect.sync(() =>
 				flags.get(`sleep-during-action-started:${key}`),
@@ -653,11 +655,11 @@ layer(TestLayer)("end-to-end", (it) => {
 		}),
 	);
 
-		it.effect("surfaces an error thrown inside an actor's build effect", () =>
-			Effect.gen(function* () {
-				// `getOrCreate` only builds a typed proxy on the client and
-				// rivetkit's wake is lazy on first action, so the build
-				// defect surfaces on `.Ping()`, not here.
+	it.effect("surfaces an error thrown inside an actor's build effect", () =>
+		Effect.gen(function* () {
+			// `getOrCreate` only builds a typed proxy on the client and
+			// rivetkit's wake is lazy on first action, so the build
+			// defect surfaces on `.Ping()`, not here.
 			const failing = (yield* FailingActor.client).getOrCreate([
 				"t-build-error",
 			]);
@@ -665,44 +667,44 @@ layer(TestLayer)("end-to-end", (it) => {
 			assert.isTrue(exit._tag === "Success");
 			if (exit._tag === "Success") {
 				assert.instanceOf(exit.value, RivetError.RivetError);
+			}
+		}),
+	);
+
+	it.effect(
+		"closes the wake scope when wake fails after registering scoped resources",
+		() =>
+			Effect.gen(function* () {
+				const key = "t-failed-wake-cleanup";
+				const flags = yield* Flags;
+				const actor = (yield* FailingWakeCleanup.client).getOrCreate([
+					key,
+				]);
+
+				const exit = yield* actor.Ping().pipe(Effect.flip, Effect.exit);
+				assert.isTrue(exit._tag === "Success");
+				if (exit._tag === "Success") {
+					assert.instanceOf(exit.value, RivetError.RivetError);
 				}
+
+				assert.strictEqual(
+					flags.get(`failed-wake-started:${key}`),
+					true,
+				);
+				assert.strictEqual(
+					flags.get(`failed-wake-finalizer:${key}`),
+					true,
+				);
+				assert.strictEqual(
+					flags.get(`failed-wake-fiber-interrupted:${key}`),
+					true,
+				);
 			}),
-		);
+	);
 
-		it.effect(
-			"closes the wake scope when wake fails after registering scoped resources",
-			() =>
-				Effect.gen(function* () {
-					const key = "t-failed-wake-cleanup";
-					const flags = yield* Flags;
-					const actor = (yield* FailingWakeCleanup.client).getOrCreate([
-						key,
-					]);
-
-					const exit = yield* actor.Ping().pipe(Effect.flip, Effect.exit);
-					assert.isTrue(exit._tag === "Success");
-					if (exit._tag === "Success") {
-						assert.instanceOf(exit.value, RivetError.RivetError);
-					}
-
-					assert.strictEqual(
-						flags.get(`failed-wake-started:${key}`),
-						true,
-					);
-					assert.strictEqual(
-						flags.get(`failed-wake-finalizer:${key}`),
-						true,
-					);
-					assert.strictEqual(
-						flags.get(`failed-wake-fiber-interrupted:${key}`),
-						true,
-					);
-				}),
-		);
-
-		it.effect(
-			"wake options state decode failure inside build effect surfaces as RivetError",
-			() =>
+	it.effect(
+		"wake options state decode failure inside build effect surfaces as RivetError",
+		() =>
 			Effect.gen(function* () {
 				const failing = (yield* WakeDecodeFail.client).getOrCreate([
 					"t-wake-decode-fail",

--- a/rivetkit-typescript/packages/effect/test/fixtures/actors.ts
+++ b/rivetkit-typescript/packages/effect/test/fixtures/actors.ts
@@ -471,7 +471,10 @@ export const CounterLive = Counter.toLayer(
 					Effect.gen(function* () {
 						const key = address.key.join("/");
 						yield* Effect.sync(() => {
-							flags.set(`sleep-during-action-started:${key}`, true);
+							flags.set(
+								`sleep-during-action-started:${key}`,
+								true,
+							);
 						});
 						yield* sleep;
 						return yield* Effect.never.pipe(

--- a/rivetkit-typescript/packages/effect/test/shared-engine.ts
+++ b/rivetkit-typescript/packages/effect/test/shared-engine.ts
@@ -6,7 +6,11 @@ import {
 	TEST_ENGINE_TOKEN,
 } from "../../rivetkit/tests/shared-engine";
 
-export { getOrStartSharedTestEngine, releaseSharedTestEngine, TEST_ENGINE_TOKEN };
+export {
+	getOrStartSharedTestEngine,
+	releaseSharedTestEngine,
+	TEST_ENGINE_TOKEN,
+};
 export type { SharedTestEngine };
 
 export interface PreparedNamespace {

--- a/rivetkit-typescript/packages/rivetkit/src/utils/env-vars.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/utils/env-vars.ts
@@ -52,10 +52,14 @@ export const getRivetkitRuntime = (): string | undefined =>
 	getEnvUniversal("RIVETKIT_RUNTIME");
 export type RuntimeMode = "envoy" | "serverless";
 
-export const getRivetkitRuntimeMode = (): RuntimeMode =>
-	getEnvUniversal("RIVETKIT_RUNTIME_MODE") === "serverless"
-		? "serverless"
-		: "envoy";
+export const getRivetkitRuntimeMode = (): RuntimeMode => {
+	const value = getEnvUniversal("RIVETKIT_RUNTIME_MODE");
+	if (value === undefined) return "envoy";
+	if (value === "envoy" || value === "serverless") return value;
+	throw new Error(
+		`RIVETKIT_RUNTIME_MODE env var must be "envoy" or "serverless"; got "${value}"`,
+	);
+};
 
 export const getRivetkitPublicDir = (): string | undefined => {
 	const value = getEnvUniversal("RIVETKIT_PUBLIC_DIR");

--- a/rivetkit-typescript/packages/rivetkit/tests/listener.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/listener.test.ts
@@ -30,14 +30,18 @@ describe("getRivetkitRuntimeMode", () => {
 		expect(getRivetkitRuntimeMode()).toBe("envoy");
 	});
 
-	test("empty string is envoy", () => {
+	test("empty string is rejected", () => {
 		process.env.RIVETKIT_RUNTIME_MODE = "";
-		expect(getRivetkitRuntimeMode()).toBe("envoy");
+		expect(() => getRivetkitRuntimeMode()).toThrow(
+			/RIVETKIT_RUNTIME_MODE env var must be/,
+		);
 	});
 
-	test("unrecognized value is envoy", () => {
+	test("unrecognized value is rejected", () => {
 		process.env.RIVETKIT_RUNTIME_MODE = "potato";
-		expect(getRivetkitRuntimeMode()).toBe("envoy");
+		expect(() => getRivetkitRuntimeMode()).toThrow(
+			/RIVETKIT_RUNTIME_MODE env var must be/,
+		);
 	});
 });
 

--- a/rivetkit-typescript/packages/rivetkit/tests/registry-shutdown.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/registry-shutdown.test.ts
@@ -76,7 +76,10 @@ function createFake(): Fake {
 		handleServerlessRequest: async (
 			_registry: unknown,
 			_req: unknown,
-			onStreamEvent: (error: unknown, event?: { kind: string }) => unknown,
+			onStreamEvent: (
+				error: unknown,
+				event?: { kind: string },
+			) => unknown,
 		) => {
 			await onStreamEvent(null, { kind: "end" });
 			return { status: 200, headers: {} };
@@ -87,7 +90,9 @@ function createFake(): Fake {
 		state.builderCalls += 1;
 		// A distinct handle per build so fan-out can prove both modes were
 		// torn down (Mode A and Mode B build separate registries).
-		const registry = { id: state.builderCalls } as unknown as RegistryHandle;
+		const registry = {
+			id: state.builderCalls,
+		} as unknown as RegistryHandle;
 		const serveConfig = {
 			serverlessBasePath: "/api/rivet",
 			serverlessMaxStartPayloadBytes: 1024,

--- a/turbo.json
+++ b/turbo.json
@@ -25,6 +25,17 @@
 			"outputs": ["dist/**"],
 			"env": ["BASE_URL", "VITE_APP_*", "VITE_FEATURE_FLAGS"]
 		},
+		"build:inspector": {
+			"dependsOn": ["^build"],
+			"inputs": [
+				"src/**",
+				"vite.inspector.config.ts",
+				"tsconfig.json",
+				"package.json"
+			],
+			"outputs": ["dist/**"],
+			"env": ["VITE_APP_*", "VITE_DEPLOYMENT_TYPE"]
+		},
 		"build:inspector-ui": {
 			"dependsOn": ["^build"],
 			"inputs": [

--- a/website/src/content/docs/general/environment-variables.mdx
+++ b/website/src/content/docs/general/environment-variables.mdx
@@ -68,7 +68,7 @@ These variables configure how clients connect to your actors.
 
 | Environment Variable | Description |
 |---------------------|-------------|
-| `RIVETKIT_RUNTIME_MODE` | Controls how `registry.start()` runs. Defaults to `envoy`: opens a long-lived WebSocket to the engine (Mode A). Set to `serverless` to bind an HTTP listener via `registry.listen()` (Mode B). |
+| `RIVETKIT_RUNTIME_MODE` | Controls how `registry.start()` runs. Accepted values are `envoy` and `serverless`; any other explicit value errors. Defaults to `envoy`: opens a long-lived WebSocket to the engine (Mode A). Set to `serverless` to bind an HTTP listener via `registry.listen()` (Mode B). |
 | `RIVETKIT_PUBLIC_DIR` | Directory of static assets to serve alongside the framework routes when calling `registry.listen()`. Used as a fallback when `opts.publicDir` is not passed. On auto-listen via `registry.start()`, defaults to `/public` when this env var is unset. |
 | `RIVET_PORT` | Port the listener binds when calling `registry.listen()` without an explicit `opts.port`. Must be an integer between 1 and 65535. Defaults to `3000`. |
 


### PR DESCRIPTION
## Summary
- Reject explicit `RIVETKIT_RUNTIME_MODE` values other than `envoy` or `serverless`; unset still defaults to `envoy`.
- Update listener coverage and env-var docs for the stricter runtime-mode contract.
- Apply Biome formatting to files reported by CI and add `rivetkit` as an `@rivetkit/effect` dev dependency so clean Turbo builds order `rivetkit` before `@rivetkit/effect`.
- Add the missing Turbo `build:inspector` task used by the Railway inspector Dockerfile, and make kitchen-sink top-level `/health` a process-readiness endpoint while leaving RivetKit health at `/api/rivet/health`.

## Validation
- `pnpm --filter rivetkit exec vitest run tests/listener.test.ts -t getRivetkitRuntimeMode`
- `pnpm exec biome check ./rivetkit-typescript --formatter-enabled=true --linter-enabled=false --assist-enabled=false`
- `pnpm exec biome check ./frontend --formatter-enabled=true --linter-enabled=false --assist-enabled=false`
- `pnpm exec turbo run build --filter='./rivetkit-typescript/packages/effect' --force`
- `pnpm exec turbo run build:inspector --filter=@rivetkit/engine-frontend --force`
- `pnpm --filter kitchen-sink build`
- built kitchen-sink server returns `200 {"ok":true}` from `/health`