### PR TITLE
fix(frontend): await sign-out and bypass session cache on login redirect

### DIFF
--- a/frontend/src/app/user-dropdown.tsx
+++ b/frontend/src/app/user-dropdown.tsx
@@ -204,11 +204,11 @@ export function UserDropdown({ children }: { children?: React.ReactNode }) {
 				</DropdownMenuItem>
 				<DropdownMenuSeparator />
 				<DropdownMenuItem
-					onSelect={() => {
-						authClient.signOut();
-						router.invalidate();
+					onSelect={async () => {
+						await authClient.signOut();
 						queryClient.clear();
-						return navigate({ to: "/login" });
+						await router.invalidate();
+						navigate({ to: "/login" });
 					}}
 				>
 					<Icon

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -21,7 +21,11 @@ export const Route = createFileRoute("/login")({
 		}
 
 		if (features.auth) {
-			const session = await authClient.getSession();
+			// Bypass the session cookie cache so a just-signed-out user is not
+			// bounced back into the app by a stale cached session.
+			const session = await authClient.getSession({
+				query: { disableCookieCache: true },
+			});
 			if (session.data) {
 				await redirectToOrganization({
 					from:


### PR DESCRIPTION
## Problem

Signing out sent the user to `https://dashboard.rivet.dev/login`, which 404'd while the app still showed them as logged in.

## Root cause

The sign-out handler fired `authClient.signOut()` **without awaiting** it, then immediately navigated to `/login`. Because the cloud-api has better-auth `cookieCache` enabled (confirmed by probing `get-session` during an in-flight sign-out — it kept returning the same cached session), `/login`'s `beforeLoad` called `authClient.getSession()` and got the **stale cached session**. That triggered `redirectToOrganization()`, which either bounced the user back to the org ("still logged in") or hit the now-dead session on the org fetch and threw `notFound()` → the **404 at `/login`**.

The race is latency-dependent, so it only manifests against the remote cloud-api, not the fast local stack.

## Fix

1. `user-dropdown.tsx` — await `signOut()` before clearing caches and navigating, so the session is actually gone before `/login` evaluates.
2. `login.tsx` — pass `disableCookieCache: true` to the redirect-gate `getSession()` so a just-signed-out user can't be bounced by a stale cached session (matches the existing pattern in `_context.tsx`).

## Testing

Verified on the local full cloud-api stack:
- Sign out → lands on `/login` with the login form, no 404, no bounce-back.
- Reload `/login` while signed out → stays on `/login` (uncached check sees the cleared session).
- Visit `/login` while genuinely signed in → still correctly redirects to the org.

Note: the production 404 itself could not be reproduced locally (latency-dependent; local cloud-api responds too fast to open the race window, and prod login is gated by Cloudflare Turnstile). The root-cause mechanism (`cookieCache` enabled + unawaited sign-out) was confirmed empirically.