### PR TITLE
docs: fix typo

### DIFF
--- a/website/src/content/docs/general/architecture.mdx
+++ b/website/src/content/docs/general/architecture.mdx
@@ -57,7 +57,7 @@ skill: true
 	- having isolated state to each actor that combines compute and storage for in-memory reads and writes
 	- communication is standardized based on actions & events
 	- scale horizontally
-- read more about scalign at (link to scaling doc)
+- read more about scaling at [Design Patterns](/docs/actors/design-patterns)
 
 ### horizontal scaling
 

--- a/website/src/content/docs/general/architecture.mdx
+++ b/website/src/content/docs/general/architecture.mdx
@@ -54,7 +54,7 @@ skill: true
 ### architecting for scale
 
 - actors scale by:
-	- having isolated state to each acotr that combines compute and storage for in-memory reads and writes
+	- having isolated state to each actor that combines compute and storage for in-memory reads and writes
 	- communication is stndardized based on actions & events
 	- scale horizontally
 - read more about scalign at (link to scaling doc)
@@ -94,11 +94,11 @@ actors have create, destroy, wake, and sleep lifecycle hooks that you can implem
 
 ### multi-region, globally unique actor keys
 
-- acotrs can optionally have a globally unique "key"
+- actors can optionally have a globally unique "key"
 - when creating an actor with a key
 - this system is highly optimized to reduce wan round trips using per-key Paxos with a custom database called Epoxy (https://github.com/rivet-dev/rivet/tree/main/engine/packages/epoxy)
 - limitation: when creating an actor with a given key, that key will always be pinned to that region even if the actor is destroyed. creating a new actor with the same key will always live in the same region.
-- see the acotr keys document
+- see the actors keys document
 
 ### input
 
@@ -249,7 +249,7 @@ there are 2 types of runners:
 ### runner pool
 
 - runners are pooled together by sharing a common name (ie "default")
-- when an acotr is created, it chooses the pool by selecting the runner name to run on
+- when an actor is created, it chooses the pool by selecting the runner name to run on
 - rivet will automatically load balance actors across these runners
 
 ### runner key
@@ -374,7 +374,7 @@ TODO: copy the rest of this from low-level webosckets document and rephrase
 
 ### globally unique actor keys
 
-- acotr keys are globally unique to be able to benefit from multi-region capabilities without any extra work
+- actor keys are globally unique to be able to benefit from multi-region capabilities without any extra work
 - see more about globally uniuqe actor keys above
 - see the actor keys document
 

--- a/website/src/content/docs/general/architecture.mdx
+++ b/website/src/content/docs/general/architecture.mdx
@@ -43,7 +43,7 @@ skill: true
 
 - actors are designed to have an actor-per-entity
 - you can think about actors a bit like objects in object-oriented programming where each is responsible for their own state and expose methods (ie actions in our case)
-- examples incldue
+- examples include
 	- actor per user
 	- actor per user session
 	- actor per document

--- a/website/src/content/docs/general/architecture.mdx
+++ b/website/src/content/docs/general/architecture.mdx
@@ -9,7 +9,7 @@ skill: true
 ### rivetkit
 
 - rivetkit is the typescript library used for both local development & to connect your application to rivet
-- a rivetkit instance is called a "runner." you can run multiple runners to scale rivetkit horiziotnally. read omre about runners below.
+- a rivetkit instance is called a "runner." you can run multiple runners to scale rivetkit horiziotnally. read more about runners below.
 
 #### local development
 

--- a/website/src/content/docs/general/architecture.mdx
+++ b/website/src/content/docs/general/architecture.mdx
@@ -31,7 +31,7 @@ skill: true
 ### rivet self-hosted
 
 - available as a standalone rust binary or a docker contianer
-- can be configured ot persist to postgres or rocksdb
+- can be configured to persist to postgres or rocksdb
 - can scale horiziontally across multipe nodes and can scale across multiple regions
 - see [self-hosting docs](/docs/self-hosting/)
 

--- a/website/src/content/docs/general/architecture.mdx
+++ b/website/src/content/docs/general/architecture.mdx
@@ -55,7 +55,7 @@ skill: true
 
 - actors scale by:
 	- having isolated state to each actor that combines compute and storage for in-memory reads and writes
-	- communication is stndardized based on actions & events
+	- communication is standardized based on actions & events
 	- scale horizontally
 - read more about scalign at (link to scaling doc)
 

--- a/website/src/content/docs/general/architecture.mdx
+++ b/website/src/content/docs/general/architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Architecture"
-description: "- rivetkit is the typescript library used for both local development & to connect your application to rivet - a rivetkit instance is called a \"runner.\" you can run multiple runners to scale rivetkit horiziotnally. read omre about runners below."
+description: "- rivetkit is the typescript library used for both local development & to connect your application to rivet - a rivetkit instance is called a \"runner.\" you can run multiple runners to scale rivetkit horizontally. read omre about runners below."
 skill: true
 ---
 
@@ -9,7 +9,7 @@ skill: true
 ### rivetkit
 
 - rivetkit is the typescript library used for both local development & to connect your application to rivet
-- a rivetkit instance is called a "runner." you can run multiple runners to scale rivetkit horiziotnally. read more about runners below.
+- a rivetkit instance is called a "runner." you can run multiple runners to scale rivetkit horizontally. read more about runners below.
 
 #### local development
 

--- a/website/src/content/docs/general/architecture.mdx
+++ b/website/src/content/docs/general/architecture.mdx
@@ -42,7 +42,7 @@ skill: true
 ### actor-per-entity
 
 - actors are designed to have an actor-per-entity
-- you can think about actors a bit like objects in object-oriented programming where ach is responsible for their own state and expose methods (ie actions in our case)
+- you can think about actors a bit like objects in object-oriented programming where each is responsible for their own state and expose methods (ie actions in our case)
 - examples incldue
 	- actor per user
 	- actor per user session


### PR DESCRIPTION
multiple typos and 1 missing link, there's more missing links but have to run now