### PR TITLE
docs(blog): add Rivet Compute launch week post

### DIFF
--- a/website/src/components/marketing/sections/RedesignedHero.tsx
+++ b/website/src/components/marketing/sections/RedesignedHero.tsx
@@ -211,10 +211,11 @@ const CopyInstallButton = () => {
 
 interface RedesignedHeroProps {
   latestChangelogTitle: string;
+  latestChangelogHref: string;
   thinkingImages: ThinkingImage[];
 }
 
-export const RedesignedHero = ({ latestChangelogTitle, thinkingImages }: RedesignedHeroProps) => {
+export const RedesignedHero = ({ latestChangelogTitle, latestChangelogHref, thinkingImages }: RedesignedHeroProps) => {
   const heroRef = useRef<HTMLElement>(null);
   // Fade the hero out as it scrolls away. Anchored to the hero's own height
   // (start..end against the top of the viewport) rather than a fixed viewport
@@ -243,7 +244,7 @@ export const RedesignedHero = ({ latestChangelogTitle, thinkingImages }: Redesig
               className='mb-7'
             >
               <a
-                href='/changelog'
+                href={latestChangelogHref}
                 className={`${GLOW_PILL_CLASS} group inline-flex items-center gap-2 rounded-full border border-ink/12 bg-paper/45 px-2.5 py-1 text-[13px] text-ink-soft shadow-[0_8px_22px_-20px_rgba(27,25,22,0.45)] transition-colors hover:border-ink/25 hover:text-ink`}
                 onMouseMove={handleGlowPillMouseMove}
               >

--- a/website/src/content.config.ts
+++ b/website/src/content.config.ts
@@ -42,7 +42,7 @@ const posts = defineCollection({
 	schema: z.object({
 		title: z.string(),
 		description: z.string(),
-		author: z.enum(['nathan-flurry', 'nicholas-kissel', 'forest-anderson']),
+		author: z.enum(['nathan-flurry', 'nicholas-kissel', 'forest-anderson', 'andrew-theberge']),
 		published: z.coerce.date(),
 		category: z.enum(['changelog', 'monthly-update', 'launch-week', 'technical', 'guide', 'frogs']),
 		keywords: z.array(z.string()).optional(),

--- a/website/src/content/posts/2026-06-17-introducing-rivet-compute/page.mdx
+++ b/website/src/content/posts/2026-06-17-introducing-rivet-compute/page.mdx
@@ -1,0 +1,56 @@
+---
+image: { format: "jpg", file: "image.jpg?1" }
+author: andrew-theberge
+published: "2026-06-17"
+category: changelog
+keywords: ["rivet", "compute", "serverless", "deploy", "actors", "hosting"]
+title: "Introducing Rivet Compute"
+description: "A serverless platform for hosting your actors. Deploy your backend to the cloud with a single command, no infrastructure to manage."
+---
+
+Today we're releasing **Rivet Compute**: a serverless platform dedicated to hosting your actors.
+
+Until now, running an actors backend meant bringing your own infrastructure. You either self-hosted the engine or deployed to a third-party platform like Vercel, and you owned the provisioning, scaling, and operations that came with it. Rivet Compute changes that. It's the first time you can deploy your actors directly onto infrastructure we run, with a single command and nothing to manage.
+
+## Deploy with one command
+
+Point the Rivet CLI at your project and deploy:
+
+```bash
+npx @rivetkit/cli deploy
+```
+
+The CLI resolves your project from the token, builds and pushes your Docker image to Rivet's built-in registry, provisions the managed pool, and prints your deployment URL once the pool is ready. There's no separate registry to configure, no cluster to stand up, and no infrastructure to wire together. Your backend is live as soon as the status reaches **Ready**.
+
+## Built for actors
+
+Rivet Compute isn't a generic container host that you have to adapt your app to. It's purpose-built for actors, so the runtime, networking, and actor lifecycle all work the way your app expects out of the box.
+
+- **No infrastructure to manage**: provisioning, scaling, and networking are handled for you. You ship your app, we run it.
+- **Actors ready on deploy**: once your deployment is **Ready**, your actors are live and available for connections.
+- **Live status**: the dashboard shows each phase as your backend comes up, from provisioning through to ready.
+
+## Push-to-deploy CI
+
+After your first local deploy, scaffold a GitHub Actions workflow that deploys on every push:
+
+```bash
+npx @rivetkit/cli setup-ci
+```
+
+This writes `.github/workflows/rivet-deploy.yml`, which creates production and pull-request namespaces, posts preview links on every PR, and cleans up preview namespaces when pull requests close. Set your token as a repository secret and every branch ships automatically:
+
+```bash
+gh secret set RIVET_CLOUD_TOKEN
+```
+
+## Pay for what runs
+
+Rivet Compute meters usage per minute and bills monthly. You're only charged while your instances are actually running, based on the memory and vCPU they use. There's no preview list and no waitlist. It's available today. See the [pricing page](/pricing) for the current rates.
+
+## Get started
+
+- [Deploying to Rivet Compute](/docs/deploy/rivet-compute)
+- [CLI reference](/docs/cli)
+- [Documentation](/docs)
+- [Discord](https://rivet.dev/discord)

--- a/website/src/lib/article.tsx
+++ b/website/src/lib/article.tsx
@@ -1,6 +1,7 @@
 const forestAnderson = { src: "https://assets.rivet.dev/repo/website/src/authors/forest-anderson/avatar.jpeg", width: 256, height: 256, format: "jpg" };
 const nathanFlurry = { src: "https://assets.rivet.dev/repo/website/src/authors/nathan-flurry/avatar.jpeg", width: 1516, height: 1516, format: "jpg" };
 const nicholasKissel = { src: "https://assets.rivet.dev/repo/website/src/authors/nicholas-kissel/avatar.jpeg", width: 256, height: 256, format: "jpg" };
+const andrewTheberge = { src: "https://assets.rivet.dev/repo/website/src/authors/nathan-flurry/avatar.jpeg", width: 1516, height: 1516, format: "jpg" };
 export const AUTHORS = {
 	"nathan-flurry": {
 		name: "Nathan Flurry",
@@ -26,6 +27,11 @@ export const AUTHORS = {
 		role: "Founding Engineer",
 		avatar: forestAnderson,
 		url: "https://twitter.com/angelonfira",
+	},
+	"andrew-theberge": {
+		name: "Andrew Theberge",
+		role: "Engineer",
+		avatar: andrewTheberge,
 	},
 } as const;
 

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -78,6 +78,9 @@ const latest = changelogEntries.sort(
 )[0];
 
 const latestChangelogTitle = latest?.data.title ?? '';
+const latestChangelogHref = latest
+	? `/changelog/${latest.id.replace(/\/page$/, '')}/`
+	: '/changelog';
 ---
 
 <MarketingLayout
@@ -89,7 +92,7 @@ const latestChangelogTitle = latest?.data.title ?? '';
 	<ScrollObserver client:load>
 		<div class="paper-grain min-h-screen font-sans text-ink-soft">
 			<main>
-				<RedesignedHero latestChangelogTitle={latestChangelogTitle} thinkingImages={thinkingImages} client:load />
+				<RedesignedHero latestChangelogTitle={latestChangelogTitle} latestChangelogHref={latestChangelogHref} thinkingImages={thinkingImages} client:load />
 				<ProductSplitSection client:visible />
 				<ObservabilitySection client:visible />
 				<IntegrationsSection client:visible />


### PR DESCRIPTION
[SLOP(claude-opus-4-8-medium)] docs(blog): drop --token flag from compute deploy snippet

[SLOP(claude-opus-4-8-medium)] docs(blog): recategorize compute post to changelog and add hero image