### PR TITLE
fix(website): docs config schema text color + sidebar scroll persistence

### DIFF
--- a/website/src/components/ActiveLink.tsx
+++ b/website/src/components/ActiveLink.tsx
@@ -1,7 +1,7 @@
 "use client";
 import type { ReactNode, AnchorHTMLAttributes } from "react";
 import { normalizePath } from "@/lib/normalizePath";
-import { useState, useEffect } from "react";
+import { usePathname } from "@/hooks/usePathname";
 
 export interface ActiveLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
 	isActive?: boolean;
@@ -17,11 +17,7 @@ export function ActiveLink({
 	children,
 	...props
 }: ActiveLinkProps) {
-	const [pathname, setPathname] = useState("");
-
-	useEffect(() => {
-		setPathname(window.location.pathname);
-	}, []);
+	const pathname = usePathname();
 
 	const isActive =
 		isActiveOverride ||

--- a/website/src/components/DocsNavigation.tsx
+++ b/website/src/components/DocsNavigation.tsx
@@ -6,7 +6,7 @@ import type { SidebarItem } from "@/lib/sitemap";
 import { cn } from "@rivet-gg/components";
 import { Icon, faArrowUpRight } from "@rivet-gg/icons";
 import clsx from "clsx";
-import type { PropsWithChildren, ReactNode } from "react";
+import { type PropsWithChildren, type ReactNode, useEffect, useRef } from "react";
 
 interface TreeItemProps {
 	index: number;
@@ -173,10 +173,31 @@ export function NavLink({
 	);
 }
 
-export function DocsNavigation({ sidebar }: { sidebar: SidebarItem[] }) {
+export function DocsNavigation({
+	sidebar,
+	tabKey,
+}: { sidebar: SidebarItem[]; tabKey?: string }) {
+	const scrollRef = useRef<HTMLDivElement>(null);
+	const prevTabKey = useRef(tabKey);
+
+	// The sidebar island is persisted across view transitions to keep its scroll
+	// position, so it does not remount when navigating within a tab. Reset the
+	// scroll only when moving to a different tab, whose sidebar is unrelated.
+	useEffect(() => {
+		if (prevTabKey.current !== tabKey) {
+			prevTabKey.current = tabKey;
+			if (scrollRef.current) {
+				scrollRef.current.scrollTop = 0;
+			}
+		}
+	}, [tabKey]);
+
 	return (
 		<NavigationStateProvider>
-			<div className="sticky top-header max-h-content text-ink pl-8 pr-6 py-6 overflow-y-auto [mask-image:linear-gradient(to_bottom,transparent_0,#000_2rem,#000_calc(100%-1.5rem),transparent_100%)] [-webkit-mask-image:linear-gradient(to_bottom,transparent_0,#000_2rem,#000_calc(100%-1.5rem),transparent_100%)]">
+			<div
+				ref={scrollRef}
+				className="sticky top-header max-h-content text-ink pl-8 pr-6 py-6 overflow-y-auto [mask-image:linear-gradient(to_bottom,transparent_0,#000_2rem,#000_calc(100%-1.5rem),transparent_100%)] [-webkit-mask-image:linear-gradient(to_bottom,transparent_0,#000_2rem,#000_calc(100%-1.5rem),transparent_100%)]"
+			>
 				<Tree pages={sidebar} />
 			</div>
 		</NavigationStateProvider>

--- a/website/src/components/FoldableSchema.tsx
+++ b/website/src/components/FoldableSchema.tsx
@@ -16,7 +16,7 @@ export function Foldable({
 			<button
 				type="button"
 				className={cn(
-					"mt-2 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors",
+					"mt-2 flex items-center gap-1 text-xs text-muted-foreground hover:text-ink transition-colors",
 				)}
 				onClick={() => setIsOpen((open) => !open)}
 			>

--- a/website/src/components/JsonSchemaPreview.tsx
+++ b/website/src/components/JsonSchemaPreview.tsx
@@ -368,9 +368,9 @@ export function PropertyLabel({
 					className,
 				)}
 			>
-				<code className="text-foreground/90">
+				<code className="text-ink/90">
 					{parent ? <>{parent}.</> : null}
-					<span className="font-bold text-foreground">{name}</span>
+					<span className="font-bold text-ink">{name}</span>
 				</code>
 				<div className="text-xs text-muted-foreground">
 					{getPropertyTypeLabel(schema, defs, nullable)}
@@ -392,7 +392,7 @@ function TypeLabel({ type, description }: TypeLabelProps) {
 	return (
 		<>
 			<div className="scrollbar-hide flex items-center gap-1 overflow-auto">
-				<code className="font-bold text-foreground">
+				<code className="font-bold text-ink">
 					{getTypeLabel(type)}
 				</code>
 			</div>

--- a/website/src/hooks/usePathname.ts
+++ b/website/src/hooks/usePathname.ts
@@ -9,7 +9,12 @@ export function usePathname(): string {
 	const [pathname, setPathname] = useState("");
 
 	useEffect(() => {
-		setPathname(window.location.pathname);
+		const update = () => setPathname(window.location.pathname);
+		update();
+		// Astro view transitions swap the page without remounting persisted
+		// islands, so listen for navigation to keep the pathname current.
+		document.addEventListener("astro:page-load", update);
+		return () => document.removeEventListener("astro:page-load", update);
 	}, []);
 
 	return pathname;

--- a/website/src/pages/docs/[...slug].astro
+++ b/website/src/pages/docs/[...slug].astro
@@ -92,7 +92,7 @@ const breadcrumbSchema = {
 <DocsLayout title={`${title} - Rivet`} description={description} canonicalUrl={canonicalUrl} sidebar={foundTab?.tab?.sidebar}>
 	<script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
 	<aside class="hidden md:block border-r border-ink/10">
-		{foundTab?.tab?.sidebar && <DocsNavigation sidebar={foundTab.tab.sidebar} client:load />}
+		{foundTab?.tab?.sidebar && <DocsNavigation sidebar={foundTab.tab.sidebar} tabKey={foundTab.tab.title} client:load transition:persist="docs-sidebar" />}
 	</aside>
 	<div class="flex justify-center w-full min-w-0">
 		<div class="flex gap-8 max-w-6xl w-full min-w-0">


### PR DESCRIPTION
## Summary

Two independent fixes for the docs site, both on the light porcelain docs theme.

### 1. Config schema property names rendered white (invisible)

The Configuration Reference tables (actor / registry / engine config) rendered property names with `text-foreground`, which resolves to **white** under the site's global `dark` class. On the porcelain docs surface they were nearly invisible.

- `JsonSchemaPreview.tsx`: property name + parent-path prefix + enum type labels `text-foreground` → `text-ink` (the docs' primary text token).
- `FoldableSchema.tsx`: the "Show possible variants" toggle's `hover:text-foreground` → `hover:text-ink` (it also went white on hover).

Affects the actor-configuration, registry-configuration, and self-hosting/configuration pages.

### 2. Sidebar scroll position reset to top on every navigation

The docs use Astro view transitions, so clicking a sidebar link swaps the page client-side. Astro restores window scroll but **not inner scroll containers**, and the sidebar's scroll lives inside a React island that re-mounted on every navigation (which is how its active-item highlight updated).

- `[...slug].astro`: persist the sidebar island across navigations (`transition:persist`) so its scroll position survives.
- `usePathname.ts`: make it navigation-reactive (subscribe to `astro:page-load`) so the active highlight still updates without a re-mount. It already documented itself as replicating Next.js `usePathname`, which is reactive, so this also closes a latent contract gap.
- `ActiveLink.tsx`: use the now-reactive `usePathname`.
- `DocsNavigation.tsx`: reset sidebar scroll to top only when the tab (nav tree) changes.

Within-tab navigation now keeps the sidebar's scroll position; switching tabs resets it.

## Testing

Not yet verified in a running browser (this workspace had no `node_modules`). The changes follow documented Astro view-transition behavior (`transition:persist` for sidebar scroll is the canonical Astro use case), but a quick visual check on the docs is recommended. Targets the desktop sidebar; the mobile drawer nav is a separate component.