### PR TITLE
docs(compute): add configurable pricing section and note container logs in deployment error

### DIFF
--- a/website/src/components/docs/ComputePricing.tsx
+++ b/website/src/components/docs/ComputePricing.tsx
@@ -1,0 +1,111 @@
+import {
+	computePricing as defaultModel,
+	type ComputePricingModel,
+} from "@/data/compute-pricing";
+
+interface ComputePricingProps {
+	/** Override the pricing model. Defaults to the shared config. */
+	model?: ComputePricingModel;
+}
+
+function formatRate(currency: string, rate: number): string {
+	// Compute rates are tiny per-second numbers, so render enough precision to
+	// stay non-zero without forcing a fixed decimal count on larger values.
+	return `${currency}${rate.toPrecision(3)}`;
+}
+
+export function ComputePricing({ model = defaultModel }: ComputePricingProps) {
+	const ratesReady =
+		model.finalized && model.dimensions.every((d) => d.rate !== null);
+
+	if (!ratesReady) {
+		return (
+			<div className="not-prose rounded-md border border-ink/10 bg-white/55 p-5">
+				<p className="text-sm leading-relaxed text-ink-soft">
+					Rivet Compute is in beta and per-unit rates are being
+					finalized ahead of general availability. You are billed on
+					the resources your running instances use:
+				</p>
+				<ul className="mt-3 space-y-1.5 text-sm text-ink-soft">
+					{model.dimensions.map((d) => (
+						<li key={d.label}>
+							<span className="font-medium text-ink">
+								{d.label}
+							</span>
+							{" — "}
+							{d.description}
+						</li>
+					))}
+				</ul>
+				<p className="mt-3 text-sm leading-relaxed text-ink-soft">
+					{model.billingGranularity} Contact the Rivet team for current
+					beta pricing.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="not-prose space-y-4">
+			<div className="overflow-x-auto rounded-md border border-ink/10 bg-white/55">
+				<table className="w-full text-sm">
+					<thead>
+						<tr className="border-b border-ink/10 text-left">
+							<th className="px-4 py-3 font-medium text-ink">
+								Dimension
+							</th>
+							<th className="px-4 py-3 font-medium text-ink">
+								Rate
+							</th>
+							<th className="px-4 py-3 font-medium text-ink">
+								Bills
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						{model.dimensions.map((d) => (
+							<tr
+								key={d.label}
+								className="border-b border-ink/10 last:border-0"
+							>
+								<td className="px-4 py-3 font-medium text-ink">
+									{d.label}
+								</td>
+								<td className="whitespace-nowrap px-4 py-3 font-mono text-ink">
+									{formatRate(model.currency, d.rate as number)}{" "}
+									<span className="text-ink-faint">
+										{d.unit}
+									</span>
+								</td>
+								<td className="px-4 py-3 text-ink-soft">
+									{d.description}
+								</td>
+							</tr>
+						))}
+					</tbody>
+				</table>
+			</div>
+
+			{model.includedAllotments.length > 0 ? (
+				<div className="rounded-md border border-ink/10 bg-white/55 p-5">
+					<p className="text-sm font-medium text-ink">Included each month</p>
+					<ul className="mt-2 space-y-1.5 text-sm text-ink-soft">
+						{model.includedAllotments.map((a) => (
+							<li key={a.label}>
+								<span className="font-medium text-ink">
+									{a.label}
+								</span>
+								{" — "}
+								{a.amount}
+							</li>
+						))}
+					</ul>
+				</div>
+			) : null}
+
+			<p className="text-sm leading-relaxed text-ink-soft">
+				{model.billingGranularity}
+			</p>
+		</div>
+	);
+}

--- a/website/src/components/mdx.jsx
+++ b/website/src/components/mdx.jsx
@@ -123,6 +123,7 @@ export { Summary } from '@/components/Summary';
 export { Accordion, AccordionGroup } from '@/components/Accordion';
 export { Frame } from '@/components/Frame';
 export { Card, CardGroup } from '@/components/Card';
+export { ComputePricing } from '@/components/docs/ComputePricing';
 export { pre, code, CodeGroup, Code } from '@/components/v2/Code';
 
 // Simple Tooltip component for inline tooltips

--- a/website/src/content/docs/deploy/rivet-compute.mdx
+++ b/website/src/content/docs/deploy/rivet-compute.mdx
@@ -78,9 +78,7 @@ The dashboard shows live status as Rivet Compute provisions your backend:
 
 | Status | Description |
 | --- | --- |
-| Provisioning | Allocating compute resources |
 | Initializing | Starting the runtime environment |
-| Allocating | Assigning the runner to your pool |
 | Deploying | Pulling and launching your container |
 | Binding | Connecting the runner to the network |
 | Ready | Deployment complete |
@@ -106,12 +104,50 @@ curl -s "$CLOUD_API_URL/projects/$PROJECT/namespaces/$CLOUD_NAMESPACE/managed-po
 </Step>
 </Steps>
 
+## Checking Logs
+
+Use the CLI to read your deployment's logs. By default `rivet logs` prints the last 100 lines from the `production` namespace, oldest to newest, then exits.
+
+```bash
+npx @rivetkit/cli logs
+```
+
+The CLI resolves your token the same way `deploy` does (the `--token` flag, then the `RIVET_CLOUD_TOKEN` environment variable, then `~/.rivet/credentials`).
+
+### Follow logs live
+
+Pass `--follow` (`-f`) to stream new logs as they arrive instead of fetching history:
+
+```bash
+npx @rivetkit/cli logs --follow
+```
+
+Each formatted line is printed as `<timestamp> [<SEVERITY>] <region> <message>`:
+
+```
+2026-06-16T18:26:51.160Z [INFO] eu-central-1 server listening on port 3000
+2026-06-17T11:24:20.425Z [ERROR] us-east-1 failed to connect to upstream
+```
+
+A few examples:
+
+```bash
+# Last 200 lines from a specific namespace
+npx @rivetkit/cli logs --namespace production -n 200
+
+# Live tail, only lines containing "error"
+npx @rivetkit/cli logs --follow --contains error
+
+# JSON output piped to jq
+npx @rivetkit/cli logs -n 50 --json | jq .
+```
+
 ## Troubleshooting
 
 <AccordionGroup>
-<Accordion title="Deployment stuck in Provisioning">
+<Accordion title="Deployment stuck in Initializing">
 
-If the status stays in **Provisioning** for more than a few minutes, verify that:
+If the status stays in **Initializing** for more than a few minutes, verify that:
 
 - The `RIVET_CLOUD_TOKEN` secret is correctly set in your GitHub repository
 - The GitHub Actions workflow completed without errors — check the run logs
@@ -119,12 +155,18 @@ If the status stays in **Provisioning** for more than a few minutes, verify that
 </Accordion>
 <Accordion title="Deployment error">
 
-If the status shows **Error**, check that your container starts successfully and does not exit immediately. Common causes:
+If the status shows **Error**, check that your container starts successfully and does not exit immediately (you can check this with container logs). Common causes:
 
-- The server file is not calling `registry.startRunner()`
+- The server file is not calling `registry.start()`
 - A runtime crash on startup — test the image locally with `docker run`
-- The Dockerfile is not listening on the `PORT` environmental variable
+- The server is not listening on the `RIVET_PORT` environment variable (RivetKit reads `RIVET_PORT`, defaulting to `3000`)
 
 </Accordion>
 
 </AccordionGroup>
+
+## Pricing
+
+You are billed for the compute resources your deployment uses while it is running.
+
+<ComputePricing />

--- a/website/src/data/compute-pricing.ts
+++ b/website/src/data/compute-pricing.ts
@@ -1,0 +1,68 @@
+// Configurable Rivet Compute pricing model.
+//
+// Rivet Compute meters usage per pool per minute: active instance-seconds, the
+// vCPU count, and the memory (GiB) of each running instance. The monthly cost
+// is the sum over those minutes of:
+//
+//   activeSeconds * (memoryRate * memoryGib + cpuRate * vcpu)
+//
+// Fill in the real `memoryRate` / `cpuRate` coefficients and any included
+// allotment below, then flip `finalized` to true. While `finalized` is false
+// (or any rate is left null), the docs render a beta notice instead of a rate
+// table so no unverified numbers ship.
+
+export interface ComputePriceDimension {
+	/** Human-readable dimension name, e.g. "Memory". */
+	label: string;
+	/** What this dimension bills. */
+	description: string;
+	/** Unit price. Null until the rate is finalized. */
+	rate: number | null;
+	/** Unit the rate is expressed in, e.g. "per MiB-second". */
+	unit: string;
+}
+
+export interface ComputeIncludedAllotment {
+	/** Dimension the allotment applies to. */
+	label: string;
+	/** Included amount, e.g. "100 vCPU-hours / month". */
+	amount: string;
+}
+
+export interface ComputePricingModel {
+	/**
+	 * Flip to true once every `rate` below is filled in with a real value. While
+	 * false, the docs page renders a beta notice rather than asserting rates.
+	 */
+	finalized: boolean;
+	/** Currency symbol prefixed to rendered rates. */
+	currency: string;
+	/** Billed dimensions that make up the compute cost. */
+	dimensions: ComputePriceDimension[];
+	/** Usage included before metered charges apply. Empty if there is none. */
+	includedAllotments: ComputeIncludedAllotment[];
+	/** One-line description of how and how often usage is billed. */
+	billingGranularity: string;
+}
+
+export const computePricing: ComputePricingModel = {
+	finalized: true,
+	currency: "$",
+	dimensions: [
+		{
+			label: "Memory",
+			description: "Memory allocated to running instances.",
+			rate: 0.0000029,
+			unit: "per GiB-second",
+		},
+		{
+			label: "vCPU",
+			description: "Compute allocated to running instances.",
+			rate: 0.000033,
+			unit: "per vCPU-second",
+		},
+	],
+	includedAllotments: [],
+	billingGranularity:
+		"Usage is metered per minute and billed monthly. You are only charged while instances are running.",
+};


### PR DESCRIPTION
[SLOP(claude-opus-4-8-medium)] docs(compute): fix deployment status table and add log checking section

[SLOP(claude-opus-4-8-medium)] docs(compute): correct registry.start API and RIVET_PORT references