### PR TITLE
Website: blog list changelog feed + blog/docs icon fixes

### DIFF
--- a/website/src/components/ArticleSocials.tsx
+++ b/website/src/components/ArticleSocials.tsx
@@ -3,8 +3,8 @@ import { getSiteUrl } from "@/lib/siteUrl";
 import {
 	Icon,
 	faHackerNews,
-	faReddit,
-	faRssSquare,
+	faRedditAlien,
+	faRss,
 	faXTwitter,
 } from "@rivet-gg/icons";
 import { useState, useEffect } from "react";
@@ -20,7 +20,7 @@ export function ArticleSocials({ title }) {
 	const articleUrl = siteUrl + pathname;
 	return (
 		<div className="relative mt-14 flex items-center justify-center after:absolute after:inset-x-0 after:-z-[1] after:h-[1px] after:bg-ink/10">
-			<SocialIcon url="/rss/feed.xml" icon={faRssSquare} />
+			<SocialIcon url="/rss/feed.xml" icon={faRss} />
 			<SocialIcon
 				url={`https://x.com/share?text=${encodeURIComponent(`${title} ${articleUrl} via @rivet_dev`)}`}
 				icon={faXTwitter}
@@ -33,7 +33,7 @@ export function ArticleSocials({ title }) {
 			/>
 			<SocialIcon
 				url={`https://www.reddit.com/submit?url=${articleUrl}&title=${encodeURIComponent(title)}`}
-				icon={faReddit}
+				icon={faRedditAlien}
 			/>
 		</div>
 	);

--- a/website/src/components/ArticleSocials.tsx
+++ b/website/src/components/ArticleSocials.tsx
@@ -13,7 +13,7 @@ export function ArticleSocials({ title }) {
 	const siteUrl = getSiteUrl();
 	const articleUrl = siteUrl + pathname;
 	return (
-		<div className="relative mt-14 flex items-center justify-center after:absolute after:inset-x-0 after:-z-[1] after:h-[1px] after:bg-ink/10">
+		<div className="mt-14 flex items-center justify-center gap-2">
 			<SocialIcon url="/rss/feed.xml">
 				<Icon icon={faRss} size="xl" />
 			</SocialIcon>
@@ -44,7 +44,7 @@ function SocialIcon({ url, children }) {
 			href={url}
 			target="_blank"
 			rel="noreferrer"
-			className="bg-paper px-3 text-ink-faint transition-colors hover:text-pine"
+			className="px-3 text-ink-faint transition-colors hover:text-pine"
 		>
 			{children}
 		</a>

--- a/website/src/components/ArticleSocials.tsx
+++ b/website/src/components/ArticleSocials.tsx
@@ -1,12 +1,6 @@
 "use client";
 import { getSiteUrl } from "@/lib/siteUrl";
-import {
-	Icon,
-	faHackerNews,
-	faRedditAlien,
-	faRss,
-	faXTwitter,
-} from "@rivet-gg/icons";
+import { Icon, faRedditAlien, faRss, faXTwitter } from "@rivet-gg/icons";
 import { useState, useEffect } from "react";
 
 export function ArticleSocials({ title }) {
@@ -20,26 +14,31 @@ export function ArticleSocials({ title }) {
 	const articleUrl = siteUrl + pathname;
 	return (
 		<div className="relative mt-14 flex items-center justify-center after:absolute after:inset-x-0 after:-z-[1] after:h-[1px] after:bg-ink/10">
-			<SocialIcon url="/rss/feed.xml" icon={faRss} />
+			<SocialIcon url="/rss/feed.xml">
+				<Icon icon={faRss} size="xl" />
+			</SocialIcon>
 			<SocialIcon
 				url={`https://x.com/share?text=${encodeURIComponent(`${title} ${articleUrl} via @rivet_dev`)}`}
-				icon={faXTwitter}
-			/>
+			>
+				<Icon icon={faXTwitter} size="xl" />
+			</SocialIcon>
 			<SocialIcon
 				url={`https://news.ycombinator.com/submitlink?u=${encodeURIComponent(
 					articleUrl,
 				)}&t=${encodeURIComponent(title)}`}
-				icon={faHackerNews}
-			/>
+			>
+				<HackerNewsIcon />
+			</SocialIcon>
 			<SocialIcon
 				url={`https://www.reddit.com/submit?url=${articleUrl}&title=${encodeURIComponent(title)}`}
-				icon={faRedditAlien}
-			/>
+			>
+				<Icon icon={faRedditAlien} size="xl" />
+			</SocialIcon>
 		</div>
 	);
 }
 
-function SocialIcon({ url, icon }) {
+function SocialIcon({ url, children }) {
 	return (
 		<a
 			href={url}
@@ -47,7 +46,27 @@ function SocialIcon({ url, icon }) {
 			rel="noreferrer"
 			className="bg-paper px-3 text-ink-faint transition-colors hover:text-pine"
 		>
-			<Icon icon={icon} size="xl" />
+			{children}
 		</a>
+	);
+}
+
+// Hacker News has no boxless brand glyph in Font Awesome, so we draw the bare
+// "Y" mark here to match the other boxless icons in the share row.
+function HackerNewsIcon() {
+	return (
+		<svg
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2.7"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+			focusable="false"
+			className="inline-block h-[1.45em] w-[1.45em] align-[-0.125em]"
+		>
+			<path d="M6 5 L12 13 L12 19.5 M18 5 L12 13" />
+		</svg>
 	);
 }

--- a/website/src/components/BlogArticle.astro
+++ b/website/src/components/BlogArticle.astro
@@ -178,7 +178,7 @@ const otherArticles = allPosts
 		color: #1b1916;
 	}
 
-	.blog-article .blog-prose a {
+	.blog-article .blog-prose a:not(.not-prose) {
 		color: #2e4034;
 		text-decoration: underline;
 		text-decoration-color: rgb(46 64 52 / 0.35);
@@ -188,7 +188,7 @@ const otherArticles = allPosts
 		transition: text-decoration-color 0.15s ease, color 0.15s ease;
 	}
 
-	.blog-article .blog-prose a:hover {
+	.blog-article .blog-prose a:not(.not-prose):hover {
 		color: #1b1916;
 		text-decoration-color: rgb(46 64 52 / 0.9);
 	}
@@ -261,9 +261,9 @@ const otherArticles = allPosts
 		color: #1b1916;
 	}
 
-	.blog-article .blog-prose h2 a,
-	.blog-article .blog-prose h3 a,
-	.blog-article .blog-prose h4 a {
+	.blog-article .blog-prose h2 a:not(.not-prose),
+	.blog-article .blog-prose h3 a:not(.not-prose),
+	.blog-article .blog-prose h4 a:not(.not-prose) {
 		color: inherit;
 		text-decoration: none;
 	}

--- a/website/src/pages/blog/index.astro
+++ b/website/src/pages/blog/index.astro
@@ -13,16 +13,19 @@ const MONTHS = [
 
 const posts = await getCollection('posts');
 
-// Blog posts for the main column
-const blogPosts = posts
-	.filter((post) => post.data.category !== 'changelog' && !post.data.unpublished)
+// Unified feed of blog posts and changelog entries for the main column, newest
+// first. Changelog entries route to /changelog/, everything else to /blog/.
+const articles = posts
+	.filter((post) => !post.data.unpublished)
 	.sort((a, b) => b.data.published.getTime() - a.data.published.getTime())
 	.map((post) => {
 		const slug = post.id.replace(/\/page$/, '');
 		const data = post.data as unknown as { title: string; description: string };
+		const section = post.data.category === 'changelog' ? 'changelog' : 'blog';
 		return {
 			...post,
 			slug,
+			href: `/${section}/${slug}/`,
 			image: getPostImage(post),
 			title: data.title,
 			description: data.description,
@@ -106,10 +109,10 @@ for (const entry of changelogPosts) {
 				</div>
 			</aside>
 
-			<!-- Blog posts -->
+			<!-- Blog posts + changelog -->
 			<div class="order-first grid grid-cols-1 gap-6 md:grid-cols-2 lg:order-none">
-				{blogPosts.map((article) => (
-					<a href={`/blog/${article.slug}/`} class="size-full">
+				{articles.map((article) => (
+					<a href={article.href} class="size-full">
 						<article class="flex size-full flex-col items-start justify-between border border-ink/10 bg-white/55 p-4 transition-colors hover:border-ink/25">
 							<div class="w-full">
 								{article.image && (


### PR DESCRIPTION
Three small website changes for the blog/docs.

## 1. Changelog entries in the blog list feed

The `/blog` index center column now shows **both** blog posts and changelog entries, sorted newest-first. The month-grouped changelog sidebar is kept as-is. Previously the center grid filtered out `category: 'changelog'`, so changelog appeared only in the sidebar.

- `website/src/pages/blog/index.astro`: build one unified `articles` feed from all published posts. Each card routes to `/changelog/{slug}/` for changelog entries and `/blog/{slug}/` for everything else.

## 2. Drop white icon backgrounds on the blog post share row

The bottom-of-post share icons used filled/squared Font Awesome variants whose symbol is knocked out in white (a boxy "white background" look), inconsistent with the bare X glyph. All four are now bare, boxless marks.

- `website/src/components/ArticleSocials.tsx`: `faRssSquare` → `faRss`, `faReddit` → `faRedditAlien`. X stays `faXTwitter`.
- Hacker News has no boxless brand glyph in Font Awesome (every HN/YC mark is a filled square — the HN logo *is* a square "Y"), so its icon is now a small custom boxless "Y" SVG drawn to match the weight of the other icons.

## 3. Heading copy-link icon was invisible (black-on-black) in blog posts

Hovering a section heading's copy-link button filled it with `ink` but the link icon stayed `ink` too, so it disappeared. Root cause: the blog prose link rules (`.blog-prose a` and `.blog-prose h2/h3/h4 a { color: inherit }`) matched the `not-prose` anchor button and out-specified its `hover:text-white`. Docs were unaffected (the typography plugin's `:where()` selectors already respect `not-prose`).

- `website/src/components/BlogArticle.astro`: scope those prose link rules with `:not(.not-prose)` so the heading anchor button keeps its own hover color. The icon is now white on the ink hover background, matching docs.