### PR TITLE
feat(http): stream HTTP bodies end-to-end

### DIFF
--- a/engine/artifacts/config-schema.json
+++ b/engine/artifacts/config-schema.json
@@ -1022,6 +1022,15 @@
           "format": "uint64",
           "minimum": 0.0
         },
+        "gateway_response_chunk_idle_timeout_ms": {
+          "description": "Timeout between streaming HTTP response chunks in milliseconds.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
         "gateway_response_start_timeout_ms": {
           "description": "Timeout for response to start in milliseconds.",
           "type": [

--- a/engine/packages/config/src/config/pegboard.rs
+++ b/engine/packages/config/src/config/pegboard.rs
@@ -105,6 +105,10 @@ pub struct Pegboard {
 	pub gateway_websocket_open_timeout_ms: Option<u64>,
 	/// Timeout for response to start in milliseconds.
 	pub gateway_response_start_timeout_ms: Option<u64>,
+	/// Timeout between streaming HTTP response chunks in milliseconds.
+	///
+	/// Disabled when unset so long-lived streams such as SSE may remain idle.
+	pub gateway_response_chunk_idle_timeout_ms: Option<u64>,
 	/// Ping interval for gateway updates in milliseconds.
 	pub gateway_update_ping_interval_ms: Option<u64>,
 	/// GC interval for in-flight requests in milliseconds.
@@ -278,6 +282,10 @@ impl Pegboard {
 	pub fn gateway_response_start_timeout_ms(&self) -> u64 {
 		self.gateway_response_start_timeout_ms
 			.unwrap_or(5 * 60 * 1000)
+	}
+
+	pub fn gateway_response_chunk_idle_timeout_ms(&self) -> Option<u64> {
+		self.gateway_response_chunk_idle_timeout_ms
 	}
 
 	pub fn gateway_update_ping_interval_ms(&self) -> u64 {

--- a/engine/packages/guard-core/src/custom_serve.rs
+++ b/engine/packages/guard-core/src/custom_serve.rs
@@ -2,7 +2,7 @@ use anyhow::{Result, bail};
 use async_trait::async_trait;
 use bytes::Bytes;
 use http_body_util::Full;
-use hyper::{Request, Response};
+use hyper::{Request, Response, body::Incoming as BodyIncoming};
 use tokio_tungstenite::tungstenite::protocol::frame::CloseFrame;
 
 use crate::WebSocketHandle;
@@ -17,12 +17,27 @@ pub enum HibernationResult {
 /// Trait for custom request serving logic that can handle both HTTP and WebSocket requests
 #[async_trait]
 pub trait CustomServeTrait: Send + Sync {
+	/// Returns true when this service wants the original request body stream.
+	/// The default buffered path keeps retry semantics for existing custom routes.
+	fn streams_request_body(&self) -> bool {
+		false
+	}
+
 	/// Handle a regular HTTP request
 	async fn handle_request(
 		&self,
 		req: Request<Full<Bytes>>,
 		req_ctx: &mut RequestContext,
 	) -> Result<Response<ResponseBody>>;
+
+	/// Handle a regular HTTP request with the original inbound body stream.
+	async fn handle_streaming_request(
+		&self,
+		_req: Request<BodyIncoming>,
+		_req_ctx: &mut RequestContext,
+	) -> Result<Response<ResponseBody>> {
+		bail!("service does not support streaming request bodies");
+	}
 
 	/// Handle a WebSocket connection after upgrade. Supports connection retries.
 	async fn handle_websocket(

--- a/engine/packages/guard-core/src/proxy_service.rs
+++ b/engine/packages/guard-core/src/proxy_service.rs
@@ -727,7 +727,8 @@ impl ProxyService {
 		metrics::PROXY_REQUEST_PENDING.inc();
 		metrics::PROXY_REQUEST_TOTAL.inc();
 
-		let res = if hyper_tungstenite::is_upgrade_request(&req) {
+		let is_websocket = hyper_tungstenite::is_upgrade_request(&req);
+		let res = if is_websocket {
 			self.handle_websocket_upgrade(req, req_ctx, target).await
 		} else {
 			self.handle_http_request(req, req_ctx, target).await
@@ -746,20 +747,39 @@ impl ProxyService {
 
 		metrics::PROXY_REQUEST_PENDING.dec();
 
-		// Release in-flight counter and request ID when done
-		let state_clone = self.state.clone();
 		let client_ip = req_ctx.client_ip;
 		let in_flight_request_id = req_ctx.in_flight_request_id;
-		tokio::spawn(
-			async move {
-				state_clone
-					.release_in_flight(client_ip, in_flight_request_id)
-					.await;
-			}
-			.instrument(tracing::info_span!("release_in_flight_task")),
-		);
+		let state = self.state.clone();
+		let runtime = tokio::runtime::Handle::current();
+		let release_in_flight = move || {
+			runtime.spawn(
+				async move {
+					state
+						.release_in_flight(client_ip, in_flight_request_id)
+						.await;
+				}
+				.instrument(tracing::info_span!("release_in_flight_task")),
+			);
+		};
 
-		res
+		if is_websocket {
+			release_in_flight();
+			res
+		} else {
+			match res {
+				Ok(response) => {
+					let (parts, body) = response.into_parts();
+					Ok(Response::from_parts(
+						parts,
+						body.with_completion(release_in_flight),
+					))
+				}
+				Err(err) => {
+					release_in_flight();
+					Err(err)
+				}
+			}
+		}
 	}
 
 	#[tracing::instrument(skip_all)]
@@ -936,6 +956,10 @@ impl ProxyService {
 				.build());
 			}
 			ResolveRouteOutput::CustomServe(mut handler) => {
+				if handler.streams_request_body() {
+					return handler.handle_streaming_request(req, req_ctx).await;
+				}
+
 				// Collect request body
 				let (req_parts, body) = req.into_parts();
 				let req_body =
@@ -1002,18 +1026,10 @@ impl ProxyService {
 						continue;
 					}
 
-					// Release in-flight counter and request ID before returning
-					self.state
-						.release_in_flight(req_ctx.client_ip, req_ctx.in_flight_request_id)
-						.await;
 					return res;
 				}
 
 				// If we get here, all attempts failed
-				// Release in-flight counter and request ID before returning error
-				self.state
-					.release_in_flight(req_ctx.client_ip, req_ctx.in_flight_request_id)
-					.await;
 				return Err(errors::RetryAttemptsExceeded {
 					attempts: req_ctx.retry.max_attempts,
 					last_error_code,

--- a/engine/packages/guard-core/src/response_body.rs
+++ b/engine/packages/guard-core/src/response_body.rs
@@ -1,6 +1,32 @@
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::body::Incoming as BodyIncoming;
+use tokio::sync::mpsc;
+
+pub type ResponseBodyError = Box<dyn std::error::Error + Send + Sync>;
+
+#[doc(hidden)]
+pub struct CompletionGuard(Option<Box<dyn FnOnce() + Send + 'static>>);
+
+impl CompletionGuard {
+	fn complete(&mut self) {
+		if let Some(callback) = self.0.take() {
+			callback();
+		}
+	}
+}
+
+impl std::fmt::Debug for CompletionGuard {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("CompletionGuard").finish_non_exhaustive()
+	}
+}
+
+impl Drop for CompletionGuard {
+	fn drop(&mut self) {
+		self.complete();
+	}
+}
 
 /// Response body type that can handle both streaming and buffered responses
 #[derive(Debug)]
@@ -9,11 +35,27 @@ pub enum ResponseBody {
 	Full(Full<Bytes>),
 	/// Streaming response body
 	Incoming(BodyIncoming),
+	/// Channel-backed streaming response body
+	Channel(mpsc::Receiver<Result<Bytes, ResponseBodyError>>),
+	/// Body carrying a callback that runs at EOF, error, or drop.
+	WithCompletion {
+		body: Box<ResponseBody>,
+		completion: CompletionGuard,
+	},
+}
+
+impl ResponseBody {
+	pub(crate) fn with_completion(self, callback: impl FnOnce() + Send + 'static) -> Self {
+		Self::WithCompletion {
+			body: Box::new(self),
+			completion: CompletionGuard(Some(Box::new(callback))),
+		}
+	}
 }
 
 impl http_body::Body for ResponseBody {
 	type Data = Bytes;
-	type Error = Box<dyn std::error::Error + Send + Sync>;
+	type Error = ResponseBodyError;
 
 	fn poll_frame(
 		self: std::pin::Pin<&mut Self>,
@@ -46,6 +88,25 @@ impl http_body::Body for ResponseBody {
 					std::task::Poll::Pending => std::task::Poll::Pending,
 				}
 			}
+			ResponseBody::Channel(rx) => match rx.poll_recv(cx) {
+				std::task::Poll::Ready(Some(Ok(bytes))) => {
+					std::task::Poll::Ready(Some(Ok(http_body::Frame::data(bytes))))
+				}
+				std::task::Poll::Ready(Some(Err(err))) => std::task::Poll::Ready(Some(Err(err))),
+				std::task::Poll::Ready(None) => std::task::Poll::Ready(None),
+				std::task::Poll::Pending => std::task::Poll::Pending,
+			},
+			ResponseBody::WithCompletion { body, completion } => {
+				let result = std::pin::Pin::new(body.as_mut()).poll_frame(cx);
+				if matches!(
+					&result,
+					std::task::Poll::Ready(None)
+						| std::task::Poll::Ready(Some(Err(_)))
+				) {
+					completion.complete();
+				}
+				result
+			}
 		}
 	}
 
@@ -53,6 +114,8 @@ impl http_body::Body for ResponseBody {
 		match self {
 			ResponseBody::Full(body) => body.is_end_stream(),
 			ResponseBody::Incoming(body) => body.is_end_stream(),
+			ResponseBody::Channel(rx) => rx.is_closed() && rx.is_empty(),
+			ResponseBody::WithCompletion { body, .. } => body.is_end_stream(),
 		}
 	}
 
@@ -60,6 +123,70 @@ impl http_body::Body for ResponseBody {
 		match self {
 			ResponseBody::Full(body) => body.size_hint(),
 			ResponseBody::Incoming(body) => body.size_hint(),
+			ResponseBody::Channel(_) => http_body::SizeHint::default(),
+			ResponseBody::WithCompletion { body, .. } => body.size_hint(),
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::sync::{
+		Arc,
+		atomic::{AtomicUsize, Ordering},
+	};
+
+	use bytes::Bytes;
+	use http_body_util::{BodyExt, Full};
+	use tokio::sync::mpsc;
+
+	use super::{ResponseBody, ResponseBodyError};
+
+	fn completion_counter() -> (Arc<AtomicUsize>, impl FnOnce() + Send + 'static) {
+		let count = Arc::new(AtomicUsize::new(0));
+		let callback_count = count.clone();
+		(count, move || {
+			callback_count.fetch_add(1, Ordering::SeqCst);
+		})
+	}
+
+	#[tokio::test]
+	async fn completion_runs_once_at_eof() {
+		let (count, callback) = completion_counter();
+		let body = ResponseBody::Full(Full::new(Bytes::from_static(b"done")))
+			.with_completion(callback);
+
+		assert_eq!(
+			body.collect().await.unwrap().to_bytes(),
+			Bytes::from_static(b"done")
+		);
+		assert_eq!(count.load(Ordering::SeqCst), 1);
+	}
+
+	#[tokio::test]
+	async fn completion_runs_once_on_error() {
+		let (tx, rx) = mpsc::channel(1);
+		tx.send(Err::<Bytes, ResponseBodyError>("stream failed".into()))
+			.await
+			.unwrap();
+		drop(tx);
+
+		let (count, callback) = completion_counter();
+		let mut body = ResponseBody::Channel(rx).with_completion(callback);
+
+		assert!(body.frame().await.unwrap().is_err());
+		assert_eq!(count.load(Ordering::SeqCst), 1);
+		drop(body);
+		assert_eq!(count.load(Ordering::SeqCst), 1);
+	}
+
+	#[test]
+	fn completion_runs_once_on_drop() {
+		let (_tx, rx) = mpsc::channel(1);
+		let (count, callback) = completion_counter();
+		let body = ResponseBody::Channel(rx).with_completion(callback);
+
+		drop(body);
+		assert_eq!(count.load(Ordering::SeqCst), 1);
 	}
 }

--- a/engine/packages/guard-core/tests/response_body.rs
+++ b/engine/packages/guard-core/tests/response_body.rs
@@ -1,0 +1,30 @@
+use bytes::Bytes;
+use http_body_util::BodyExt;
+use rivet_guard_core::ResponseBody;
+use tokio::sync::mpsc;
+
+#[tokio::test]
+async fn channel_body_yields_sent_chunks() {
+	let (tx, rx) = mpsc::channel(2);
+	tx.send(Ok(Bytes::from_static(b"hello "))).await.unwrap();
+	tx.send(Ok(Bytes::from_static(b"world"))).await.unwrap();
+	drop(tx);
+
+	let collected = ResponseBody::Channel(rx).collect().await.unwrap();
+
+	assert_eq!(collected.to_bytes(), Bytes::from_static(b"hello world"));
+}
+
+#[tokio::test]
+async fn channel_body_surfaces_errors() {
+	let (tx, rx) = mpsc::channel(1);
+	tx.send(Err(std::io::Error::other("stream failed").into()))
+		.await
+		.unwrap();
+	drop(tx);
+
+	let mut body = ResponseBody::Channel(rx);
+	let frame = body.frame().await.expect("expected frame");
+
+	assert!(frame.is_err());
+}

--- a/engine/packages/pegboard-envoy/src/tunnel_to_ws_task.rs
+++ b/engine/packages/pegboard-envoy/src/tunnel_to_ws_task.rs
@@ -258,7 +258,7 @@ fn to_envoy_tunnel_message_kind_name(kind: &protocol::ToEnvoyTunnelMessageKind) 
 	match kind {
 		protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestStart(_) => "ToEnvoyRequestStart",
 		protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestChunk(_) => "ToEnvoyRequestChunk",
-		protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort => "ToEnvoyRequestAbort",
+		protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort(_) => "ToEnvoyRequestAbort",
 		protocol::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketOpen(_) => "ToEnvoyWebSocketOpen",
 		protocol::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketMessage(_) => "ToEnvoyWebSocketMessage",
 		protocol::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketClose(_) => "ToEnvoyWebSocketClose",
@@ -272,7 +272,7 @@ fn to_envoy_tunnel_message_inner_data_len(kind: &protocol::ToEnvoyTunnelMessageK
 		}
 		protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestChunk(msg) => msg.body.len(),
 		protocol::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketMessage(msg) => msg.data.len(),
-		protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort
+		protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort(_)
 		| protocol::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketOpen(_)
 		| protocol::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketClose(_) => 0,
 	}

--- a/engine/packages/pegboard-envoy/src/ws_to_tunnel_task.rs
+++ b/engine/packages/pegboard-envoy/src/ws_to_tunnel_task.rs
@@ -1448,7 +1448,7 @@ fn tunnel_message_kind_name(kind: &protocol::ToRivetTunnelMessageKind) -> &'stat
 	match kind {
 		ToRivetTunnelMessageKind::ToRivetResponseStart(_) => "ToRivetResponseStart",
 		ToRivetTunnelMessageKind::ToRivetResponseChunk(_) => "ToRivetResponseChunk",
-		ToRivetTunnelMessageKind::ToRivetResponseAbort => "ToRivetResponseAbort",
+		ToRivetTunnelMessageKind::ToRivetResponseAbort(_) => "ToRivetResponseAbort",
 		ToRivetTunnelMessageKind::ToRivetWebSocketOpen(_) => "ToRivetWebSocketOpen",
 		ToRivetTunnelMessageKind::ToRivetWebSocketMessage(_) => "ToRivetWebSocketMessage",
 		ToRivetTunnelMessageKind::ToRivetWebSocketMessageAck(_) => "ToRivetWebSocketMessageAck",
@@ -2183,10 +2183,48 @@ fn tunnel_message_inner_data_len(kind: &protocol::ToRivetTunnelMessageKind) -> u
 		}
 		ToRivetTunnelMessageKind::ToRivetResponseChunk(chunk) => chunk.body.len(),
 		ToRivetTunnelMessageKind::ToRivetWebSocketMessage(msg) => msg.data.len(),
-		ToRivetTunnelMessageKind::ToRivetResponseAbort
-		| ToRivetTunnelMessageKind::ToRivetWebSocketOpen(_)
+		ToRivetTunnelMessageKind::ToRivetResponseAbort(abort) => {
+			abort.reason.detail.as_ref().map_or(0, |detail| detail.len())
+		}
+		ToRivetTunnelMessageKind::ToRivetWebSocketOpen(_)
 		| ToRivetTunnelMessageKind::ToRivetWebSocketMessageAck(_)
 		| ToRivetTunnelMessageKind::ToRivetWebSocketClose(_) => 0,
+	}
+}
+
+#[cfg(test)]
+mod payload_accounting_tests {
+	use rivet_envoy_protocol as protocol;
+
+	use super::tunnel_message_inner_data_len;
+
+	#[test]
+	fn response_abort_counts_detail_utf8_bytes() {
+		let detail = "actor failed: café".to_owned();
+		let message = protocol::ToRivetTunnelMessageKind::ToRivetResponseAbort(
+			protocol::ToRivetResponseAbort {
+				reason: protocol::HttpStreamAbortReason {
+					kind: protocol::HttpStreamAbortReasonKind::HandlerError,
+					detail: Some(detail.clone()),
+				},
+			},
+		);
+
+		assert_eq!(tunnel_message_inner_data_len(&message), detail.len());
+	}
+
+	#[test]
+	fn response_abort_without_detail_has_no_inner_payload() {
+		let message = protocol::ToRivetTunnelMessageKind::ToRivetResponseAbort(
+			protocol::ToRivetResponseAbort {
+				reason: protocol::HttpStreamAbortReason {
+					kind: protocol::HttpStreamAbortReasonKind::HandlerError,
+					detail: None,
+				},
+			},
+		);
+
+		assert_eq!(tunnel_message_inner_data_len(&message), 0);
 	}
 }
 

--- a/engine/packages/pegboard-gateway2/src/hibernation_task.rs
+++ b/engine/packages/pegboard-gateway2/src/hibernation_task.rs
@@ -15,7 +15,7 @@ use std::sync::{
 use tokio::sync::{mpsc, watch};
 use tokio_tungstenite::tungstenite::Message;
 
-use crate::shared_state::{InFlightRequestHandle, MsgGcReason};
+use crate::shared_state::{InFlightRequestHandle, InFlightTunnelMessage, MsgGcReason};
 
 use super::HibernationLifecycleResult;
 
@@ -26,7 +26,7 @@ pub async fn task(
 	in_flight_req: InFlightRequestHandle,
 	ctx: StandaloneCtx,
 	actor_id: Id,
-	mut msg_rx: mpsc::UnboundedReceiver<protocol::ToRivetTunnelMessageKind>,
+	mut msg_rx: mpsc::UnboundedReceiver<InFlightTunnelMessage>,
 	mut drop_rx: watch::Receiver<Option<MsgGcReason>>,
 	egress_bytes: Arc<AtomicU64>,
 	mut hibernation_abort_rx: watch::Receiver<()>,
@@ -55,7 +55,7 @@ pub async fn task(
 		tokio::select! {
 			res = msg_rx.recv() => {
 				if let Some(msg) = res {
-					match msg {
+					match msg.message_kind {
 						protocol::ToRivetTunnelMessageKind::ToRivetWebSocketMessage(ws_msg) => {
 							tracing::trace!(
 								request_id=%protocol::util::id_to_string(&in_flight_req.request_id),

--- a/engine/packages/pegboard-gateway2/src/http_stream/mod.rs
+++ b/engine/packages/pegboard-gateway2/src/http_stream/mod.rs
@@ -1,0 +1,76 @@
+use rivet_envoy_protocol as protocol;
+use tokio::sync::mpsc;
+
+use crate::shared_state::{InFlightRequestHandle, RequestStopResult};
+
+mod request;
+mod response;
+
+pub(super) use request::{
+	send_to_envoy_or_actor_stopped, should_stream_http_request_body_hint,
+	stream_http_request_and_wait_for_response, wait_for_http_response_start,
+};
+pub(super) use response::drain_http_response_stream;
+
+pub(super) const HTTP_RESPONSE_BODY_CHANNEL_CAPACITY: usize = 16;
+pub(super) type ResponseBodyError = Box<dyn std::error::Error + Send + Sync>;
+
+pub(super) struct HttpClientDisconnectGuard {
+	in_flight_req: Option<InFlightRequestHandle>,
+}
+
+impl HttpClientDisconnectGuard {
+	pub(super) fn new(in_flight_req: InFlightRequestHandle) -> Self {
+		Self {
+			in_flight_req: Some(in_flight_req),
+		}
+	}
+
+	pub(super) fn disarm(&mut self) {
+		self.in_flight_req = None;
+	}
+}
+
+impl Drop for HttpClientDisconnectGuard {
+	fn drop(&mut self) {
+		let Some(in_flight_req) = self.in_flight_req.take() else {
+			return;
+		};
+		tokio::spawn(async move {
+			send_http_request_abort(
+				&in_flight_req,
+				protocol::HttpStreamAbortReasonKind::ClientDisconnect,
+				Some("client disconnected before the HTTP response started".to_owned()),
+			)
+			.await;
+			in_flight_req
+				.stop(RequestStopResult::ClientDisconnect)
+				.await;
+		});
+	}
+}
+
+pub(super) async fn send_http_request_abort(
+	in_flight_req: &InFlightRequestHandle,
+	kind: protocol::HttpStreamAbortReasonKind,
+	detail: impl Into<Option<String>>,
+) {
+	let message = protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort(
+		protocol::ToEnvoyRequestAbort {
+			reason: protocol::HttpStreamAbortReason {
+				kind,
+				detail: detail.into(),
+			},
+		},
+	);
+	if let Err(err) = in_flight_req.send_message(message, true).await {
+		tracing::debug!(?err, "failed sending http request abort to envoy");
+	}
+}
+
+fn send_http_body_error(
+	body_tx: &mpsc::Sender<Result<bytes::Bytes, ResponseBodyError>>,
+	message: impl Into<String>,
+) {
+	let _ = body_tx.try_send(Err(Box::new(std::io::Error::other(message.into()))));
+}

--- a/engine/packages/pegboard-gateway2/src/http_stream/request.rs
+++ b/engine/packages/pegboard-gateway2/src/http_stream/request.rs
@@ -1,0 +1,316 @@
+use anyhow::{Result, anyhow};
+use bytes::Bytes;
+use gas::prelude::*;
+use http_body_util::BodyExt;
+use hyper::body::{Body, SizeHint};
+use rivet_envoy_protocol as protocol;
+use rivet_guard_core::errors::{
+	ActorStoppedWhileWaiting, GatewayResponseStartTimeout, InvalidRequestBody,
+	TunnelMessageTimeout, TunnelRequestAborted, TunnelResponseClosed,
+};
+use std::time::Duration;
+use tokio::sync::{mpsc, watch};
+
+use crate::shared_state::{
+	InFlightRequestHandle, InFlightTunnelMessage, MsgGcReason,
+};
+
+const PHASE_WAITING_FOR_RESPONSE_START: &str = "waiting_for_response_start";
+const HTTP_BODY_CHUNK_SIZE: usize = 64 * 1024;
+const HTTP_BODY_CHUNK_FLUSH_INTERVAL: Duration = Duration::from_millis(10);
+
+pub(crate) fn should_stream_http_request_body_hint(size_hint: &SizeHint) -> bool {
+	size_hint
+		.upper()
+		.map_or(true, |body_len| body_len as usize > HTTP_BODY_CHUNK_SIZE)
+}
+
+fn next_request_body_size(current: usize, chunk: usize, limit: usize) -> Option<usize> {
+	current.checked_add(chunk).filter(|size| *size <= limit)
+}
+
+#[derive(Default)]
+struct HttpRequestBodyChunker {
+	pending: Vec<u8>,
+}
+
+impl HttpRequestBodyChunker {
+	fn is_empty(&self) -> bool {
+		self.pending.is_empty()
+	}
+
+	fn push(&mut self, mut data: &[u8]) -> Vec<Vec<u8>> {
+		let mut chunks = Vec::new();
+		while !data.is_empty() {
+			let remaining = HTTP_BODY_CHUNK_SIZE - self.pending.len();
+			let take = remaining.min(data.len());
+			self.pending.extend_from_slice(&data[..take]);
+			data = &data[take..];
+			if self.pending.len() == HTTP_BODY_CHUNK_SIZE {
+				chunks.push(std::mem::take(&mut self.pending));
+			}
+		}
+		chunks
+	}
+
+	fn flush(&mut self) -> Option<Vec<u8>> {
+		(!self.pending.is_empty()).then(|| std::mem::take(&mut self.pending))
+	}
+}
+
+pub(crate) async fn send_to_envoy_or_actor_stopped(
+	in_flight_req: &InFlightRequestHandle,
+	stopped_sub: &mut message::SubscriptionHandle<pegboard::workflows::actor2::Stopped>,
+	actor_id: Id,
+	phase: &'static str,
+	message: protocol::ToEnvoyTunnelMessageKind,
+	ephemeral: bool,
+) -> Result<()> {
+	tokio::select! {
+		biased;
+		_ = stopped_sub.next() => {
+			tracing::debug!("actor stopped while sending request");
+			Err(ActorStoppedWhileWaiting {
+				actor_id: actor_id.to_string(),
+				phase: phase.to_owned(),
+			}
+			.build())
+		}
+		res = in_flight_req.send_message(message, ephemeral) => res,
+	}
+}
+
+async fn send_streaming_http_request_body_chunks<B>(
+	in_flight_req: &InFlightRequestHandle,
+	mut body: B,
+	max_body_size: usize,
+) -> Result<()>
+where
+	B: Body<Data = Bytes> + Unpin,
+	B::Error: std::fmt::Display,
+{
+	// Ingress accounting is based on bytes read from the client, before
+	// coalescing, so transport framing cannot bypass the cumulative body limit.
+	let mut body_size = 0usize;
+	let mut chunker = HttpRequestBodyChunker::default();
+	let mut flush_deadline = None;
+
+	// The caller polls this upload future alongside response-start/abort
+	// observation. Dropping it on an early actor result immediately stops reading
+	// the client. While it is active, small DATA frames are coalesced to avoid
+	// protocol-message amplification, with a deadline from the first buffered
+	// byte so low-volume streams still make bounded progress.
+	loop {
+		let frame = if let Some(deadline) = flush_deadline {
+			tokio::select! {
+				frame = body.frame() => frame,
+				_ = tokio::time::sleep_until(deadline) => {
+					if let Some(chunk) = chunker.flush() {
+						send_http_request_body_chunk(in_flight_req, chunk, false).await?;
+					}
+					flush_deadline = None;
+					continue;
+				}
+			}
+		} else {
+			body.frame().await
+		};
+		let Some(frame) = frame else {
+			break;
+		};
+		let frame = match frame {
+			Ok(frame) => frame,
+			Err(error) => {
+				super::send_http_request_abort(
+					in_flight_req,
+					protocol::HttpStreamAbortReasonKind::ClientDisconnect,
+					Some(error.to_string()),
+				)
+				.await;
+				return Err(anyhow!("failed to read streaming request body: {error}"));
+			}
+		};
+		let Ok(data) = frame.into_data() else {
+			continue;
+		};
+		let Some(next_body_size) =
+			next_request_body_size(body_size, data.len(), max_body_size)
+		else {
+			super::send_http_request_abort(
+				in_flight_req,
+				protocol::HttpStreamAbortReasonKind::BodyTooLarge,
+				Some(format!(
+					"request body exceeded the {max_body_size}-byte limit"
+				)),
+			)
+			.await;
+			return Err(InvalidRequestBody {
+				reason: format!("request body exceeded the {max_body_size}-byte limit"),
+			}
+			.build());
+		};
+		body_size = next_body_size;
+
+		let was_empty = chunker.is_empty();
+		for chunk in chunker.push(&data) {
+			send_http_request_body_chunk(in_flight_req, chunk, false).await?;
+		}
+		if chunker.is_empty() {
+			flush_deadline = None;
+		} else if was_empty {
+			flush_deadline = Some(tokio::time::Instant::now() + HTTP_BODY_CHUNK_FLUSH_INTERVAL);
+		}
+	}
+
+	// Normal EOF flushes any partial protocol chunk, then sends exactly one final
+	// marker so actor-side upload state and request routing can be released.
+	if let Some(chunk) = chunker.flush() {
+		send_http_request_body_chunk(in_flight_req, chunk, false).await?;
+	}
+	send_http_request_body_chunk(in_flight_req, Vec::new(), true).await
+}
+
+async fn send_http_request_body_chunk(
+	in_flight_req: &InFlightRequestHandle,
+	body: Vec<u8>,
+	finish: bool,
+) -> Result<()> {
+	let message = protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestChunk(
+		protocol::ToEnvoyRequestChunk { body, finish },
+	);
+	in_flight_req.send_message(message, false).await
+}
+
+pub(crate) async fn wait_for_http_response_start(
+	msg_rx: &mut mpsc::UnboundedReceiver<InFlightTunnelMessage>,
+	drop_rx: &mut watch::Receiver<Option<MsgGcReason>>,
+	stopped_sub: &mut message::SubscriptionHandle<pegboard::workflows::actor2::Stopped>,
+	actor_id: Id,
+	request_id: protocol::RequestId,
+	deadline: tokio::time::Instant,
+	timeout: Duration,
+) -> Result<(protocol::MessageId, protocol::ToRivetResponseStart)> {
+	loop {
+		tokio::select! {
+			res = msg_rx.recv() => {
+				let Some(msg) = res else {
+					tracing::warn!(
+						request_id=%protocol::util::id_to_string(&request_id),
+						"received empty message response during request init",
+					);
+					return Err(TunnelResponseClosed {
+						phase: PHASE_WAITING_FOR_RESPONSE_START.to_owned(),
+					}
+					.build());
+				};
+
+				match msg.message_kind {
+					protocol::ToRivetTunnelMessageKind::ToRivetResponseStart(response_start) => {
+						return Ok((msg.message_id, response_start));
+					}
+					protocol::ToRivetTunnelMessageKind::ToRivetResponseAbort(abort) => {
+						tracing::warn!(
+							reason_kind = ?abort.reason.kind,
+							reason_detail = ?abort.reason.detail,
+							"request aborted"
+						);
+						return Err(TunnelRequestAborted {
+							phase: PHASE_WAITING_FOR_RESPONSE_START.to_owned(),
+						}
+						.build());
+					}
+					_ => {
+						tracing::warn!("received non-response message from pubsub");
+					}
+				}
+			}
+			_ = drop_rx.changed() => {
+				tracing::warn!(reason=?drop_rx.borrow(), "tunnel message timeout");
+				return Err(TunnelMessageTimeout {
+					phase: PHASE_WAITING_FOR_RESPONSE_START.to_owned(),
+					reason: format!("{:?}", drop_rx.borrow().as_ref()),
+				}
+				.build());
+			}
+			_ = stopped_sub.next() => {
+				tracing::debug!("actor stopped while waiting for request response");
+				return Err(ActorStoppedWhileWaiting {
+					actor_id: actor_id.to_string(),
+					phase: PHASE_WAITING_FOR_RESPONSE_START.to_owned(),
+				}.build());
+			}
+			_ = tokio::time::sleep_until(deadline) => {
+				tracing::warn!("timed out waiting for response start from envoy");
+				return Err(GatewayResponseStartTimeout {
+					phase: "response_start".to_owned(),
+					timeout_ms: timeout.as_millis() as u64,
+				}
+				.build());
+			}
+		}
+	}
+}
+
+pub(crate) async fn stream_http_request_and_wait_for_response<B>(
+	in_flight_req: &InFlightRequestHandle,
+	msg_rx: &mut mpsc::UnboundedReceiver<InFlightTunnelMessage>,
+	drop_rx: &mut watch::Receiver<Option<MsgGcReason>>,
+	stopped_sub: &mut message::SubscriptionHandle<pegboard::workflows::actor2::Stopped>,
+	actor_id: Id,
+	request_id: protocol::RequestId,
+	body: B,
+	max_body_size: usize,
+	response_start_deadline: tokio::time::Instant,
+	response_start_timeout: Duration,
+) -> Result<(protocol::MessageId, protocol::ToRivetResponseStart)>
+where
+	B: Body<Data = Bytes> + Unpin,
+	B::Error: std::fmt::Display,
+{
+	// Upload ingress, cumulative byte accounting, and bounded-latency
+	// coalescing run in one future. Response start/abort is observed
+	// concurrently so a slow or rejected upload cannot retain the request.
+	let upload = send_streaming_http_request_body_chunks(
+		in_flight_req,
+		body,
+		max_body_size,
+	);
+	tokio::pin!(upload);
+	tokio::select! {
+		upload_result = &mut upload => {
+			// Normal completion already sent the final upload marker. Continue
+			// waiting under the original response-start deadline.
+			upload_result?;
+			wait_for_http_response_start(
+				msg_rx,
+				drop_rx,
+				stopped_sub,
+				actor_id,
+				request_id,
+				response_start_deadline,
+				response_start_timeout,
+			)
+			.await
+		}
+		response_start = wait_for_http_response_start(
+			msg_rx,
+			drop_rx,
+			stopped_sub,
+			actor_id,
+			request_id,
+			response_start_deadline,
+			response_start_timeout,
+		) => {
+			let response_start = response_start?;
+			// An early successful response makes the unread client body
+			// irrelevant. Drop the upload future and send a clean final marker
+			// so actor request routing can be released.
+			send_http_request_body_chunk(in_flight_req, Vec::new(), true).await?;
+			Ok(response_start)
+		}
+	}
+}
+
+#[cfg(test)]
+#[path = "../../tests/support/http_stream_request.rs"]
+mod tests;

--- a/engine/packages/pegboard-gateway2/src/http_stream/response.rs
+++ b/engine/packages/pegboard-gateway2/src/http_stream/response.rs
@@ -1,0 +1,268 @@
+use bytes::Bytes;
+use gas::prelude::*;
+use rivet_envoy_protocol as protocol;
+use std::time::Duration;
+use tokio::sync::{mpsc, watch};
+
+use crate::shared_state::{
+	InFlightRequestHandle, InFlightTunnelMessage, MsgGcReason, RequestStopResult,
+};
+
+use super::{ResponseBodyError, send_http_body_error, send_http_request_abort};
+
+const HTTP_BODY_CHUNK_SIZE: usize = 64 * 1024;
+
+fn advance_http_stream_message_index(
+	expected: protocol::MessageIndex,
+	actual: protocol::MessageIndex,
+) -> std::result::Result<protocol::MessageIndex, ()> {
+	if actual == expected {
+		Ok(expected.wrapping_add(1))
+	} else {
+		Err(())
+	}
+}
+
+async fn send_http_response_body_bytes(
+	in_flight_req: &InFlightRequestHandle,
+	body_tx: &mpsc::Sender<Result<Bytes, ResponseBodyError>>,
+	drop_rx: &mut watch::Receiver<Option<MsgGcReason>>,
+	stopped_sub: &mut message::SubscriptionHandle<pegboard::workflows::actor2::Stopped>,
+	actor_id: Id,
+	body: Vec<u8>,
+	detail: &'static str,
+) -> bool {
+	let body = Bytes::from(body);
+	for offset in (0..body.len()).step_by(HTTP_BODY_CHUNK_SIZE) {
+		let chunk = body.slice(offset..(offset + HTTP_BODY_CHUNK_SIZE).min(body.len()));
+		let delivery = tokio::select! {
+			biased;
+			_ = body_tx.closed() => Err((RequestStopResult::ClientDisconnect, detail.to_owned())),
+			_ = drop_rx.changed() => {
+				let overloaded = matches!(
+					drop_rx.borrow().as_ref(),
+					Some(MsgGcReason::HttpResponseQueueOverloaded)
+				);
+				let reason = format!("{:?}", drop_rx.borrow().as_ref());
+				if overloaded {
+					send_http_request_abort(
+						in_flight_req,
+						protocol::HttpStreamAbortReasonKind::Overloaded,
+						Some("gateway streaming response queue overloaded".to_owned()),
+					)
+					.await;
+				}
+				Err((
+					RequestStopResult::RequestTimeout,
+					format!("response stream garbage collected: {reason}"),
+				))
+			}
+			_ = stopped_sub.next() => {
+				tracing::debug!(%actor_id, "actor stopped while delivering streaming response");
+				Err((
+					RequestStopResult::EnvoyError,
+					"actor stopped while streaming response".to_owned(),
+				))
+			}
+			result = body_tx.send(Ok(chunk)) => match result {
+				Ok(()) => Ok(()),
+				Err(_) => Err((RequestStopResult::ClientDisconnect, detail.to_owned())),
+			},
+		};
+		if let Err((stop_result, message)) = delivery {
+			tracing::debug!(?stop_result, %message, "stopped delivering streaming http response");
+			if !matches!(stop_result, RequestStopResult::ClientDisconnect) {
+				send_http_body_error(body_tx, message);
+			} else {
+				send_http_request_abort(
+					in_flight_req,
+					protocol::HttpStreamAbortReasonKind::ClientDisconnect,
+					Some(detail.to_owned()),
+				)
+				.await;
+			}
+			in_flight_req.stop(stop_result).await;
+			return false;
+		}
+	}
+
+	true
+}
+
+pub(crate) async fn drain_http_response_stream(
+	in_flight_req: InFlightRequestHandle,
+	mut msg_rx: mpsc::UnboundedReceiver<InFlightTunnelMessage>,
+	mut drop_rx: watch::Receiver<Option<MsgGcReason>>,
+	mut stopped_sub: message::SubscriptionHandle<pegboard::workflows::actor2::Stopped>,
+	body_tx: mpsc::Sender<Result<Bytes, ResponseBodyError>>,
+	initial_body: Option<Vec<u8>>,
+	mut expected_message_index: protocol::MessageIndex,
+	actor_id: Id,
+	idle_timeout: Option<Duration>,
+) {
+	if let Some(body) = initial_body.filter(|body| !body.is_empty()) {
+		if !send_http_response_body_bytes(
+			&in_flight_req,
+			&body_tx,
+			&mut drop_rx,
+			&mut stopped_sub,
+			actor_id,
+			body,
+			"client dropped response before initial body was sent",
+		)
+		.await
+		{
+			return;
+		}
+	}
+
+	loop {
+		tokio::select! {
+			res = msg_rx.recv() => {
+				let Some(msg) = res else {
+					tracing::warn!("streaming response tunnel channel closed");
+					send_http_body_error(&body_tx, "response stream closed before finish");
+					in_flight_req.stop(RequestStopResult::EnvoyError).await;
+					return;
+				};
+
+				match advance_http_stream_message_index(
+					expected_message_index,
+					msg.message_id.message_index,
+				) {
+					Ok(next_message_index) => expected_message_index = next_message_index,
+					Err(()) => {
+						tracing::warn!(
+							expected_message_index,
+							actual_message_index = msg.message_id.message_index,
+							"streaming response message index gap"
+						);
+						send_http_request_abort(
+							&in_flight_req,
+							protocol::HttpStreamAbortReasonKind::InternalError,
+							Some("gateway detected response stream message index gap".to_owned()),
+						)
+						.await;
+						send_http_body_error(&body_tx, "response stream message index gap");
+						in_flight_req.stop(RequestStopResult::EnvoyError).await;
+						return;
+					}
+				}
+
+				match msg.message_kind {
+					protocol::ToRivetTunnelMessageKind::ToRivetResponseChunk(chunk) => {
+						if !chunk.body.is_empty() && !send_http_response_body_bytes(
+							&in_flight_req,
+							&body_tx,
+							&mut drop_rx,
+							&mut stopped_sub,
+							actor_id,
+							chunk.body,
+							"client dropped streaming response body",
+						).await {
+							return;
+						}
+
+						if chunk.finish {
+							in_flight_req.stop(RequestStopResult::Success).await;
+							return;
+						}
+					}
+					protocol::ToRivetTunnelMessageKind::ToRivetResponseAbort(abort) => {
+						let message = match &abort.reason.detail {
+							Some(detail) => format!("{:?}: {detail}", abort.reason.kind),
+							None => format!("{:?}", abort.reason.kind),
+						};
+						tracing::warn!(
+							reason_kind = ?abort.reason.kind,
+							reason_detail = ?abort.reason.detail,
+							"streaming http response aborted by envoy"
+						);
+						send_http_body_error(
+							&body_tx,
+							format!("response stream aborted: {message}"),
+						);
+						in_flight_req.stop(RequestStopResult::EnvoyError).await;
+						return;
+					}
+					other => {
+						tracing::warn!(
+							message_kind = ?other,
+							"unexpected message while streaming http response"
+						);
+						send_http_request_abort(
+							&in_flight_req,
+							protocol::HttpStreamAbortReasonKind::InternalError,
+							Some("gateway received unexpected response stream message".to_owned()),
+						)
+						.await;
+						send_http_body_error(&body_tx, "unexpected response stream message");
+						in_flight_req.stop(RequestStopResult::EnvoyError).await;
+						return;
+					}
+				}
+			}
+			_ = drop_rx.changed() => {
+				let overloaded = matches!(
+					drop_rx.borrow().as_ref(),
+					Some(MsgGcReason::HttpResponseQueueOverloaded)
+				);
+				let reason = format!("{:?}", drop_rx.borrow().as_ref());
+				tracing::warn!(reason, "streaming response tunnel channel dropped");
+				if overloaded {
+					send_http_request_abort(
+						&in_flight_req,
+						protocol::HttpStreamAbortReasonKind::Overloaded,
+						Some("gateway streaming response queue overloaded".to_owned()),
+					)
+					.await;
+				}
+				send_http_body_error(&body_tx, format!("response stream garbage collected: {reason}"));
+				in_flight_req.stop(RequestStopResult::RequestTimeout).await;
+				return;
+			}
+			_ = stopped_sub.next() => {
+				tracing::debug!(%actor_id, "actor stopped while streaming response");
+				send_http_body_error(&body_tx, "actor stopped while streaming response");
+				in_flight_req.stop(RequestStopResult::EnvoyError).await;
+				return;
+			}
+			_ = body_tx.closed() => {
+				tracing::debug!("client dropped idle streaming http response body");
+				send_http_request_abort(
+					&in_flight_req,
+					protocol::HttpStreamAbortReasonKind::ClientDisconnect,
+					Some("client dropped streaming response body".to_owned()),
+				)
+				.await;
+				in_flight_req.stop(RequestStopResult::ClientDisconnect).await;
+				return;
+			}
+			_ = async {
+				match idle_timeout {
+					Some(timeout) => tokio::time::sleep(timeout).await,
+					None => std::future::pending().await,
+				}
+			} => {
+				let idle_timeout = idle_timeout.expect("idle timeout branch cannot run when disabled");
+				tracing::warn!(
+					timeout_ms = idle_timeout.as_millis() as u64,
+					"timed out waiting for streaming response chunk"
+				);
+				send_http_request_abort(
+					&in_flight_req,
+					protocol::HttpStreamAbortReasonKind::IdleTimeout,
+					Some("gateway timed out waiting for response stream chunk".to_owned()),
+				)
+				.await;
+				send_http_body_error(&body_tx, "response stream idle timeout");
+				in_flight_req.stop(RequestStopResult::RequestTimeout).await;
+				return;
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+#[path = "../../tests/support/http_stream_response.rs"]
+mod tests;

--- a/engine/packages/pegboard-gateway2/src/lib.rs
+++ b/engine/packages/pegboard-gateway2/src/lib.rs
@@ -1,9 +1,12 @@
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use bytes::Bytes;
 use gas::prelude::*;
-use http_body_util::{BodyExt, Full};
-use hyper::{Request, Response, StatusCode, body::Body};
+use http_body_util::{BodyExt, Full, Limited};
+use hyper::{
+	Method, Request, Response, StatusCode,
+	body::{Body, Incoming as BodyIncoming},
+};
 use rivet_envoy_protocol as protocol;
 use rivet_error::*;
 use rivet_guard_core::{
@@ -11,8 +14,7 @@ use rivet_guard_core::{
 	custom_serve::{CustomServeTrait, HibernationResult},
 	errors::{
 		ActorStoppedWhileWaiting, ActorStoppedWhileWaitingForWebSocketOpen,
-		GatewayResponseStartTimeout, TunnelMessageTimeout, TunnelRequestAborted,
-		TunnelResponseClosed, WebSocketClosedBeforeOpen, WebSocketOpenDropped,
+		InvalidRequestBody, WebSocketClosedBeforeOpen, WebSocketOpenDropped,
 		WebSocketOpenResponseClosed, WebSocketOpenTimeout,
 	},
 	request_context::RequestContext,
@@ -23,7 +25,7 @@ use std::{
 	sync::{Arc, atomic::AtomicU64},
 	time::{Duration, Instant},
 };
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch};
 use tokio_tungstenite::tungstenite::protocol::frame::{CloseFrame, coding::CloseCode};
 use universaldb::utils::IsolationLevel::*;
 
@@ -32,6 +34,7 @@ use crate::shared_state::{
 };
 
 mod hibernation_task;
+mod http_stream;
 mod keepalive_task;
 pub mod metrics;
 mod metrics_task;
@@ -40,10 +43,16 @@ pub mod shared_state;
 mod tunnel_to_ws_task;
 mod ws_to_tunnel_task;
 
+use http_stream::{
+	HttpClientDisconnectGuard, HTTP_RESPONSE_BODY_CHANNEL_CAPACITY, ResponseBodyError,
+	drain_http_response_stream, send_http_request_abort, send_to_envoy_or_actor_stopped,
+	should_stream_http_request_body_hint, stream_http_request_and_wait_for_response,
+	wait_for_http_response_start,
+};
+
 const RECORD_REQ_METRICS_TIMEOUT: Duration = Duration::from_secs(15);
 const UPDATE_METRICS_INTERVAL: Duration = Duration::from_secs(15);
 const PHASE_PRE_REQUEST: &str = "pre_request";
-const PHASE_WAITING_FOR_RESPONSE_START: &str = "waiting_for_response_start";
 const PHASE_PRE_WEBSOCKET_OPEN: &str = "pre_websocket_open";
 const PHASE_WAITING_FOR_WEBSOCKET_OPEN: &str = "waiting_for_websocket_open";
 const SLOW_WEBSOCKET_OPEN_WAIT_THRESHOLD: Duration = Duration::from_secs(1);
@@ -110,19 +119,100 @@ impl PegboardGateway2 {
 }
 
 impl PegboardGateway2 {
-	async fn handle_request_inner(
+	async fn handle_http_request<B>(
+		&self,
+		req: Request<B>,
+		req_ctx: &mut RequestContext,
+	) -> Result<Response<ResponseBody>>
+	where
+		B: Body<Data = Bytes> + Unpin,
+		B::Error: std::error::Error + Send + Sync + 'static,
+	{
+		let ctx = self.ctx.with_ray(req_ctx.ray_id(), req_ctx.req_id())?;
+		let req_body_size_hint = req.body().size_hint();
+		let ingress_size = req_body_size_hint
+			.upper()
+			.unwrap_or(req_body_size_hint.lower()) as usize;
+
+		let (res, metrics_res) = tokio::join!(
+			self.handle_request_inner(&ctx, req, req_ctx),
+			record_req_metrics(
+				&ctx,
+				self.actor_id,
+				self.namespace_id,
+				Metric::HttpIngress(ingress_size),
+			),
+		);
+
+		if let Err(err) = metrics_res {
+			tracing::error!(?err, "http request ingress metrics failed");
+			return res;
+		}
+
+		let egress_size = res
+			.as_ref()
+			.map(|res| res.size_hint().upper().unwrap_or(res.size_hint().lower()) as usize)
+			.unwrap_or_default();
+		let actor_id = self.actor_id;
+		let namespace_id = self.namespace_id;
+		let envoy_key = self.envoy_key.clone();
+		tokio::spawn(
+			async move {
+				if let Err(err) = record_req_metrics(
+					&ctx,
+					actor_id,
+					namespace_id,
+					Metric::HttpEgress(egress_size),
+				)
+				.await
+				{
+					tracing::error!(
+						?err,
+						?namespace_id,
+						%envoy_key,
+						"http request egress metrics failed, likely corrupt now",
+					);
+				}
+			}
+			.in_current_span(),
+		);
+
+		res
+	}
+
+	async fn handle_request_inner<B>(
 		&self,
 		ctx: &StandaloneCtx,
-		req: Request<Full<Bytes>>,
+		req: Request<B>,
 		req_ctx: &mut RequestContext,
-	) -> Result<Response<ResponseBody>> {
+	) -> Result<Response<ResponseBody>>
+	where
+		B: Body<Data = Bytes> + Unpin,
+		B::Error: std::error::Error + Send + Sync + 'static,
+	{
 		// Use the actor ID from the gateway instance
 		let actor_id = self.actor_id.to_string();
 		let request_id = req_ctx.in_flight_request_id()?;
 
 		// Extract request parts
-		let headers = req
-			.headers()
+		let request_body_size_hint = req.body().size_hint();
+		let max_request_body_size = ctx.config().guard().http_max_request_body_size();
+		if request_body_size_hint
+			.upper()
+			.is_some_and(|body_size| body_size > max_request_body_size as u64)
+		{
+			return Err(InvalidRequestBody {
+				reason: format!(
+					"request body exceeded the {max_request_body_size}-byte limit"
+				),
+			}
+			.build());
+		}
+		let request_stream = !matches!(req_ctx.method(), &Method::GET | &Method::HEAD)
+			&& should_stream_http_request_body_hint(&request_body_size_hint);
+		let (req_parts, body) = req.into_parts();
+		let headers = req_parts
+			.headers
 			.iter()
 			.filter_map(|(name, value)| {
 				value
@@ -131,14 +221,18 @@ impl PegboardGateway2 {
 					.map(|value_str| (name.to_string(), value_str.to_string()))
 			})
 			.collect::<HashMap<_, _>>();
-
-		// NOTE: Size constraints have already been applied by guard
-		let body_bytes = req
-			.into_body()
-			.collect()
-			.await
-			.context("failed to read body")?
-			.to_bytes();
+		let (body_bytes, streaming_body) = if request_stream {
+			(Bytes::new(), Some(body))
+		} else {
+			(
+				Limited::new(body, max_request_body_size)
+					.collect()
+					.await
+					.map_err(|error| anyhow!("failed to read body: {error}"))?
+					.to_bytes(),
+				None,
+			)
+		};
 
 		let mut stopped_sub = ctx
 			.subscribe::<pegboard::workflows::actor2::Stopped>(("actor_id", self.actor_id))
@@ -199,6 +293,8 @@ impl PegboardGateway2 {
 				false,
 			)
 			.await?;
+		let mut client_disconnect_guard =
+			HttpClientDisconnectGuard::new(in_flight_req.clone());
 
 		let res = async {
 			// Start request
@@ -208,100 +304,62 @@ impl PegboardGateway2 {
 					method: req_ctx.method().to_string(),
 					path: self.path.clone(),
 					headers,
-					body: if body_bytes.is_empty() {
+					body: if body_bytes.is_empty() || request_stream {
 						None
 					} else {
 						Some(body_bytes.to_vec())
 					},
-					stream: false,
+					stream: request_stream,
 				},
 			);
 
-			tokio::select! {
-				// Prefer quick stop path
-				biased;
-				_ = stopped_sub.next() => {
-					tracing::debug!("actor stopped while sending request");
-					return Err(ActorStoppedWhileWaiting {
-						actor_id: self.actor_id.to_string(),
-						phase: PHASE_PRE_REQUEST.to_owned(),
-					}
-					.build());
-				}
-				res = in_flight_req.send_message(message, false) => res?,
-			}
+			send_to_envoy_or_actor_stopped(
+				&in_flight_req,
+				&mut stopped_sub,
+				self.actor_id,
+				PHASE_PRE_REQUEST,
+				message,
+				false,
+			)
+			.await?;
 
-			// Wait for response
 			tracing::debug!("gateway waiting for response from tunnel");
-			let fut = async {
-				loop {
-					tokio::select! {
-						res = msg_rx.recv() => {
-							if let Some(msg) = res {
-								match msg {
-									protocol::ToRivetTunnelMessageKind::ToRivetResponseStart(
-										response_start,
-									) => {
-										return anyhow::Ok(response_start);
-									}
-									protocol::ToRivetTunnelMessageKind::ToRivetResponseAbort => {
-										tracing::warn!("request aborted");
-										return Err(TunnelRequestAborted {
-											phase: PHASE_WAITING_FOR_RESPONSE_START.to_owned(),
-										}
-										.build());
-									}
-									_ => {
-										tracing::warn!("received non-response message from pubsub");
-									}
-								}
-							} else {
-								tracing::warn!(
-									request_id=%protocol::util::id_to_string(&request_id),
-									"received empty message response during request init",
-								);
-								return Err(TunnelResponseClosed {
-									phase: PHASE_WAITING_FOR_RESPONSE_START.to_owned(),
-								}
-								.build());
-							}
-						}
-						_ = drop_rx.changed() => {
-							tracing::warn!(reason=?drop_rx.borrow(), "tunnel message timeout");
-							return Err(TunnelMessageTimeout {
-								phase: PHASE_WAITING_FOR_RESPONSE_START.to_owned(),
-								reason: format!("{:?}", drop_rx.borrow().as_ref()),
-							}
-							.build());
-						}
-						_ = stopped_sub.next() => {
-							tracing::debug!("actor stopped while waiting for request response");
-							return Err(ActorStoppedWhileWaiting {
-								actor_id: self.actor_id.to_string(),
-								phase: PHASE_WAITING_FOR_RESPONSE_START.to_owned(),
-							}.build());
-						}
-					}
-				}
-			}
-			.instrument(tracing::info_span!("wait_for_tunnel_response"));
 			let response_start_timeout = Duration::from_millis(
 				self.ctx
 					.config()
 					.pegboard()
 					.gateway_response_start_timeout_ms(),
 			);
-			let response_start = tokio::time::timeout(response_start_timeout, fut)
-				.await
-				.map_err(|_| {
-					tracing::warn!("timed out waiting for response start from envoy");
-
-					GatewayResponseStartTimeout {
-						phase: "response_start".to_owned(),
-						timeout_ms: response_start_timeout.as_millis() as u64,
-					}
-					.build()
-				})??;
+			let response_start_deadline = tokio::time::Instant::now() + response_start_timeout;
+			let response_start = if let Some(body) = streaming_body {
+				stream_http_request_and_wait_for_response(
+					&in_flight_req,
+					&mut msg_rx,
+					&mut drop_rx,
+					&mut stopped_sub,
+					self.actor_id,
+					request_id,
+					body,
+					max_request_body_size,
+					response_start_deadline,
+					response_start_timeout,
+				)
+				.instrument(tracing::info_span!("stream_request_and_wait_for_response"))
+				.await?
+			} else {
+				wait_for_http_response_start(
+					&mut msg_rx,
+					&mut drop_rx,
+					&mut stopped_sub,
+					self.actor_id,
+					request_id,
+					response_start_deadline,
+					response_start_timeout,
+				)
+				.instrument(tracing::info_span!("wait_for_tunnel_response"))
+				.await?
+			};
+			let (response_start_message_id, mut response_start) = response_start;
 			tracing::debug!("response handler task ended");
 
 			// Build HTTP response
@@ -313,20 +371,60 @@ impl PegboardGateway2 {
 				response_builder = response_builder.header(key, value);
 			}
 
-			// Add body
-			let body = response_start.body.unwrap_or_default();
-			let response =
-				response_builder.body(ResponseBody::Full(Full::new(Bytes::from(body))))?;
+			let response = if response_start.stream {
+				let (body_tx, body_rx) =
+					mpsc::channel::<Result<Bytes, ResponseBodyError>>(
+						HTTP_RESPONSE_BODY_CHANNEL_CAPACITY,
+					);
+				let idle_timeout = self
+					.ctx
+					.config()
+					.pegboard()
+					.gateway_response_chunk_idle_timeout_ms()
+					.map(|timeout_ms| Duration::from_millis(timeout_ms.max(1)));
+				let expected_message_index =
+					response_start_message_id.message_index.wrapping_add(1);
+				let initial_body = response_start.body.take();
 
-			in_flight_req.stop(RequestStopResult::Success).await;
+				tokio::spawn(
+					drain_http_response_stream(
+						in_flight_req.clone(),
+						msg_rx,
+						drop_rx,
+						stopped_sub,
+						body_tx,
+						initial_body,
+						expected_message_index,
+						self.actor_id,
+						idle_timeout,
+					)
+					.in_current_span(),
+				);
+
+				response_builder.body(ResponseBody::Channel(body_rx))?
+			} else {
+				let body = response_start.body.unwrap_or_default();
+				let response =
+					response_builder.body(ResponseBody::Full(Full::new(Bytes::from(body))))?;
+
+				in_flight_req.stop(RequestStopResult::Success).await;
+				response
+			};
 
 			Ok(response)
 		}
 		.await;
 
 		if res.is_err() {
+			send_http_request_abort(
+				&in_flight_req,
+				protocol::HttpStreamAbortReasonKind::InternalError,
+				Some("gateway stopped the HTTP request before completion".to_owned()),
+			)
+			.await;
 			in_flight_req.stop(RequestStopResult::EnvoyError).await;
 		}
+		client_disconnect_guard.disarm();
 
 		res
 	}
@@ -456,7 +554,7 @@ impl PegboardGateway2 {
 						tokio::select! {
 							res = msg_rx.recv() => {
 								if let Some(msg) = res {
-									match msg {
+									match msg.message_kind {
 										protocol::ToRivetTunnelMessageKind::ToRivetWebSocketOpen(msg) => {
 											tracing::trace!(
 												actor_id = %self.actor_id,
@@ -912,63 +1010,26 @@ impl PegboardGateway2 {
 
 #[async_trait]
 impl CustomServeTrait for PegboardGateway2 {
+	fn streams_request_body(&self) -> bool {
+		true
+	}
+
 	#[tracing::instrument(skip_all, fields(actor_id=?self.actor_id, actor_key=?self.actor_key, actor_generation=?self.actor_generation, namespace_id=?self.namespace_id, pool_name=%self.pool_name, envoy_key=%self.envoy_key))]
 	async fn handle_request(
 		&self,
 		req: Request<Full<Bytes>>,
 		req_ctx: &mut RequestContext,
 	) -> Result<Response<ResponseBody>> {
-		let ctx = self.ctx.with_ray(req_ctx.ray_id(), req_ctx.req_id())?;
-		let req_body_size_hint = req.body().size_hint();
+		self.handle_http_request(req, req_ctx).await
+	}
 
-		let (res, metrics_res) = tokio::join!(
-			self.handle_request_inner(&ctx, req, req_ctx),
-			record_req_metrics(
-				&ctx,
-				self.actor_id,
-				self.namespace_id,
-				Metric::HttpIngress(
-					req_body_size_hint
-						.upper()
-						.unwrap_or(req_body_size_hint.lower()) as usize
-				),
-			),
-		);
-
-		let response_size = match &res {
-			Ok(res) => res.size_hint().upper().unwrap_or(res.size_hint().lower()),
-			Err(_) => 0,
-		};
-
-		if let Err(err) = metrics_res {
-			tracing::error!(?err, "http req ingress metrics failed");
-		} else {
-			let actor_id = self.actor_id;
-			let namespace_id = self.namespace_id;
-			let envoy_key = self.envoy_key.clone();
-			tokio::spawn(
-				async move {
-					if let Err(err) = record_req_metrics(
-						&ctx,
-						actor_id,
-						namespace_id,
-						Metric::HttpEgress(response_size as usize),
-					)
-					.await
-					{
-						tracing::error!(
-							?err,
-							?namespace_id,
-							%envoy_key,
-							"http req egress metrics failed, likely corrupt now",
-						);
-					}
-				}
-				.in_current_span(),
-			);
-		}
-
-		res
+	#[tracing::instrument(skip_all, fields(actor_id=?self.actor_id, actor_key=?self.actor_key, actor_generation=?self.actor_generation, namespace_id=?self.namespace_id, pool_name=%self.pool_name, envoy_key=%self.envoy_key))]
+	async fn handle_streaming_request(
+		&self,
+		req: Request<BodyIncoming>,
+		req_ctx: &mut RequestContext,
+	) -> Result<Response<ResponseBody>> {
+		self.handle_http_request(req, req_ctx).await
 	}
 
 	#[tracing::instrument(skip_all, fields(actor_id=?self.actor_id, actor_key=?self.actor_key, actor_generation=?self.actor_generation, namespace_id=?self.namespace_id, pool_name=%self.pool_name, envoy_key=%self.envoy_key))]

--- a/engine/packages/pegboard-gateway2/src/shared_state.rs
+++ b/engine/packages/pegboard-gateway2/src/shared_state.rs
@@ -9,7 +9,7 @@ use std::{
 	ops::Deref,
 	sync::{
 		Arc,
-		atomic::{AtomicU64, Ordering},
+		atomic::{AtomicU64, AtomicUsize, Ordering},
 	},
 	time::{Duration, Instant},
 };
@@ -18,6 +18,9 @@ use universalpubsub::{NextOutput, PubSub, PublishOpts};
 use vbare::OwnedVersionedData;
 
 use crate::{WebsocketPendingLimitReached, metrics};
+
+const HTTP_RESPONSE_QUEUE_MAX_MESSAGES: usize = 384;
+const STREAMING_HTTP_RESPONSE_QUEUE_MAX_BYTES: usize = 20 * 1024 * 1024;
 
 #[derive(Debug, Clone, Copy)]
 pub enum RequestProtocol {
@@ -69,7 +72,7 @@ fn to_envoy_tunnel_message_kind_name(kind: &protocol::ToEnvoyTunnelMessageKind) 
 	match kind {
 		protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestStart(_) => "ToEnvoyRequestStart",
 		protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestChunk(_) => "ToEnvoyRequestChunk",
-		protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort => "ToEnvoyRequestAbort",
+		protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort(_) => "ToEnvoyRequestAbort",
 		protocol::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketOpen(_) => "ToEnvoyWebSocketOpen",
 		protocol::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketMessage(_) => "ToEnvoyWebSocketMessage",
 		protocol::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketClose(_) => "ToEnvoyWebSocketClose",
@@ -80,7 +83,7 @@ fn to_rivet_tunnel_message_kind_name(kind: &protocol::ToRivetTunnelMessageKind) 
 	match kind {
 		protocol::ToRivetTunnelMessageKind::ToRivetResponseStart(_) => "ToRivetResponseStart",
 		protocol::ToRivetTunnelMessageKind::ToRivetResponseChunk(_) => "ToRivetResponseChunk",
-		protocol::ToRivetTunnelMessageKind::ToRivetResponseAbort => "ToRivetResponseAbort",
+		protocol::ToRivetTunnelMessageKind::ToRivetResponseAbort(_) => "ToRivetResponseAbort",
 		protocol::ToRivetTunnelMessageKind::ToRivetWebSocketOpen(_) => "ToRivetWebSocketOpen",
 		protocol::ToRivetTunnelMessageKind::ToRivetWebSocketMessage(_) => "ToRivetWebSocketMessage",
 		protocol::ToRivetTunnelMessageKind::ToRivetWebSocketMessageAck(_) => {
@@ -119,6 +122,8 @@ pub enum MsgGcReason {
 	/// The gateway has not kept alive the in flight request during hibernation for the given timeout
 	/// duration.
 	HibernationTimeout,
+	/// The HTTP response producer outran the gateway consumer.
+	HttpResponseQueueOverloaded,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -153,6 +158,7 @@ pub struct SharedStateInner {
 	tunnel_ping_timeout: i64,
 	hws_message_ack_timeout: Duration,
 	hws_max_pending_size: u64,
+	buffered_http_response_max_bytes: usize,
 }
 
 #[derive(Clone)]
@@ -180,6 +186,7 @@ impl SharedState {
 				pegboard_config.gateway_hws_message_ack_timeout_ms(),
 			),
 			hws_max_pending_size: pegboard_config.gateway_hws_max_pending_size(),
+			buffered_http_response_max_bytes: pegboard_config.envoy_max_response_payload_size(),
 		}))
 	}
 
@@ -375,6 +382,12 @@ impl SharedState {
 	) -> Result<InFlightRequestCtx> {
 		let (msg_tx, msg_rx) = mpsc::unbounded_channel();
 		let (drop_tx, drop_rx) = watch::channel(None);
+		let http_response_queue_budget = matches!(protocol, RequestProtocol::Http)
+			.then(|| {
+				Arc::new(HttpResponseQueueBudget::new(
+					self.buffered_http_response_max_bytes,
+				))
+			});
 
 		let new = match self
 			.in_flight_requests
@@ -395,6 +408,7 @@ impl SharedState {
 					state: InFlightRequestState::Active {
 						msg_tx,
 						drop_tx,
+						http_response_queue_budget,
 						last_pong: util::timestamp::now(),
 						hibernation_state: None,
 					},
@@ -413,7 +427,12 @@ impl SharedState {
 			Entry::Occupied(mut entry) => {
 				entry.actor_key = actor_key;
 				entry.actor_generation = actor_generation;
-				entry.wake(receiver_subject, msg_tx, drop_tx);
+				entry.wake(
+					receiver_subject,
+					msg_tx,
+					drop_tx,
+					http_response_queue_budget,
+				);
 
 				false
 			}
@@ -452,7 +471,7 @@ impl SharedState {
 		let (msg_tx, msg_rx) = mpsc::unbounded_channel();
 		let (drop_tx, drop_rx) = watch::channel(None);
 
-		req.hibernate(msg_tx, drop_tx);
+		req.hibernate(msg_tx, drop_tx, None);
 		req.namespace_id = namespace_id;
 		req.pool_name = pool_name.to_string();
 		req.actor_key = actor_key;
@@ -545,13 +564,83 @@ impl Deref for SharedState {
 }
 
 pub struct InFlightRequestCtx {
-	pub msg_rx: mpsc::UnboundedReceiver<protocol::ToRivetTunnelMessageKind>,
+	pub msg_rx: mpsc::UnboundedReceiver<InFlightTunnelMessage>,
 	/// Used to check if the request handler has been dropped.
 	///
 	/// This is separate from `msg_rx` there may still be messages that need to be sent to the
 	/// request after `msg_rx` has dropped.
 	pub drop_rx: watch::Receiver<Option<MsgGcReason>>,
 	pub handle: InFlightRequestHandle,
+}
+
+#[derive(Debug)]
+pub struct InFlightTunnelMessage {
+	pub message_id: protocol::MessageId,
+	pub message_kind: protocol::ToRivetTunnelMessageKind,
+	_http_response_queue_permit: Option<HttpResponseQueuePermit>,
+}
+
+#[derive(Debug)]
+struct HttpResponseQueueBudget {
+	messages: AtomicUsize,
+	bytes: AtomicUsize,
+	buffered_response_max_bytes: usize,
+}
+
+impl HttpResponseQueueBudget {
+	fn new(buffered_response_max_bytes: usize) -> Self {
+		Self {
+			messages: AtomicUsize::new(0),
+			bytes: AtomicUsize::new(0),
+			buffered_response_max_bytes,
+		}
+	}
+
+	fn try_reserve(
+		self: &Arc<Self>,
+		bytes: usize,
+		streaming: bool,
+	) -> Option<HttpResponseQueuePermit> {
+		let max_bytes = if streaming {
+			STREAMING_HTTP_RESPONSE_QUEUE_MAX_BYTES
+		} else {
+			self.buffered_response_max_bytes
+		};
+		if bytes > max_bytes {
+			return None;
+		}
+
+		let previous_messages = self.messages.fetch_add(1, Ordering::AcqRel);
+		if previous_messages >= HTTP_RESPONSE_QUEUE_MAX_MESSAGES {
+			self.messages.fetch_sub(1, Ordering::AcqRel);
+			return None;
+		}
+
+		let previous_bytes = self.bytes.fetch_add(bytes, Ordering::AcqRel);
+		if previous_bytes.saturating_add(bytes) > max_bytes {
+			self.bytes.fetch_sub(bytes, Ordering::AcqRel);
+			self.messages.fetch_sub(1, Ordering::AcqRel);
+			return None;
+		}
+
+		Some(HttpResponseQueuePermit {
+			budget: self.clone(),
+			bytes,
+		})
+	}
+}
+
+#[derive(Debug)]
+struct HttpResponseQueuePermit {
+	budget: Arc<HttpResponseQueueBudget>,
+	bytes: usize,
+}
+
+impl Drop for HttpResponseQueuePermit {
+	fn drop(&mut self) {
+		self.budget.bytes.fetch_sub(self.bytes, Ordering::AcqRel);
+		self.budget.messages.fetch_sub(1, Ordering::AcqRel);
+	}
 }
 
 #[derive(Clone)]
@@ -1176,6 +1265,8 @@ impl InFlightRequest {
 			protocol::ToGateway::ToRivetTunnelMessage(msg) => match &mut self.state {
 				InFlightRequestState::Active {
 					msg_tx,
+					drop_tx,
+					http_response_queue_budget,
 					hibernation_state,
 					..
 				} => {
@@ -1183,7 +1274,9 @@ impl InFlightRequest {
 						&self.receiver_subject,
 						self.actor_key.as_deref(),
 						self.actor_generation,
-						&msg_tx,
+						msg_tx,
+						drop_tx,
+						http_response_queue_budget.as_ref(),
 						msg,
 					);
 
@@ -1198,6 +1291,8 @@ impl InFlightRequest {
 				}
 				InFlightRequestState::Hibernating {
 					msg_tx,
+					drop_tx,
+					http_response_queue_budget,
 					hibernation_state,
 					..
 				} => {
@@ -1205,7 +1300,9 @@ impl InFlightRequest {
 						&self.receiver_subject,
 						self.actor_key.as_deref(),
 						self.actor_generation,
-						&msg_tx,
+						msg_tx,
+						drop_tx,
+						http_response_queue_budget.as_ref(),
 						msg,
 					);
 
@@ -1221,8 +1318,9 @@ impl InFlightRequest {
 	fn wake(
 		&mut self,
 		receiver_subject: String,
-		msg_tx: mpsc::UnboundedSender<protocol::ToRivetTunnelMessageKind>,
+		msg_tx: mpsc::UnboundedSender<InFlightTunnelMessage>,
 		drop_tx: watch::Sender<Option<MsgGcReason>>,
+		http_response_queue_budget: Option<Arc<HttpResponseQueueBudget>>,
 	) {
 		self.receiver_subject = receiver_subject;
 
@@ -1243,6 +1341,7 @@ impl InFlightRequest {
 			} => InFlightRequestState::Active {
 				msg_tx,
 				drop_tx,
+				http_response_queue_budget,
 				last_pong: util::timestamp::now(),
 				hibernation_state,
 			},
@@ -1259,6 +1358,7 @@ impl InFlightRequest {
 				InFlightRequestState::Active {
 					msg_tx,
 					drop_tx,
+					http_response_queue_budget,
 					last_pong: util::timestamp::now(),
 					hibernation_state: Some(hibernation_state),
 				}
@@ -1266,13 +1366,21 @@ impl InFlightRequest {
 		});
 
 		// Should be active at this point
-		if let InFlightRequestState::Active { msg_tx, .. } = &self.state {
+		if let InFlightRequestState::Active {
+			msg_tx,
+			drop_tx,
+			http_response_queue_budget,
+			..
+		} = &self.state
+		{
 			for msg in pending_tunnel_msgs {
 				forward_tunnel_message(
 					&self.receiver_subject,
 					self.actor_key.as_deref(),
 					self.actor_generation,
 					msg_tx,
+					drop_tx,
+					http_response_queue_budget.as_ref(),
 					msg,
 				);
 			}
@@ -1282,8 +1390,9 @@ impl InFlightRequest {
 	/// Transition from pending hibernation to hibernating
 	fn hibernate(
 		&mut self,
-		msg_tx: mpsc::UnboundedSender<protocol::ToRivetTunnelMessageKind>,
+		msg_tx: mpsc::UnboundedSender<InFlightTunnelMessage>,
 		drop_tx: watch::Sender<Option<MsgGcReason>>,
+		http_response_queue_budget: Option<Arc<HttpResponseQueueBudget>>,
 	) {
 		let mut pending_tunnel_msgs = Vec::new();
 
@@ -1305,6 +1414,7 @@ impl InFlightRequest {
 				InFlightRequestState::Hibernating {
 					msg_tx,
 					drop_tx,
+					http_response_queue_budget,
 					hibernation_state,
 				}
 			}
@@ -1316,13 +1426,21 @@ impl InFlightRequest {
 		});
 
 		// Should be hibernating at this point
-		if let InFlightRequestState::Hibernating { msg_tx, .. } = &self.state {
+		if let InFlightRequestState::Hibernating {
+			msg_tx,
+			drop_tx,
+			http_response_queue_budget,
+			..
+		} = &self.state
+		{
 			for msg in pending_tunnel_msgs {
 				forward_tunnel_message(
 					&self.receiver_subject,
 					self.actor_key.as_deref(),
 					self.actor_generation,
 					msg_tx,
+					drop_tx,
+					http_response_queue_budget.as_ref(),
 					msg,
 				);
 			}
@@ -1382,9 +1500,10 @@ impl InFlightRequest {
 enum InFlightRequestState {
 	Active {
 		/// Sender for incoming messages to this request.
-		msg_tx: mpsc::UnboundedSender<protocol::ToRivetTunnelMessageKind>,
+		msg_tx: mpsc::UnboundedSender<InFlightTunnelMessage>,
 		/// Used to check if the request handler has been dropped.
 		drop_tx: watch::Sender<Option<MsgGcReason>>,
+		http_response_queue_budget: Option<Arc<HttpResponseQueueBudget>>,
 		last_pong: i64,
 		hibernation_state: Option<HibernationState>,
 	},
@@ -1392,9 +1511,10 @@ enum InFlightRequestState {
 	PendingHibernation { hibernation_state: HibernationState },
 	Hibernating {
 		/// Sender for incoming messages to this request.
-		msg_tx: mpsc::UnboundedSender<protocol::ToRivetTunnelMessageKind>,
+		msg_tx: mpsc::UnboundedSender<InFlightTunnelMessage>,
 		/// Used to check if the hibernation handler has been dropped.
 		drop_tx: watch::Sender<Option<MsgGcReason>>,
+		http_response_queue_budget: Option<Arc<HttpResponseQueueBudget>>,
 		hibernation_state: HibernationState,
 	},
 }
@@ -1420,47 +1540,116 @@ fn forward_tunnel_message(
 	receiver_subject: &str,
 	actor_key: Option<&str>,
 	actor_generation: Option<u32>,
-	msg_tx: &mpsc::UnboundedSender<protocol::ToRivetTunnelMessageKind>,
-	mut msg: protocol::ToRivetTunnelMessage,
+	msg_tx: &mpsc::UnboundedSender<InFlightTunnelMessage>,
+	drop_tx: &watch::Sender<Option<MsgGcReason>>,
+	http_response_queue_budget: Option<&Arc<HttpResponseQueueBudget>>,
+	msg: protocol::ToRivetTunnelMessage,
 ) -> Option<protocol::ToRivetTunnelMessage> {
+	let message_id = msg.message_id;
 	// Send message to the request handler to emulate the real network action
 	let inner_size = match &msg.message_kind {
 		protocol::ToRivetTunnelMessageKind::ToRivetWebSocketMessage(ws_msg) => ws_msg.data.len(),
 		_ => 0,
 	};
+	let http_response_bytes = match &msg.message_kind {
+		protocol::ToRivetTunnelMessageKind::ToRivetResponseStart(response) => {
+			response.body.as_ref().map_or(0, Vec::len)
+		}
+		protocol::ToRivetTunnelMessageKind::ToRivetResponseChunk(chunk) => chunk.body.len(),
+		_ => 0,
+	};
+	let streaming_http_response = !matches!(
+		&msg.message_kind,
+		protocol::ToRivetTunnelMessageKind::ToRivetResponseStart(response) if !response.stream
+	);
+	let http_response_queue_permit = http_response_queue_budget.and_then(|budget| {
+		budget.try_reserve(http_response_bytes, streaming_http_response)
+	});
+	if http_response_queue_budget.is_some() && http_response_queue_permit.is_none() {
+		tracing::warn!(
+			gateway_id=%display_id(&message_id.gateway_id),
+			request_id=%display_id(&message_id.request_id),
+			message_index=message_id.message_index,
+			http_response_bytes,
+			"streaming http response queue exceeded its in-flight limit"
+		);
+		drop_tx.send_replace(Some(MsgGcReason::HttpResponseQueueOverloaded));
+		return None;
+	}
 	tracing::debug!(
-		gateway_id=%display_id(&msg.message_id.gateway_id),
-		request_id=%display_id(&msg.message_id.request_id),
-		message_index=msg.message_id.message_index,
+		gateway_id=%display_id(&message_id.gateway_id),
+		request_id=%display_id(&message_id.request_id),
+		message_index=message_id.message_index,
 		actor_key,
 		actor_generation,
 		inner_size,
 		"forwarding message to request handler"
 	);
 
-	if let Err(send_err) = msg_tx.send(msg.message_kind) {
+	let tunnel_msg = InFlightTunnelMessage {
+		message_id: message_id.clone(),
+		message_kind: msg.message_kind,
+		_http_response_queue_permit: http_response_queue_permit,
+	};
+
+	if let Err(send_err) = msg_tx.send(tunnel_msg) {
 		tracing::debug!(
-			gateway_id=%display_id(&msg.message_id.gateway_id),
-			request_id=%display_id(&msg.message_id.request_id),
+			gateway_id=%display_id(&send_err.0.message_id.gateway_id),
+			request_id=%display_id(&send_err.0.message_id.request_id),
 			receiver_subject=%receiver_subject,
 			actor_key,
 			actor_generation,
 			"message handler channel closed, saving to pending msgs",
 		);
 
-		msg.message_kind = send_err.0;
-		Some(msg)
+		Some(protocol::ToRivetTunnelMessage {
+			message_id: send_err.0.message_id,
+			message_kind: send_err.0.message_kind,
+		})
 	} else {
 		tracing::trace!(
-			gateway_id=%display_id(&msg.message_id.gateway_id),
-			request_id=%display_id(&msg.message_id.request_id),
-			message_index=msg.message_id.message_index,
+			gateway_id=%display_id(&message_id.gateway_id),
+			request_id=%display_id(&message_id.request_id),
+			message_index=message_id.message_index,
 			actor_key,
 			actor_generation,
 			inner_size,
 			"delivered message to request handler channel"
 		);
 		None
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn http_response_queue_budget_bounds_messages_and_releases_capacity() {
+		let budget = Arc::new(HttpResponseQueueBudget::new(20 * 1024 * 1024));
+		let permits = (0..HTTP_RESPONSE_QUEUE_MAX_MESSAGES)
+			.map(|_| budget.try_reserve(0, true).expect("message should fit"))
+			.collect::<Vec<_>>();
+
+		assert!(budget.try_reserve(0, true).is_none());
+		drop(permits);
+		assert!(budget.try_reserve(0, true).is_some());
+	}
+
+	#[test]
+	fn http_response_queue_budget_bounds_bytes_without_limiting_total_stream_size() {
+		let budget = Arc::new(HttpResponseQueueBudget::new(20 * 1024 * 1024));
+		let permit = budget
+			.try_reserve(STREAMING_HTTP_RESPONSE_QUEUE_MAX_BYTES, true)
+			.expect("queue-sized chunk should fit");
+
+		assert!(budget.try_reserve(1, true).is_none());
+		drop(permit);
+		assert!(
+			budget
+				.try_reserve(STREAMING_HTTP_RESPONSE_QUEUE_MAX_BYTES, true)
+				.is_some()
+		);
 	}
 }
 

--- a/engine/packages/pegboard-gateway2/src/tunnel_to_ws_task.rs
+++ b/engine/packages/pegboard-gateway2/src/tunnel_to_ws_task.rs
@@ -16,14 +16,16 @@ use tokio::sync::{mpsc, watch};
 use tokio_tungstenite::tungstenite::Message;
 
 use super::LifecycleResult;
-use crate::shared_state::{InFlightRequestHandle, MsgGcReason, display_id};
+use crate::shared_state::{
+	InFlightRequestHandle, InFlightTunnelMessage, MsgGcReason, display_id,
+};
 
 #[tracing::instrument(name = "tunnel_to_ws_task", skip_all)]
 pub async fn task(
 	in_flight_req: InFlightRequestHandle,
 	client_ws: WebSocketHandle,
 	mut stopped_sub: message::SubscriptionHandle<pegboard::workflows::actor2::Stopped>,
-	mut msg_rx: mpsc::UnboundedReceiver<protocol::ToRivetTunnelMessageKind>,
+	mut msg_rx: mpsc::UnboundedReceiver<InFlightTunnelMessage>,
 	mut drop_rx: watch::Receiver<Option<MsgGcReason>>,
 	can_hibernate: bool,
 	egress_bytes: Arc<AtomicU64>,
@@ -33,7 +35,7 @@ pub async fn task(
 		tokio::select! {
 			res = msg_rx.recv() => {
 				if let Some(msg) = res {
-					match msg {
+					match msg.message_kind {
 						protocol::ToRivetTunnelMessageKind::ToRivetWebSocketMessage(ws_msg) => {
 							let data_len = ws_msg.data.len();
 							let binary = ws_msg.binary;

--- a/engine/packages/pegboard-gateway2/tests/support/http_stream_request.rs
+++ b/engine/packages/pegboard-gateway2/tests/support/http_stream_request.rs
@@ -1,0 +1,41 @@
+use super::*;
+
+#[test]
+fn request_body_streams_only_after_one_chunk() {
+	let hint = |size| SizeHint::with_exact(size as u64);
+	assert!(!should_stream_http_request_body_hint(&hint(0)));
+	assert!(!should_stream_http_request_body_hint(&hint(
+		HTTP_BODY_CHUNK_SIZE
+	)));
+	assert!(should_stream_http_request_body_hint(&hint(
+		HTTP_BODY_CHUNK_SIZE + 1
+	)));
+}
+
+#[test]
+fn streaming_request_body_size_is_cumulative_and_overflow_safe() {
+	assert_eq!(next_request_body_size(6, 4, 10), Some(10));
+	assert_eq!(next_request_body_size(7, 4, 10), None);
+	assert_eq!(next_request_body_size(usize::MAX, 1, usize::MAX), None);
+}
+
+#[test]
+fn request_body_chunker_coalesces_tiny_frames() {
+	let mut chunker = HttpRequestBodyChunker::default();
+	let mut chunks = Vec::new();
+	for _ in 0..HTTP_BODY_CHUNK_SIZE {
+		chunks.extend(chunker.push(&[7]));
+	}
+
+	assert_eq!(chunks.len(), 1);
+	assert_eq!(chunks[0].len(), HTTP_BODY_CHUNK_SIZE);
+	assert!(chunker.is_empty());
+}
+
+#[test]
+fn request_body_chunker_flushes_partial_data() {
+	let mut chunker = HttpRequestBodyChunker::default();
+	assert!(chunker.push(&[1, 2, 3]).is_empty());
+	assert_eq!(chunker.flush(), Some(vec![1, 2, 3]));
+	assert!(chunker.is_empty());
+}

--- a/engine/packages/pegboard-gateway2/tests/support/http_stream_response.rs
+++ b/engine/packages/pegboard-gateway2/tests/support/http_stream_response.rs
@@ -1,0 +1,19 @@
+use super::*;
+
+#[test]
+fn response_stream_message_index_advances_and_wraps() {
+	assert_eq!(advance_http_stream_message_index(7, 7), Ok(8));
+	assert_eq!(
+		advance_http_stream_message_index(
+			protocol::MessageIndex::MAX,
+			protocol::MessageIndex::MAX
+		),
+		Ok(0)
+	);
+}
+
+#[test]
+fn response_stream_message_index_rejects_gaps() {
+	assert_eq!(advance_http_stream_message_index(7, 8), Err(()));
+	assert_eq!(advance_http_stream_message_index(7, 6), Err(()));
+}

--- a/engine/sdks/rust/envoy-client/src/actor.rs
+++ b/engine/sdks/rust/envoy-client/src/actor.rs
@@ -4,13 +4,15 @@ use std::sync::Arc;
 
 use crate::async_counter::AsyncCounter;
 use rivet_envoy_protocol as protocol;
-use tokio::sync::mpsc;
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc, oneshot, watch};
 use tokio::sync::oneshot::error::TryRecvError;
-use tokio::task::{JoinError, JoinSet};
+use tokio::task::{AbortHandle, JoinError, JoinSet};
 use tracing::Instrument;
 
-use crate::config::{HttpRequest, HttpResponse, WebSocketMessage};
+use crate::config::{
+	HTTP_BODY_MAX_CHUNK_SIZE, HTTP_BODY_STREAM_CHANNEL_CAPACITY, HttpRequest, HttpResponse,
+	HttpRequestBodyError, HttpRequestBodyStream, ResponseChunk, WebSocketMessage,
+};
 use crate::connection::ws_send;
 use crate::context::SharedContext;
 use crate::handle::EnvoyHandle;
@@ -43,6 +45,10 @@ pub enum ToActor {
 	},
 	ReqAbort {
 		message_id: protocol::MessageId,
+		reason: protocol::HttpStreamAbortReason,
+	},
+	ReqComplete {
+		message_id: protocol::MessageId,
 	},
 	WsOpen {
 		message_id: protocol::MessageId,
@@ -66,7 +72,12 @@ pub enum ToActor {
 
 struct PendingRequest {
 	envoy_message_index: u16,
-	body_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
+	body_tx: Option<mpsc::Sender<Vec<u8>>>,
+	body_abort_tx: Option<watch::Sender<Option<HttpRequestBodyError>>>,
+	task_abort_handle: Option<AbortHandle>,
+	body_rejected: bool,
+	upload_complete: bool,
+	response_complete: bool,
 }
 
 struct WsEntry {
@@ -78,12 +89,14 @@ struct WsEntry {
 
 struct ActorContext {
 	shared: Arc<SharedContext>,
+	tx: mpsc::UnboundedSender<ToActor>,
 	actor_id: String,
 	generation: u32,
 	command_idx: i64,
 	event_index: i64,
 	error: Option<String>,
 	pending_requests: BufferMap<PendingRequest>,
+	early_request_chunks: BufferMap<Vec<protocol::ToEnvoyRequestChunk>>,
 	ws_entries: BufferMap<WsEntry>,
 	hibernating_requests: Vec<protocol::HibernatingRequest>,
 	active_http_request_count: Arc<AsyncCounter>,
@@ -104,6 +117,12 @@ enum StopProgress {
 	Pending(PendingStop),
 }
 
+/// Counts one HTTP request task from dispatch through the full response drain.
+///
+/// This guard is created before invoking the runtime callback and is held across
+/// `send_response`, including streaming `body_stream` drains. Sleep/shutdown
+/// logic relies on this counter staying non-zero until the final response chunk
+/// is sent or the task is aborted.
 impl ActiveHttpRequestGuard {
 	fn new(active_http_request_count: Arc<AsyncCounter>) -> Self {
 		active_http_request_count.increment();
@@ -136,6 +155,7 @@ pub fn create_actor(
 		config,
 		hibernating_requests,
 		preloaded_kv,
+		tx.clone(),
 		rx,
 		active_http_request_count.clone(),
 	));
@@ -158,6 +178,7 @@ async fn actor_inner(
 	config: protocol::ActorConfig,
 	hibernating_requests: Vec<protocol::HibernatingRequest>,
 	preloaded_kv: Option<protocol::PreloadedKv>,
+	tx: mpsc::UnboundedSender<ToActor>,
 	mut rx: mpsc::UnboundedReceiver<ToActor>,
 	active_http_request_count: Arc<AsyncCounter>,
 ) {
@@ -169,12 +190,14 @@ async fn actor_inner(
 
 	let mut ctx = ActorContext {
 		shared: shared.clone(),
+		tx,
 		actor_id: actor_id.clone(),
 		generation,
 		command_idx: 0,
 		event_index: 0,
 		error: None,
 		pending_requests: BufferMap::new(),
+		early_request_chunks: BufferMap::new(),
 		ws_entries: BufferMap::new(),
 		hibernating_requests,
 		active_http_request_count,
@@ -326,13 +349,16 @@ async fn actor_inner(
 						}
 					}
 					ToActor::ReqStart { message_id, req } => {
-						handle_req_start(&mut ctx, &handle, &mut http_request_tasks, message_id, req);
+						handle_req_start(&mut ctx, &handle, &mut http_request_tasks, message_id, req).await;
 					}
 					ToActor::ReqChunk { message_id, chunk } => {
 						handle_req_chunk(&mut ctx, message_id, chunk);
 					}
-					ToActor::ReqAbort { message_id } => {
-						handle_req_abort(&mut ctx, message_id);
+					ToActor::ReqAbort { message_id, reason } => {
+						handle_req_abort(&mut ctx, message_id, reason);
+					}
+					ToActor::ReqComplete { message_id } => {
+						handle_req_complete(&mut ctx, message_id);
 					}
 					ToActor::WsOpen {
 						message_id,
@@ -508,7 +534,7 @@ fn send_stopped_event(
 	);
 }
 
-fn handle_req_start(
+async fn handle_req_start(
 	ctx: &mut ActorContext,
 	handle: &EnvoyHandle,
 	http_request_tasks: &mut JoinSet<()>,
@@ -518,6 +544,11 @@ fn handle_req_start(
 	let pending = PendingRequest {
 		envoy_message_index: 0,
 		body_tx: None,
+		body_abort_tx: None,
+		task_abort_handle: None,
+		body_rejected: false,
+		upload_complete: !req.stream,
+		response_complete: false,
 	};
 	ctx.pending_requests
 		.insert(&[&message_id.gateway_id, &message_id.request_id], pending);
@@ -529,14 +560,16 @@ fn handle_req_start(
 		.collect();
 
 	let body_stream = if req.stream {
-		let (body_tx, body_rx) = mpsc::unbounded_channel::<Vec<u8>>();
+		let (body_tx, body_rx) = mpsc::channel::<Vec<u8>>(HTTP_BODY_STREAM_CHANNEL_CAPACITY);
+		let (body_abort_tx, body_abort_rx) = watch::channel(None);
 		if let Some(pending) = ctx
 			.pending_requests
 			.get_mut(&[&message_id.gateway_id, &message_id.request_id])
 		{
 			pending.body_tx = Some(body_tx);
+			pending.body_abort_tx = Some(body_abort_tx);
 		}
-		Some(body_rx)
+		Some(HttpRequestBodyStream::new(body_rx, body_abort_rx))
 	} else {
 		None
 	};
@@ -555,6 +588,8 @@ fn handle_req_start(
 	let gateway_id = message_id.gateway_id;
 	let request_id = message_id.request_id;
 	let request_guard = ActiveHttpRequestGuard::new(ctx.active_http_request_count.clone());
+	let actor_tx = ctx.tx.clone();
+	let completion_message_id = message_id.clone();
 
 	let task = async move {
 		let _request_guard = request_guard;
@@ -573,18 +608,32 @@ fn handle_req_start(
 				send_fetch_error_response(&shared, gateway_id, request_id).await;
 			}
 		}
+		let _ = actor_tx.send(ToActor::ReqComplete {
+			message_id: completion_message_id,
+		});
 	}
 	.in_current_span();
 
 	#[cfg(target_arch = "wasm32")]
-	http_request_tasks.spawn_local(task);
+	let task_abort_handle = http_request_tasks.spawn_local(task);
 	#[cfg(not(target_arch = "wasm32"))]
-	http_request_tasks.spawn(task);
-
-	if !req.stream {
-		ctx.pending_requests
-			.remove(&[&message_id.gateway_id, &message_id.request_id]);
+	let task_abort_handle = http_request_tasks.spawn(task);
+	if let Some(pending) = ctx
+		.pending_requests
+		.get_mut(&[&message_id.gateway_id, &message_id.request_id])
+	{
+		pending.task_abort_handle = Some(task_abort_handle);
 	}
+
+	if let Some(chunks) = ctx
+		.early_request_chunks
+		.remove(&[&message_id.gateway_id, &message_id.request_id])
+	{
+		for chunk in chunks {
+			handle_req_chunk(ctx, message_id.clone(), chunk);
+		}
+	}
+
 }
 
 fn handle_http_request_task_result(result: Result<(), JoinError>) {
@@ -624,27 +673,132 @@ fn handle_req_chunk(
 	chunk: protocol::ToEnvoyRequestChunk,
 ) {
 	let finish = chunk.finish;
-	let pending = ctx
-		.pending_requests
-		.get(&[&message_id.gateway_id, &message_id.request_id]);
-	if let Some(pending) = pending {
-		if let Some(body_tx) = &pending.body_tx {
-			let _ = body_tx.send(chunk.body);
-		} else {
-			tracing::warn!("received chunk for pending request without stream controller");
+	let key: [&[u8]; 2] = [&message_id.gateway_id, &message_id.request_id];
+	let mut response_aborted = false;
+	let pending = ctx.pending_requests.get_mut(&key);
+	match pending {
+		Some(pending) if pending.body_rejected => {}
+		Some(pending) => {
+			if !chunk.body.is_empty() {
+				if let Some(body_tx) = pending.body_tx.clone() {
+					match body_tx.try_send(chunk.body) {
+						Ok(()) => {}
+						Err(mpsc::error::TrySendError::Closed(_)) => {
+							tracing::debug!("streamed request body consumer closed");
+							pending.body_tx = None;
+						}
+						Err(mpsc::error::TrySendError::Full(_)) => {
+							let reason = protocol::HttpStreamAbortReason {
+								kind: protocol::HttpStreamAbortReasonKind::Overloaded,
+								detail: Some(
+									"request body consumer did not keep up with the upload".to_owned(),
+								),
+							};
+							tracing::warn!("streamed request body channel overloaded");
+							if let Some(body_abort_tx) = pending.body_abort_tx.take() {
+								body_abort_tx.send_replace(Some(HttpRequestBodyError {
+									reason: reason.clone(),
+								}));
+							}
+							if let Some(task_abort_handle) = pending.task_abort_handle.take() {
+								task_abort_handle.abort();
+							}
+							pending.body_tx = None;
+							pending.body_rejected = true;
+							response_aborted = true;
+
+							let shared = ctx.shared.clone();
+							let gateway_id = message_id.gateway_id;
+							let request_id = message_id.request_id;
+							spawn_detached(async move {
+								send_response_abort(&shared, gateway_id, request_id, 0, reason).await;
+							});
+						}
+					}
+				} else {
+					tracing::warn!("received chunk for pending request without stream controller");
+					if !finish {
+						return;
+					}
+				}
+			}
 		}
-	} else {
-		tracing::warn!("received chunk for unknown pending request");
+		None => {
+			if let Some(chunks) = ctx
+				.early_request_chunks
+				.get_mut(&[&message_id.gateway_id, &message_id.request_id])
+			{
+				chunks.push(chunk);
+			} else {
+				ctx.early_request_chunks.insert(
+					&[&message_id.gateway_id, &message_id.request_id],
+					vec![chunk],
+				);
+			}
+			return;
+		}
 	}
 
 	if finish {
-		ctx.pending_requests
-			.remove(&[&message_id.gateway_id, &message_id.request_id]);
+		handle_req_phase_complete(ctx, message_id, true, response_aborted);
+	} else if response_aborted {
+		handle_req_phase_complete(ctx, message_id, false, true);
 	}
 }
 
-fn handle_req_abort(ctx: &mut ActorContext, message_id: protocol::MessageId) {
-	ctx.pending_requests
+fn handle_req_complete(ctx: &mut ActorContext, message_id: protocol::MessageId) {
+	handle_req_phase_complete(ctx, message_id, false, true);
+}
+
+fn handle_req_phase_complete(
+	ctx: &mut ActorContext,
+	message_id: protocol::MessageId,
+	upload_complete: bool,
+	response_complete: bool,
+) {
+	let key: [&[u8]; 2] = [&message_id.gateway_id, &message_id.request_id];
+	let Some(pending) = ctx.pending_requests.get_mut(&key) else {
+		return;
+	};
+	if upload_complete {
+		pending.upload_complete = true;
+		pending.body_tx = None;
+		pending.body_abort_tx = None;
+	}
+	if response_complete {
+		pending.response_complete = true;
+	}
+	if !pending.upload_complete || !pending.response_complete {
+		return;
+	}
+
+	ctx.pending_requests.remove(&key);
+	let _ = crate::envoy::send_to_envoy_tx(
+		&ctx.shared,
+		crate::envoy::ToEnvoyMessage::HttpRequestComplete {
+			gateway_id: message_id.gateway_id,
+			request_id: message_id.request_id,
+		},
+	);
+}
+
+fn handle_req_abort(
+	ctx: &mut ActorContext,
+	message_id: protocol::MessageId,
+	reason: protocol::HttpStreamAbortReason,
+) {
+	if let Some(mut pending) = ctx
+		.pending_requests
+		.remove(&[&message_id.gateway_id, &message_id.request_id])
+	{
+		if let Some(body_abort_tx) = pending.body_abort_tx.take() {
+			body_abort_tx.send_replace(Some(HttpRequestBodyError { reason }));
+		}
+		if let Some(task_abort_handle) = pending.task_abort_handle.take() {
+			task_abort_handle.abort();
+		}
+	}
+	ctx.early_request_chunks
 		.remove(&[&message_id.gateway_id, &message_id.request_id]);
 }
 
@@ -727,6 +881,11 @@ async fn handle_ws_open(
 			PendingRequest {
 				envoy_message_index: 0,
 				body_tx: None,
+				body_abort_tx: None,
+				task_abort_handle: None,
+				body_rejected: false,
+				upload_complete: true,
+				response_complete: true,
 			},
 		);
 	}
@@ -1019,6 +1178,11 @@ async fn handle_hws_restore(
 				PendingRequest {
 					envoy_message_index: meta.envoy_message_index,
 					body_tx: None,
+					body_abort_tx: None,
+					task_abort_handle: None,
+					body_rejected: false,
+					upload_complete: true,
+					response_complete: true,
 				},
 			);
 
@@ -1333,31 +1497,135 @@ async fn send_response(
 	// If streaming, read chunks from the body_stream and forward them
 	if let Some(ref mut body_stream) = response.body_stream {
 		let mut message_index: u16 = 1;
+		let mut saw_finish = false;
 		while let Some(chunk) = body_stream.recv().await {
-			let finish = chunk.finish;
-			ws_send(
-				shared,
-				protocol::ToRivet::ToRivetTunnelMessage(protocol::ToRivetTunnelMessage {
-					message_id: protocol::MessageId {
+			let finish = match chunk {
+				ResponseChunk::Data { data, finish } => {
+					send_response_data_chunks(
+						shared,
+						gateway_id,
+						request_id,
+						&mut message_index,
+						data,
+						finish,
+					)
+					.await;
+					finish
+				}
+				ResponseChunk::Error(detail) => {
+					send_response_abort(
+						shared,
 						gateway_id,
 						request_id,
 						message_index,
-					},
-					message_kind: protocol::ToRivetTunnelMessageKind::ToRivetResponseChunk(
-						protocol::ToRivetResponseChunk {
-							body: chunk.data,
-							finish,
+						protocol::HttpStreamAbortReason {
+							kind: protocol::HttpStreamAbortReasonKind::HandlerError,
+							detail: Some(detail),
 						},
-					),
-				}),
-			)
-			.await;
-			message_index = message_index.wrapping_add(1);
+					)
+					.await;
+					message_index = message_index.wrapping_add(1);
+					true
+				}
+			};
 			if finish {
+				saw_finish = true;
 				break;
 			}
 		}
+		if !saw_finish {
+			send_response_abort(
+				shared,
+				gateway_id,
+				request_id,
+				message_index,
+				protocol::HttpStreamAbortReason {
+					kind: protocol::HttpStreamAbortReasonKind::HandlerError,
+					detail: Some("response body stream closed before finish".to_string()),
+				},
+			)
+			.await;
+		}
 	}
+}
+
+async fn send_response_data_chunks(
+	shared: &SharedContext,
+	gateway_id: protocol::GatewayId,
+	request_id: protocol::RequestId,
+	message_index: &mut u16,
+	data: Vec<u8>,
+	finish: bool,
+) {
+	if data.is_empty() {
+		send_response_data_chunk(shared, gateway_id, request_id, *message_index, data, finish)
+			.await;
+		*message_index = (*message_index).wrapping_add(1);
+		return;
+	}
+
+	let total_len = data.len();
+	for (idx, chunk) in data.chunks(HTTP_BODY_MAX_CHUNK_SIZE).enumerate() {
+		let end = (idx + 1) * HTTP_BODY_MAX_CHUNK_SIZE;
+		let chunk_finish = finish && end >= total_len;
+		send_response_data_chunk(
+			shared,
+			gateway_id,
+			request_id,
+			*message_index,
+			chunk.to_vec(),
+			chunk_finish,
+		)
+		.await;
+		*message_index = (*message_index).wrapping_add(1);
+	}
+}
+
+async fn send_response_data_chunk(
+	shared: &SharedContext,
+	gateway_id: protocol::GatewayId,
+	request_id: protocol::RequestId,
+	message_index: u16,
+	body: Vec<u8>,
+	finish: bool,
+) {
+	ws_send(
+		shared,
+		protocol::ToRivet::ToRivetTunnelMessage(protocol::ToRivetTunnelMessage {
+			message_id: protocol::MessageId {
+				gateway_id,
+				request_id,
+				message_index,
+			},
+			message_kind: protocol::ToRivetTunnelMessageKind::ToRivetResponseChunk(
+				protocol::ToRivetResponseChunk { body, finish },
+			),
+		}),
+	)
+	.await;
+}
+
+async fn send_response_abort(
+	shared: &SharedContext,
+	gateway_id: protocol::GatewayId,
+	request_id: protocol::RequestId,
+	message_index: u16,
+	reason: protocol::HttpStreamAbortReason,
+) {
+	ws_send(
+		shared,
+		protocol::ToRivet::ToRivetTunnelMessage(protocol::ToRivetTunnelMessage {
+			message_id: protocol::MessageId {
+				gateway_id,
+				request_id,
+				message_index,
+			},
+			message_kind: protocol::ToRivetTunnelMessageKind::ToRivetResponseAbort(
+				protocol::ToRivetResponseAbort { reason },
+			),
+		}),
+	)
+	.await;
 }
 
 async fn send_fetch_error_response(
@@ -1408,6 +1676,7 @@ mod tests {
 	use tokio::sync::Notify;
 	use tokio::sync::oneshot;
 	use tokio::task::yield_now;
+	use vbare::OwnedVersionedData;
 
 	use super::*;
 	use crate::config::{BoxFuture, EnvoyCallbacks, WebSocketHandler, WebSocketSender};
@@ -1467,6 +1736,10 @@ mod tests {
 		stop_handle_tx: Mutex<Option<oneshot::Sender<crate::config::ActorStopHandle>>>,
 	}
 
+	struct StreamingCallbacks {
+		body_tx: Mutex<Option<oneshot::Sender<mpsc::Sender<ResponseChunk>>>>,
+	}
+
 	impl EnvoyCallbacks for TestCallbacks {
 		fn on_actor_start(
 			&self,
@@ -1497,7 +1770,7 @@ mod tests {
 			_actor_id: String,
 			_gateway_id: protocol::GatewayId,
 			_request_id: protocol::RequestId,
-			_request: HttpRequest,
+			request: HttpRequest,
 		) -> BoxFuture<anyhow::Result<HttpResponse>> {
 			let fetch_started_tx = self
 				.fetch_started_tx
@@ -1513,6 +1786,7 @@ mod tests {
 			let complete_fetch = self.complete_fetch.load(Ordering::Acquire);
 
 			Box::pin(async move {
+				let _request = request;
 				if let Some(tx) = fetch_started_tx {
 					let _ = tx.send(());
 				}
@@ -1646,6 +1920,85 @@ mod tests {
 		}
 	}
 
+	impl EnvoyCallbacks for StreamingCallbacks {
+		fn on_actor_start(
+			&self,
+			_handle: EnvoyHandle,
+			_actor_id: String,
+			_generation: u32,
+			_config: protocol::ActorConfig,
+			_preloaded_kv: Option<protocol::PreloadedKv>,
+		) -> BoxFuture<anyhow::Result<()>> {
+			Box::pin(async { Ok(()) })
+		}
+
+		fn on_actor_stop(
+			&self,
+			_handle: EnvoyHandle,
+			_actor_id: String,
+			_generation: u32,
+			_reason: protocol::StopActorReason,
+		) -> BoxFuture<anyhow::Result<()>> {
+			Box::pin(async { Ok(()) })
+		}
+
+		fn on_shutdown(&self) {}
+
+		fn fetch(
+			&self,
+			_handle: EnvoyHandle,
+			_actor_id: String,
+			_gateway_id: protocol::GatewayId,
+			_request_id: protocol::RequestId,
+			_request: HttpRequest,
+		) -> BoxFuture<anyhow::Result<HttpResponse>> {
+			let body_tx = self
+				.body_tx
+				.lock()
+				.expect("streaming body mutex poisoned")
+				.take();
+
+			Box::pin(async move {
+				let (tx, rx) = mpsc::channel(HTTP_BODY_STREAM_CHANNEL_CAPACITY);
+				if let Some(body_tx) = body_tx {
+					let _ = body_tx.send(tx);
+				}
+				Ok(HttpResponse {
+					status: 200,
+					headers: HashMap::new(),
+					body: None,
+					body_stream: Some(rx.into()),
+				})
+			})
+		}
+
+		fn websocket(
+			&self,
+			_handle: EnvoyHandle,
+			_actor_id: String,
+			_gateway_id: protocol::GatewayId,
+			_request_id: protocol::RequestId,
+			_request: HttpRequest,
+			_path: String,
+			_headers: HashMap<String, String>,
+			_is_hibernatable: bool,
+			_is_restoring_hibernatable: bool,
+			_sender: WebSocketSender,
+		) -> BoxFuture<anyhow::Result<WebSocketHandler>> {
+			Box::pin(async { anyhow::bail!("websocket should not be called in streaming test") })
+		}
+
+		fn can_hibernate(
+			&self,
+			_actor_id: &str,
+			_gateway_id: &protocol::GatewayId,
+			_request_id: &protocol::RequestId,
+			_request: &HttpRequest,
+		) -> BoxFuture<anyhow::Result<bool>> {
+			Box::pin(async { Ok(false) })
+		}
+	}
+
 	fn build_shared_context(
 		callbacks: Arc<dyn EnvoyCallbacks>,
 	) -> (Arc<SharedContext>, mpsc::UnboundedReceiver<ToEnvoyMessage>) {
@@ -1718,6 +2071,31 @@ mod tests {
 				.await,
 			"timed out waiting for active HTTP request count to reach zero"
 		);
+	}
+
+	async fn recv_ws_tunnel_msg(
+		ws_rx: &mut mpsc::UnboundedReceiver<WsTxMessage>,
+	) -> protocol::ToRivetTunnelMessage {
+		tokio::time::timeout(Duration::from_secs(2), async {
+			loop {
+				let Some(msg) = ws_rx.recv().await else {
+					panic!("websocket channel closed before tunnel message");
+				};
+				let WsTxMessage::Send(bytes) = msg else {
+					continue;
+				};
+				let message = protocol::versioned::ToRivet::deserialize(
+					&bytes,
+					protocol::PROTOCOL_VERSION,
+				)
+				.expect("failed to decode ToRivet message");
+				if let protocol::ToRivet::ToRivetTunnelMessage(msg) = message {
+					return msg;
+				}
+			}
+		})
+		.await
+		.expect("timed out waiting for tunnel message")
 	}
 
 	async fn wait_for_stopped_event(envoy_rx: &mut mpsc::UnboundedReceiver<ToEnvoyMessage>) {
@@ -1856,6 +2234,220 @@ mod tests {
 			})
 			.expect("failed to send stop");
 		wait_for_stopped_event(&mut envoy_rx).await;
+	}
+
+	#[tokio::test]
+	async fn streamed_request_backpressure_does_not_block_actor_control_loop() {
+		let (fetch_started_tx, fetch_started_rx) = oneshot::channel();
+		let (fetch_dropped_tx, fetch_dropped_rx) = oneshot::channel();
+		let callbacks = Arc::new(TestCallbacks::hanging(
+			fetch_started_tx,
+			fetch_dropped_tx,
+		));
+		let (shared, mut envoy_rx) = build_shared_context(callbacks);
+		let (ws_tx, mut ws_rx) = mpsc::unbounded_channel();
+		*shared.ws_tx.lock().await = Some(ws_tx);
+		let (actor_tx, _) = create_actor(
+			shared,
+			"actor-streamed-request".to_string(),
+			1,
+			actor_config(),
+			Vec::new(),
+			None,
+		);
+		let mut request = request_start();
+		request.method = "POST".to_owned();
+		request.stream = true;
+
+		actor_tx
+			.send(ToActor::ReqStart {
+				message_id: message_id(),
+				req: request,
+			})
+			.expect("failed to send request start");
+		fetch_started_rx
+			.await
+			.expect("fetch start sender dropped before request began");
+
+		for index in 0..=HTTP_BODY_STREAM_CHANNEL_CAPACITY {
+			let mut chunk_message_id = message_id();
+			chunk_message_id.message_index = index as u16 + 1;
+			actor_tx
+				.send(ToActor::ReqChunk {
+					message_id: chunk_message_id,
+					chunk: protocol::ToEnvoyRequestChunk {
+						body: vec![index as u8],
+						finish: false,
+					},
+				})
+				.expect("failed to send streamed request chunk");
+		}
+
+		tokio::time::timeout(Duration::from_secs(2), fetch_dropped_rx)
+			.await
+			.expect("overloaded request did not cancel its handler")
+			.expect("fetch drop sender dropped");
+		let abort = recv_ws_tunnel_msg(&mut ws_rx).await;
+		assert!(matches!(
+			abort.message_kind,
+			protocol::ToRivetTunnelMessageKind::ToRivetResponseAbort(
+				protocol::ToRivetResponseAbort {
+					reason: protocol::HttpStreamAbortReason {
+						kind: protocol::HttpStreamAbortReasonKind::Overloaded,
+						..
+					}
+				}
+			)
+		));
+
+		actor_tx
+			.send(ToActor::Stop {
+				command_idx: 1,
+				reason: protocol::StopActorReason::StopIntent,
+			})
+			.expect("failed to send stop after request overload");
+		wait_for_stopped_event(&mut envoy_rx).await;
+	}
+
+	#[tokio::test]
+	async fn streamed_request_remains_cancellable_after_upload_finishes() {
+		let (fetch_started_tx, fetch_started_rx) = oneshot::channel();
+		let (fetch_dropped_tx, fetch_dropped_rx) = oneshot::channel();
+		let callbacks = Arc::new(TestCallbacks::hanging(
+			fetch_started_tx,
+			fetch_dropped_tx,
+		));
+		let (shared, _envoy_rx) = build_shared_context(callbacks);
+		let (actor_tx, _) = create_actor(
+			shared,
+			"actor-finished-upload".to_string(),
+			1,
+			actor_config(),
+			Vec::new(),
+			None,
+		);
+		let mut request = request_start();
+		request.method = "POST".to_owned();
+		request.stream = true;
+
+		actor_tx
+			.send(ToActor::ReqStart {
+				message_id: message_id(),
+				req: request,
+			})
+			.expect("failed to send request start");
+		fetch_started_rx
+			.await
+			.expect("fetch start sender dropped before request began");
+		actor_tx
+			.send(ToActor::ReqChunk {
+				message_id: message_id(),
+				chunk: protocol::ToEnvoyRequestChunk {
+					body: Vec::new(),
+					finish: true,
+				},
+			})
+			.expect("failed to finish upload");
+		actor_tx
+			.send(ToActor::ReqAbort {
+				message_id: message_id(),
+				reason: protocol::HttpStreamAbortReason {
+					kind: protocol::HttpStreamAbortReasonKind::ClientDisconnect,
+					detail: None,
+				},
+			})
+			.expect("failed to abort completed upload");
+
+		tokio::time::timeout(Duration::from_secs(2), fetch_dropped_rx)
+			.await
+			.expect("request handler was not cancelled after upload completion")
+			.expect("fetch drop sender dropped");
+	}
+
+	#[tokio::test]
+	async fn active_http_request_count_spans_streaming_response_drain() {
+		let (body_tx_tx, body_tx_rx) = oneshot::channel();
+		let callbacks = Arc::new(StreamingCallbacks {
+			body_tx: Mutex::new(Some(body_tx_tx)),
+		});
+		let (shared, _envoy_rx) = build_shared_context(callbacks);
+		let (ws_tx, mut ws_rx) = mpsc::unbounded_channel();
+		*shared.ws_tx.lock().await = Some(ws_tx);
+		let (actor_tx, active_http_request_count) = create_actor(
+			shared,
+			"actor-stream".to_string(),
+			1,
+			actor_config(),
+			Vec::new(),
+			None,
+		);
+
+		actor_tx
+			.send(ToActor::ReqStart {
+				message_id: message_id(),
+				req: request_start(),
+			})
+			.expect("failed to send request start");
+
+		let body_tx = tokio::time::timeout(Duration::from_secs(2), body_tx_rx)
+			.await
+			.expect("timed out waiting for response body sender")
+			.expect("response body sender dropped");
+		let start_msg = recv_ws_tunnel_msg(&mut ws_rx).await;
+		assert!(matches!(
+			start_msg.message_kind,
+			protocol::ToRivetTunnelMessageKind::ToRivetResponseStart(
+				protocol::ToRivetResponseStart { stream: true, .. }
+			)
+		));
+		assert_eq!(active_http_request_count.load(), 1);
+
+		body_tx
+			.send(ResponseChunk::Data {
+				data: vec![7; HTTP_BODY_MAX_CHUNK_SIZE + 3],
+				finish: false,
+			})
+			.await
+			.expect("failed to send response data");
+
+		let first = recv_ws_tunnel_msg(&mut ws_rx).await;
+		let second = recv_ws_tunnel_msg(&mut ws_rx).await;
+		match first.message_kind {
+			protocol::ToRivetTunnelMessageKind::ToRivetResponseChunk(chunk) => {
+				assert_eq!(first.message_id.message_index, 1);
+				assert_eq!(chunk.body.len(), HTTP_BODY_MAX_CHUNK_SIZE);
+				assert!(!chunk.finish);
+			}
+			other => panic!("expected first response chunk, got {other:?}"),
+		}
+		match second.message_kind {
+			protocol::ToRivetTunnelMessageKind::ToRivetResponseChunk(chunk) => {
+				assert_eq!(second.message_id.message_index, 2);
+				assert_eq!(chunk.body.len(), 3);
+				assert!(!chunk.finish);
+			}
+			other => panic!("expected second response chunk, got {other:?}"),
+		}
+		assert_eq!(active_http_request_count.load(), 1);
+
+		body_tx
+			.send(ResponseChunk::Data {
+				data: Vec::new(),
+				finish: true,
+			})
+			.await
+			.expect("failed to finish response stream");
+		let finish = recv_ws_tunnel_msg(&mut ws_rx).await;
+		match finish.message_kind {
+			protocol::ToRivetTunnelMessageKind::ToRivetResponseChunk(chunk) => {
+				assert_eq!(finish.message_id.message_index, 3);
+				assert!(chunk.body.is_empty());
+				assert!(chunk.finish);
+			}
+			other => panic!("expected finish response chunk, got {other:?}"),
+		}
+
+		wait_for_zero(&active_http_request_count).await;
 	}
 
 	#[tokio::test]

--- a/engine/sdks/rust/envoy-client/src/config.rs
+++ b/engine/sdks/rust/envoy-client/src/config.rs
@@ -5,15 +5,68 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use rivet_envoy_protocol as protocol;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, watch};
 
 use crate::handle::EnvoyHandle;
+
+pub const HTTP_BODY_STREAM_CHANNEL_CAPACITY: usize = 16;
+pub const HTTP_BODY_MAX_CHUNK_SIZE: usize = 64 * 1024;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send>>;
 
 #[cfg(target_arch = "wasm32")]
 pub type BoxFuture<T> = Pin<Box<dyn Future<Output = T>>>;
+
+#[derive(Clone, Debug)]
+pub struct HttpRequestBodyError {
+	pub reason: protocol::HttpStreamAbortReason,
+}
+
+impl std::fmt::Display for HttpRequestBodyError {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match &self.reason.detail {
+			Some(detail) => write!(f, "{:?}: {detail}", self.reason.kind),
+			None => write!(f, "{:?}", self.reason.kind),
+		}
+	}
+}
+
+impl std::error::Error for HttpRequestBodyError {}
+
+#[derive(Debug)]
+pub struct HttpRequestBodyStream {
+	rx: mpsc::Receiver<Vec<u8>>,
+	abort_rx: watch::Receiver<Option<HttpRequestBodyError>>,
+}
+
+impl HttpRequestBodyStream {
+	pub fn new(
+		rx: mpsc::Receiver<Vec<u8>>,
+		abort_rx: watch::Receiver<Option<HttpRequestBodyError>>,
+	) -> Self {
+		Self { rx, abort_rx }
+	}
+
+	pub async fn recv(&mut self) -> Result<Option<Vec<u8>>, HttpRequestBodyError> {
+		loop {
+			if let Some(error) = self.abort_rx.borrow().clone() {
+				return Err(error);
+			}
+
+			tokio::select! {
+				biased;
+				changed = self.abort_rx.changed() => {
+					if changed.is_ok() {
+						continue;
+					}
+					return Ok(self.rx.recv().await);
+				}
+				chunk = self.rx.recv() => return Ok(chunk),
+			}
+		}
+	}
+}
 
 /// HTTP request/response types used by the envoy client.
 pub struct HttpRequest {
@@ -22,7 +75,7 @@ pub struct HttpRequest {
 	pub headers: HashMap<String, String>,
 	pub body: Option<Vec<u8>>,
 	/// If the request is streamed, body chunks arrive on this channel.
-	pub body_stream: Option<mpsc::UnboundedReceiver<Vec<u8>>>,
+	pub body_stream: Option<HttpRequestBodyStream>,
 }
 
 pub struct HttpResponse {
@@ -31,13 +84,42 @@ pub struct HttpResponse {
 	pub body: Option<Vec<u8>>,
 	/// If set, the response is streamed. The envoy client reads chunks and sends
 	/// `ToRivetResponseChunk` for each one.
-	pub body_stream: Option<mpsc::UnboundedReceiver<ResponseChunk>>,
+	pub body_stream: Option<HttpResponseBodyStream>,
 }
 
 /// A chunk in a streaming HTTP response.
-pub struct ResponseChunk {
-	pub data: Vec<u8>,
-	pub finish: bool,
+pub enum ResponseChunk {
+	Data { data: Vec<u8>, finish: bool },
+	Error(String),
+}
+
+pub struct HttpResponseBodyStream {
+	rx: mpsc::Receiver<ResponseChunk>,
+	on_drop: Option<Box<dyn FnOnce() + Send>>,
+}
+
+impl HttpResponseBodyStream {
+	pub fn set_on_drop(&mut self, on_drop: impl FnOnce() + Send + 'static) {
+		self.on_drop = Some(Box::new(on_drop));
+	}
+
+	pub async fn recv(&mut self) -> Option<ResponseChunk> {
+		self.rx.recv().await
+	}
+}
+
+impl From<mpsc::Receiver<ResponseChunk>> for HttpResponseBodyStream {
+	fn from(rx: mpsc::Receiver<ResponseChunk>) -> Self {
+		Self { rx, on_drop: None }
+	}
+}
+
+impl Drop for HttpResponseBodyStream {
+	fn drop(&mut self) {
+		if let Some(on_drop) = self.on_drop.take() {
+			on_drop();
+		}
+	}
 }
 
 pub struct EnvoyConfig {

--- a/engine/sdks/rust/envoy-client/src/connection/native.rs
+++ b/engine/sdks/rust/envoy-client/src/connection/native.rs
@@ -117,6 +117,8 @@ async fn single_connection(
 			.await?;
 	let (mut write, mut read) = ws_stream.split();
 
+	// TODO: Bound shared WebSocket writer memory across protocol message types.
+	// https://github.com/rivet-dev/rivet/issues/5468
 	let (ws_tx, mut ws_rx) = mpsc::unbounded_channel::<WsTxMessage>();
 	super::install_connection(shared, ws_tx).await;
 

--- a/engine/sdks/rust/envoy-client/src/connection/wasm.rs
+++ b/engine/sdks/rust/envoy-client/src/connection/wasm.rs
@@ -156,6 +156,8 @@ mod imp {
 			}
 		}
 
+		// TODO: Bound shared WebSocket writer memory across protocol message types.
+		// https://github.com/rivet-dev/rivet/issues/5468
 		let (ws_tx, mut ws_rx) = mpsc::unbounded_channel::<WsTxMessage>();
 		super::super::install_connection(shared, ws_tx).await;
 

--- a/engine/sdks/rust/envoy-client/src/envoy.rs
+++ b/engine/sdks/rust/envoy-client/src/envoy.rs
@@ -58,6 +58,7 @@ pub struct EnvoyContext {
 	pub remote_sqlite_requests: HashMap<u32, RemoteSqliteRequestEntry>,
 	pub next_remote_sqlite_request_id: u32,
 	pub request_to_actor: BufferMap<String>,
+	pub pending_request_chunks: BufferMap<Vec<protocol::ToEnvoyRequestChunk>>,
 	pub buffered_messages: Vec<protocol::ToRivetTunnelMessage>,
 	/// Highest command index processed per `(actor_id, generation)`, used to
 	/// drop replayed commands from `pegboard-envoy` after a reconnect. Persists
@@ -129,6 +130,10 @@ pub enum ToEnvoyMessage {
 		gateway_id: protocol::GatewayId,
 		request_id: protocol::RequestId,
 		envoy_message_index: u16,
+	},
+	HttpRequestComplete {
+		gateway_id: protocol::GatewayId,
+		request_id: protocol::RequestId,
 	},
 	GetActor {
 		actor_id: String,
@@ -337,6 +342,7 @@ fn start_envoy_sync_inner(config: EnvoyConfig) -> EnvoyHandle {
 		remote_sqlite_requests: HashMap::new(),
 		next_remote_sqlite_request_id: 0,
 		request_to_actor: BufferMap::new(),
+		pending_request_chunks: BufferMap::new(),
 		buffered_messages: Vec::new(),
 		processed_command_idx: HashMap::new(),
 	};
@@ -416,6 +422,10 @@ async fn envoy_loop(
 					}
 					ToEnvoyMessage::HwsAck { gateway_id, request_id, envoy_message_index } => {
 						send_hibernatable_ws_message_ack(&mut ctx, gateway_id, request_id, envoy_message_index);
+					}
+					ToEnvoyMessage::HttpRequestComplete { gateway_id, request_id } => {
+						ctx.request_to_actor.remove(&[&gateway_id, &request_id]);
+						ctx.pending_request_chunks.remove(&[&gateway_id, &request_id]);
 					}
 					ToEnvoyMessage::GetActor { actor_id, generation, response_tx } => {
 						let info = ctx.get_actor(&actor_id, generation).map(|entry| {

--- a/engine/sdks/rust/envoy-client/src/events.rs
+++ b/engine/sdks/rust/envoy-client/src/events.rs
@@ -195,6 +195,7 @@ mod tests {
 				remote_sqlite_requests: HashMap::new(),
 				next_remote_sqlite_request_id: 0,
 				request_to_actor: crate::utils::BufferMap::new(),
+				pending_request_chunks: crate::utils::BufferMap::new(),
 				buffered_messages: Vec::new(),
 				processed_command_idx: HashMap::new(),
 			},

--- a/engine/sdks/rust/envoy-client/src/sqlite.rs
+++ b/engine/sdks/rust/envoy-client/src/sqlite.rs
@@ -606,6 +606,7 @@ mod tests {
 			remote_sqlite_requests: HashMap::new(),
 			next_remote_sqlite_request_id: 0,
 			request_to_actor: BufferMap::new(),
+			pending_request_chunks: BufferMap::new(),
 			buffered_messages: Vec::new(),
 			processed_command_idx: HashMap::new(),
 		}

--- a/engine/sdks/rust/envoy-client/src/stringify.rs
+++ b/engine/sdks/rust/envoy-client/src/stringify.rs
@@ -46,7 +46,7 @@ pub fn stringify_to_rivet_tunnel_message_kind(kind: &protocol::ToRivetTunnelMess
 				val.finish
 			)
 		}
-		protocol::ToRivetTunnelMessageKind::ToRivetResponseAbort => {
+		protocol::ToRivetTunnelMessageKind::ToRivetResponseAbort(_) => {
 			"ToRivetResponseAbort".to_string()
 		}
 		protocol::ToRivetTunnelMessageKind::ToRivetWebSocketOpen(val) => {
@@ -106,7 +106,7 @@ pub fn stringify_to_envoy_tunnel_message_kind(kind: &protocol::ToEnvoyTunnelMess
 				val.finish
 			)
 		}
-		protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort => {
+		protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort(_) => {
 			"ToEnvoyRequestAbort".to_string()
 		}
 		protocol::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketOpen(val) => {

--- a/engine/sdks/rust/envoy-client/src/tunnel.rs
+++ b/engine/sdks/rust/envoy-client/src/tunnel.rs
@@ -29,8 +29,8 @@ pub async fn handle_tunnel_message(ctx: &mut EnvoyContext, msg: protocol::ToEnvo
 		protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestChunk(chunk) => {
 			handle_request_chunk(ctx, message_id, chunk);
 		}
-		protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort => {
-			handle_request_abort(ctx, message_id);
+		protocol::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort(abort) => {
+			handle_request_abort(ctx, message_id, abort.reason);
 		}
 		protocol::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketOpen(open) => {
 			handle_ws_open(ctx, message_id, open).await;
@@ -64,9 +64,23 @@ async fn handle_request_start(
 	);
 
 	let actor = ctx.get_actor(&actor_id, None).unwrap();
-	let _ = actor
-		.handle
-		.send(crate::actor::ToActor::ReqStart { message_id, req });
+	let actor_handle = actor.handle.clone();
+	let _ = actor_handle.send(crate::actor::ToActor::ReqStart {
+		message_id: message_id.clone(),
+		req,
+	});
+
+	if let Some(chunks) = ctx
+		.pending_request_chunks
+		.remove(&[&message_id.gateway_id, &message_id.request_id])
+	{
+		for chunk in chunks {
+			let _ = actor_handle.send(crate::actor::ToActor::ReqChunk {
+				message_id: message_id.clone(),
+				chunk,
+			});
+		}
+	}
 }
 
 fn handle_request_chunk(
@@ -79,24 +93,34 @@ fn handle_request_chunk(
 		.get(&[&message_id.gateway_id, &message_id.request_id])
 		.cloned();
 
-	let finish = chunk.finish;
-
 	if let Some(actor_id) = &actor_id {
 		if let Some(actor) = ctx.get_actor(actor_id, None) {
 			let _ = actor.handle.send(crate::actor::ToActor::ReqChunk {
 				message_id: message_id.clone(),
 				chunk,
 			});
+		} else {
+			tracing::warn!(actor_id = %actor_id, "received request chunk for unknown actor");
 		}
+	} else if let Some(chunks) = ctx
+		.pending_request_chunks
+		.get_mut(&[&message_id.gateway_id, &message_id.request_id])
+	{
+		chunks.push(chunk);
+	} else {
+		ctx.pending_request_chunks.insert(
+			&[&message_id.gateway_id, &message_id.request_id],
+			vec![chunk],
+		);
 	}
 
-	if finish {
-		ctx.request_to_actor
-			.remove(&[&message_id.gateway_id, &message_id.request_id]);
-	}
 }
 
-fn handle_request_abort(ctx: &mut EnvoyContext, message_id: protocol::MessageId) {
+fn handle_request_abort(
+	ctx: &mut EnvoyContext,
+	message_id: protocol::MessageId,
+	reason: protocol::HttpStreamAbortReason,
+) {
 	let actor_id = ctx
 		.request_to_actor
 		.get(&[&message_id.gateway_id, &message_id.request_id])
@@ -105,11 +129,14 @@ fn handle_request_abort(ctx: &mut EnvoyContext, message_id: protocol::MessageId)
 		if let Some(actor) = ctx.get_actor(actor_id, None) {
 			let _ = actor.handle.send(crate::actor::ToActor::ReqAbort {
 				message_id: message_id.clone(),
+				reason,
 			});
 		}
 	}
 
 	ctx.request_to_actor
+		.remove(&[&message_id.gateway_id, &message_id.request_id]);
+	ctx.pending_request_chunks
 		.remove(&[&message_id.gateway_id, &message_id.request_id]);
 }
 

--- a/engine/sdks/rust/envoy-protocol/schemas/v7.bare
+++ b/engine/sdks/rust/envoy-protocol/schemas/v7.bare
@@ -1,0 +1,696 @@
+# MARK: Core Primitives
+
+type Id str
+type Json str
+
+type GatewayId data[4]
+type RequestId data[4]
+type MessageIndex u16
+
+# MARK: KV
+
+# Basic types
+type KvKey data
+type KvValue data
+type KvMetadata struct {
+	version: data
+	updateTs: i64
+}
+
+# Query types
+type KvListAllQuery void
+type KvListRangeQuery struct {
+	start: KvKey
+	end: KvKey
+	exclusive: bool
+}
+
+type KvListPrefixQuery struct {
+	key: KvKey
+}
+
+type KvListQuery union {
+	KvListAllQuery |
+	KvListRangeQuery |
+	KvListPrefixQuery
+}
+
+# Request types
+type KvGetRequest struct {
+	keys: list<KvKey>
+}
+
+type KvListRequest struct {
+	query: KvListQuery
+	reverse: optional<bool>
+	limit: optional<u64>
+}
+
+type KvPutRequest struct {
+	keys: list<KvKey>
+	values: list<KvValue>
+}
+
+type KvDeleteRequest struct {
+	keys: list<KvKey>
+}
+
+type KvDeleteRangeRequest struct {
+	start: KvKey
+	end: KvKey
+}
+
+type KvDropRequest void
+
+# Response types
+type KvErrorResponse struct {
+	message: str
+}
+
+type KvGetResponse struct {
+	keys: list<KvKey>
+	values: list<KvValue>
+	metadata: list<KvMetadata>
+}
+
+type KvListResponse struct {
+	keys: list<KvKey>
+	values: list<KvValue>
+	metadata: list<KvMetadata>
+}
+
+type KvPutResponse void
+type KvDeleteResponse void
+type KvDropResponse void
+
+# Request/Response unions
+type KvRequestData union {
+	KvGetRequest |
+	KvListRequest |
+	KvPutRequest |
+	KvDeleteRequest |
+	KvDeleteRangeRequest |
+	KvDropRequest
+}
+
+type KvResponseData union {
+	KvErrorResponse |
+	KvGetResponse |
+	KvListResponse |
+	KvPutResponse |
+	KvDeleteResponse |
+	KvDropResponse
+}
+
+# MARK: SQLite
+
+type SqlitePgno u32
+type SqliteGeneration u64
+type SqlitePageBytes data
+
+type SqliteDirtyPage struct {
+	pgno: SqlitePgno
+	bytes: SqlitePageBytes
+}
+
+type SqliteFetchedPage struct {
+	pgno: SqlitePgno
+	bytes: optional<SqlitePageBytes>
+}
+
+type SqliteGetPagesRequest struct {
+	actorId: Id
+	pgnos: list<SqlitePgno>
+	expectedGeneration: optional<u64>
+	expectedHeadTxid: optional<u64>
+}
+
+type SqliteGetPagesOk struct {
+	pages: list<SqliteFetchedPage>
+	headTxid: optional<u64>
+}
+
+type SqliteErrorResponse struct {
+	group: str
+	code: str
+	message: str
+}
+
+type SqliteGetPagesResponse union {
+	SqliteGetPagesOk |
+	SqliteErrorResponse
+}
+
+type SqliteCommitRequest struct {
+	actorId: Id
+	dirtyPages: list<SqliteDirtyPage>
+	dbSizePages: u32
+	nowMs: i64
+	expectedGeneration: optional<u64>
+	expectedHeadTxid: optional<u64>
+}
+
+type SqliteCommitOk struct {
+	headTxid: optional<u64>
+}
+
+type SqliteCommitResponse union {
+	SqliteCommitOk |
+	SqliteErrorResponse
+}
+
+# MARK: SQLite Remote Execution
+
+type SqliteValueNull void
+
+type SqliteValueInteger struct {
+	value: i64
+}
+
+type SqliteValueFloat struct {
+	value: data[8]
+}
+
+type SqliteValueText struct {
+	value: str
+}
+
+type SqliteValueBlob struct {
+	value: data
+}
+
+type SqliteBindParam union {
+	SqliteValueNull |
+	SqliteValueInteger |
+	SqliteValueFloat |
+	SqliteValueText |
+	SqliteValueBlob
+}
+
+type SqliteColumnValue union {
+	SqliteValueNull |
+	SqliteValueInteger |
+	SqliteValueFloat |
+	SqliteValueText |
+	SqliteValueBlob
+}
+
+type SqliteQueryResult struct {
+	columns: list<str>
+	rows: list<list<SqliteColumnValue>>
+}
+
+type SqliteExecuteResult struct {
+	columns: list<str>
+	rows: list<list<SqliteColumnValue>>
+	changes: i64
+	lastInsertRowId: optional<i64>
+}
+
+type SqliteExecRequest struct {
+	namespaceId: Id
+	actorId: Id
+	generation: SqliteGeneration
+	sql: str
+}
+
+type SqliteExecuteRequest struct {
+	namespaceId: Id
+	actorId: Id
+	generation: SqliteGeneration
+	sql: str
+	params: optional<list<SqliteBindParam>>
+}
+
+type SqliteBatchStatement struct {
+	sql: str
+	params: optional<list<SqliteBindParam>>
+}
+
+type SqliteExecuteBatchRequest struct {
+	namespaceId: Id
+	actorId: Id
+	generation: SqliteGeneration
+	statements: list<SqliteBatchStatement>
+}
+
+type SqliteExecOk struct {
+	result: SqliteQueryResult
+}
+
+type SqliteExecuteOk struct {
+	result: SqliteExecuteResult
+}
+
+type SqliteExecuteBatchOk struct {
+	results: list<SqliteExecuteResult>
+}
+
+type SqliteExecResponse union {
+	SqliteExecOk |
+	SqliteErrorResponse
+}
+
+type SqliteExecuteResponse union {
+	SqliteExecuteOk |
+	SqliteErrorResponse
+}
+
+type SqliteExecuteBatchResponse union {
+	SqliteExecuteBatchOk |
+	SqliteErrorResponse
+}
+
+# MARK: Actor
+
+# Core
+type StopCode enum {
+	OK
+	ERROR
+}
+
+type ActorName struct {
+	metadata: Json
+}
+
+type ActorConfig struct {
+	name: str
+	key: optional<str>
+	createTs: i64
+	input: optional<data>
+}
+
+type ActorCheckpoint struct {
+	actorId: Id
+	generation: u32
+	index: i64
+}
+
+# Intent
+type ActorIntentSleep void
+
+type ActorIntentStop void
+
+type ActorIntent union {
+	ActorIntentSleep |
+	ActorIntentStop
+}
+
+# State
+type ActorStateRunning void
+
+type ActorStateStopped struct {
+	code: StopCode
+	message: optional<str>
+}
+
+type ActorState union {
+	ActorStateRunning |
+	ActorStateStopped
+}
+
+# MARK: Events
+type EventActorIntent struct {
+	intent: ActorIntent
+}
+
+type EventActorStateUpdate struct {
+	state: ActorState
+}
+
+type EventActorSetAlarm struct {
+	alarmTs: optional<i64>
+}
+
+type Event union {
+	EventActorIntent |
+	EventActorStateUpdate |
+	EventActorSetAlarm
+}
+
+type EventWrapper struct {
+	checkpoint: ActorCheckpoint
+	inner: Event
+}
+
+# MARK: Preloaded KV
+
+type PreloadedKvEntry struct {
+	key: KvKey
+	value: KvValue
+	metadata: KvMetadata
+}
+
+type PreloadedKv struct {
+	entries: list<PreloadedKvEntry>
+	requestedGetKeys: list<KvKey>
+	requestedPrefixes: list<KvKey>
+}
+
+# MARK: Commands
+
+type HibernatingRequest struct {
+	gatewayId: GatewayId
+	requestId: RequestId
+}
+
+type CommandStartActor struct {
+	config: ActorConfig
+	hibernatingRequests: list<HibernatingRequest>
+	preloadedKv: optional<PreloadedKv>
+}
+
+type StopActorReason enum {
+	SLEEP_INTENT
+	STOP_INTENT
+	DESTROY
+	GOING_AWAY
+	LOST
+}
+
+type CommandStopActor struct {
+	reason: StopActorReason
+}
+
+type Command union {
+	CommandStartActor |
+	CommandStopActor
+}
+
+type CommandWrapper struct {
+	checkpoint: ActorCheckpoint
+	inner: Command
+}
+
+# We redeclare this so its top level
+type ActorCommandKeyData union {
+	CommandStartActor |
+	CommandStopActor
+}
+
+# MARK: Tunnel
+
+# Message ID
+
+type MessageId struct {
+	# Globally unique ID
+	gatewayId: GatewayId
+	# Unique ID to the gateway
+	requestId: RequestId
+	# Unique ID to the request
+	messageIndex: MessageIndex
+}
+
+# HTTP
+type ToEnvoyRequestStart struct {
+	actorId: Id
+	method: str
+	path: str
+	headers: map<str><str>
+	body: optional<data>
+	stream: bool
+}
+
+type ToEnvoyRequestChunk struct {
+	body: data
+	finish: bool
+}
+
+type HttpStreamAbortReasonKind enum {
+	UNKNOWN
+	CLIENT_DISCONNECT
+	HANDLER_ERROR
+	IDLE_TIMEOUT
+	OVERLOADED
+	BODY_TOO_LARGE
+	OUT_OF_MEMORY
+	SHUTDOWN
+	INTERNAL_ERROR
+}
+
+type HttpStreamAbortReason struct {
+	kind: HttpStreamAbortReasonKind
+	detail: optional<str>
+}
+
+type ToEnvoyRequestAbort struct {
+	reason: HttpStreamAbortReason
+}
+
+type ToRivetResponseStart struct {
+	status: u16
+	headers: map<str><str>
+	body: optional<data>
+	stream: bool
+}
+
+type ToRivetResponseChunk struct {
+	body: data
+	finish: bool
+}
+
+type ToRivetResponseAbort struct {
+	reason: HttpStreamAbortReason
+}
+
+# WebSocket
+type ToEnvoyWebSocketOpen struct {
+	actorId: Id
+	path: str
+	headers: map<str><str>
+}
+
+type ToEnvoyWebSocketMessage struct {
+	data: data
+	binary: bool
+}
+
+type ToEnvoyWebSocketClose struct {
+	code: optional<u16>
+	reason: optional<str>
+}
+
+type ToRivetWebSocketOpen struct {
+	canHibernate: bool
+}
+
+type ToRivetWebSocketMessage struct {
+	data: data
+	binary: bool
+}
+
+type ToRivetWebSocketMessageAck struct {
+	index: MessageIndex
+}
+
+type ToRivetWebSocketClose struct {
+	code: optional<u16>
+	reason: optional<str>
+	hibernate: bool
+}
+
+# To Rivet
+type ToRivetTunnelMessageKind union {
+	# HTTP
+	ToRivetResponseStart |
+	ToRivetResponseChunk |
+	ToRivetResponseAbort |
+
+	# WebSocket
+	ToRivetWebSocketOpen |
+	ToRivetWebSocketMessage |
+	ToRivetWebSocketMessageAck |
+	ToRivetWebSocketClose
+}
+
+type ToRivetTunnelMessage struct {
+	messageId: MessageId
+	messageKind: ToRivetTunnelMessageKind
+}
+
+# To Envoy
+type ToEnvoyTunnelMessageKind union {
+	# HTTP
+	ToEnvoyRequestStart |
+	ToEnvoyRequestChunk |
+	ToEnvoyRequestAbort |
+
+	# WebSocket
+	ToEnvoyWebSocketOpen |
+	ToEnvoyWebSocketMessage |
+	ToEnvoyWebSocketClose
+}
+
+type ToEnvoyTunnelMessage struct {
+	messageId: MessageId
+	messageKind: ToEnvoyTunnelMessageKind
+}
+
+type ToEnvoyPing struct {
+	ts: i64
+}
+
+# MARK: To Rivet
+type ToRivetMetadata struct {
+	prepopulateActorNames: optional<map<str><ActorName>>
+	metadata: optional<Json>
+}
+
+type ToRivetEvents list<EventWrapper>
+
+type ToRivetAckCommands struct {
+	lastCommandCheckpoints: list<ActorCheckpoint>
+}
+
+type ToRivetStopping void
+
+type ToRivetPong struct {
+	ts: i64
+}
+
+type ToRivetKvRequest struct {
+	actorId: Id
+	requestId: u32
+	data: KvRequestData
+}
+
+type ToRivetSqliteGetPagesRequest struct {
+	requestId: u32
+	data: SqliteGetPagesRequest
+}
+
+type ToRivetSqliteCommitRequest struct {
+	requestId: u32
+	data: SqliteCommitRequest
+}
+
+type ToRivetSqliteExecRequest struct {
+	requestId: u32
+	data: SqliteExecRequest
+}
+
+type ToRivetSqliteExecuteRequest struct {
+	requestId: u32
+	data: SqliteExecuteRequest
+}
+
+type ToRivetSqliteExecuteBatchRequest struct {
+	requestId: u32
+	data: SqliteExecuteBatchRequest
+}
+
+type ToRivet union {
+	ToRivetMetadata |
+	ToRivetEvents |
+	ToRivetAckCommands |
+	ToRivetStopping |
+	ToRivetPong |
+	ToRivetKvRequest |
+	ToRivetTunnelMessage |
+	ToRivetSqliteGetPagesRequest |
+	ToRivetSqliteCommitRequest |
+	ToRivetSqliteExecRequest |
+	ToRivetSqliteExecuteRequest |
+	ToRivetSqliteExecuteBatchRequest
+}
+
+# MARK: To Envoy
+type ProtocolMetadata struct {
+	envoyLostThreshold: i64
+	actorStopThreshold: i64
+	maxResponsePayloadSize: u64
+}
+
+type ToEnvoyInit struct {
+	metadata: ProtocolMetadata
+}
+
+type ToEnvoyCommands list<CommandWrapper>
+
+type ToEnvoyAckEvents struct {
+	lastEventCheckpoints: list<ActorCheckpoint>
+}
+
+type ToEnvoyKvResponse struct {
+	requestId: u32
+	data: KvResponseData
+}
+
+type ToEnvoySqliteGetPagesResponse struct {
+	requestId: u32
+	data: SqliteGetPagesResponse
+}
+
+type ToEnvoySqliteCommitResponse struct {
+	requestId: u32
+	data: SqliteCommitResponse
+}
+
+type ToEnvoySqliteExecResponse struct {
+	requestId: u32
+	data: SqliteExecResponse
+}
+
+type ToEnvoySqliteExecuteResponse struct {
+	requestId: u32
+	data: SqliteExecuteResponse
+}
+
+type ToEnvoySqliteExecuteBatchResponse struct {
+	requestId: u32
+	data: SqliteExecuteBatchResponse
+}
+
+type ToEnvoy union {
+	ToEnvoyInit |
+	ToEnvoyCommands |
+	ToEnvoyAckEvents |
+	ToEnvoyKvResponse |
+	ToEnvoyTunnelMessage |
+	ToEnvoyPing |
+	ToEnvoySqliteGetPagesResponse |
+	ToEnvoySqliteCommitResponse |
+	ToEnvoySqliteExecResponse |
+	ToEnvoySqliteExecuteResponse |
+	ToEnvoySqliteExecuteBatchResponse
+}
+
+# MARK: To Envoy Conn
+type ToEnvoyConnPing struct {
+	gatewayId: GatewayId
+	requestId: RequestId
+	ts: i64
+}
+
+type ToEnvoyConnClose void
+
+type ToEnvoyConn union {
+	ToEnvoyConnPing |
+	ToEnvoyConnClose |
+	ToEnvoyCommands |
+	ToEnvoyAckEvents |
+	ToEnvoyTunnelMessage
+}
+
+# MARK: To Gateway
+type ToGatewayPong struct {
+	requestId: RequestId
+	ts: i64
+}
+
+type ToGateway union {
+	ToGatewayPong |
+	ToRivetTunnelMessage
+}
+
+# MARK: To Outbound
+type ToOutboundActorStart struct {
+	namespaceId: Id
+	poolName: str
+	checkpoint: ActorCheckpoint
+	actorConfig: ActorConfig
+}
+
+type ToOutbound union {
+	ToOutboundActorStart
+}

--- a/engine/sdks/rust/envoy-protocol/src/lib.rs
+++ b/engine/sdks/rust/envoy-protocol/src/lib.rs
@@ -3,6 +3,6 @@ pub mod util;
 pub mod versioned;
 
 // Re-export latest
-pub use generated::v6::*;
+pub use generated::v7::*;
 
 pub use generated::PROTOCOL_VERSION;

--- a/engine/sdks/rust/envoy-protocol/src/versioned/mod.rs
+++ b/engine/sdks/rust/envoy-protocol/src/versioned/mod.rs
@@ -3,7 +3,7 @@ use std::{error::Error, fmt};
 use anyhow::{Result, bail};
 use vbare::OwnedVersionedData;
 
-use crate::generated::{v1, v2, v3, v4, v5, v6};
+use crate::generated::{v1, v2, v3, v4, v5, v6, v7};
 
 mod v1_to_v2;
 mod v2_to_v1;
@@ -15,6 +15,8 @@ mod v4_to_v5;
 mod v5_to_v4;
 mod v5_to_v6;
 mod v6_to_v5;
+mod v6_to_v7;
+mod v7_to_v6;
 
 // MARK: Protocol compatibility errors
 
@@ -111,18 +113,19 @@ pub enum ToEnvoy {
 	V4(v4::ToEnvoy),
 	V5(v5::ToEnvoy),
 	V6(v6::ToEnvoy),
+	V7(v7::ToEnvoy),
 }
 
 impl OwnedVersionedData for ToEnvoy {
-	type Latest = v6::ToEnvoy;
+	type Latest = v7::ToEnvoy;
 
 	fn wrap_latest(latest: Self::Latest) -> Self {
-		Self::V6(latest)
+		Self::V7(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
 		match self {
-			Self::V6(x) => Ok(x),
+			Self::V7(x) => Ok(x),
 			_ => bail!("version not latest"),
 		}
 	}
@@ -135,6 +138,7 @@ impl OwnedVersionedData for ToEnvoy {
 			4 => Ok(Self::V4(serde_bare::from_slice(payload)?)),
 			5 => Ok(Self::V5(serde_bare::from_slice(payload)?)),
 			6 => Ok(Self::V6(serde_bare::from_slice(payload)?)),
+			7 => Ok(Self::V7(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -147,6 +151,7 @@ impl OwnedVersionedData for ToEnvoy {
 			Self::V4(x) => serde_bare::to_vec(&x).map_err(Into::into),
 			Self::V5(x) => serde_bare::to_vec(&x).map_err(Into::into),
 			Self::V6(x) => serde_bare::to_vec(&x).map_err(Into::into),
+			Self::V7(x) => serde_bare::to_vec(&x).map_err(Into::into),
 		}
 	}
 
@@ -157,11 +162,13 @@ impl OwnedVersionedData for ToEnvoy {
 			Self::v3_to_v4,
 			Self::v4_to_v5,
 			Self::v5_to_v6,
+			Self::v6_to_v7,
 		]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
 		vec![
+			Self::v7_to_v6,
 			Self::v6_to_v5,
 			Self::v5_to_v4,
 			Self::v4_to_v3,
@@ -232,6 +239,18 @@ impl ToEnvoy {
 			_ => bail!("unexpected version"),
 		}
 	}
+	fn v6_to_v7(self) -> Result<Self> {
+		match self {
+			Self::V6(x) => Ok(Self::V7(v6_to_v7::convert_to_envoy_v6_to_v7(x)?)),
+			_ => bail!("unexpected version"),
+		}
+	}
+	fn v7_to_v6(self) -> Result<Self> {
+		match self {
+			Self::V7(x) => Ok(Self::V6(v7_to_v6::convert_to_envoy_v7_to_v6(x)?)),
+			_ => bail!("unexpected version"),
+		}
+	}
 }
 
 // MARK: ToRivet
@@ -243,18 +262,19 @@ pub enum ToRivet {
 	V4(v4::ToRivet),
 	V5(v5::ToRivet),
 	V6(v6::ToRivet),
+	V7(v7::ToRivet),
 }
 
 impl OwnedVersionedData for ToRivet {
-	type Latest = v6::ToRivet;
+	type Latest = v7::ToRivet;
 
 	fn wrap_latest(latest: Self::Latest) -> Self {
-		Self::V6(latest)
+		Self::V7(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
 		match self {
-			Self::V6(x) => Ok(x),
+			Self::V7(x) => Ok(x),
 			_ => bail!("version not latest"),
 		}
 	}
@@ -267,6 +287,7 @@ impl OwnedVersionedData for ToRivet {
 			4 => Ok(Self::V4(serde_bare::from_slice(payload)?)),
 			5 => Ok(Self::V5(serde_bare::from_slice(payload)?)),
 			6 => Ok(Self::V6(serde_bare::from_slice(payload)?)),
+			7 => Ok(Self::V7(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -279,6 +300,7 @@ impl OwnedVersionedData for ToRivet {
 			Self::V4(x) => serde_bare::to_vec(&x).map_err(Into::into),
 			Self::V5(x) => serde_bare::to_vec(&x).map_err(Into::into),
 			Self::V6(x) => serde_bare::to_vec(&x).map_err(Into::into),
+			Self::V7(x) => serde_bare::to_vec(&x).map_err(Into::into),
 		}
 	}
 
@@ -289,11 +311,13 @@ impl OwnedVersionedData for ToRivet {
 			Self::v3_to_v4,
 			Self::v4_to_v5,
 			Self::v5_to_v6,
+			Self::v6_to_v7,
 		]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
 		vec![
+			Self::v7_to_v6,
 			Self::v6_to_v5,
 			Self::v5_to_v4,
 			Self::v4_to_v3,
@@ -364,6 +388,18 @@ impl ToRivet {
 			_ => bail!("unexpected version"),
 		}
 	}
+	fn v6_to_v7(self) -> Result<Self> {
+		match self {
+			Self::V6(x) => Ok(Self::V7(v6_to_v7::convert_to_rivet_v6_to_v7(x)?)),
+			_ => bail!("unexpected version"),
+		}
+	}
+	fn v7_to_v6(self) -> Result<Self> {
+		match self {
+			Self::V7(x) => Ok(Self::V6(v7_to_v6::convert_to_rivet_v7_to_v6(x)?)),
+			_ => bail!("unexpected version"),
+		}
+	}
 }
 
 // MARK: ToEnvoyConn
@@ -375,18 +411,19 @@ pub enum ToEnvoyConn {
 	V4(v4::ToEnvoyConn),
 	V5(v5::ToEnvoyConn),
 	V6(v6::ToEnvoyConn),
+	V7(v7::ToEnvoyConn),
 }
 
 impl OwnedVersionedData for ToEnvoyConn {
-	type Latest = v6::ToEnvoyConn;
+	type Latest = v7::ToEnvoyConn;
 
 	fn wrap_latest(latest: Self::Latest) -> Self {
-		Self::V6(latest)
+		Self::V7(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
 		match self {
-			Self::V6(x) => Ok(x),
+			Self::V7(x) => Ok(x),
 			_ => bail!("version not latest"),
 		}
 	}
@@ -399,6 +436,7 @@ impl OwnedVersionedData for ToEnvoyConn {
 			4 => Ok(Self::V4(serde_bare::from_slice(payload)?)),
 			5 => Ok(Self::V5(serde_bare::from_slice(payload)?)),
 			6 => Ok(Self::V6(serde_bare::from_slice(payload)?)),
+			7 => Ok(Self::V7(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -411,6 +449,7 @@ impl OwnedVersionedData for ToEnvoyConn {
 			Self::V4(x) => serde_bare::to_vec(&x).map_err(Into::into),
 			Self::V5(x) => serde_bare::to_vec(&x).map_err(Into::into),
 			Self::V6(x) => serde_bare::to_vec(&x).map_err(Into::into),
+			Self::V7(x) => serde_bare::to_vec(&x).map_err(Into::into),
 		}
 	}
 
@@ -421,11 +460,13 @@ impl OwnedVersionedData for ToEnvoyConn {
 			Self::v3_to_v4,
 			Self::v4_to_v5,
 			Self::v5_to_v6,
+			Self::v6_to_v7,
 		]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
 		vec![
+			Self::v7_to_v6,
 			Self::v6_to_v5,
 			Self::v5_to_v4,
 			Self::v4_to_v3,
@@ -496,6 +537,22 @@ impl ToEnvoyConn {
 			_ => bail!("unexpected version"),
 		}
 	}
+	fn v6_to_v7(self) -> Result<Self> {
+		match self {
+			Self::V6(x) => Ok(Self::V7(
+				v6_to_v7::convert_to_envoy_conn_v6_to_v7(x)?,
+			)),
+			_ => bail!("unexpected version"),
+		}
+	}
+	fn v7_to_v6(self) -> Result<Self> {
+		match self {
+			Self::V7(x) => Ok(Self::V6(
+				v7_to_v6::convert_to_envoy_conn_v7_to_v6(x)?,
+			)),
+			_ => bail!("unexpected version"),
+		}
+	}
 }
 
 // MARK: ToGateway
@@ -507,18 +564,19 @@ pub enum ToGateway {
 	V4(v4::ToGateway),
 	V5(v5::ToGateway),
 	V6(v6::ToGateway),
+	V7(v7::ToGateway),
 }
 
 impl OwnedVersionedData for ToGateway {
-	type Latest = v6::ToGateway;
+	type Latest = v7::ToGateway;
 
 	fn wrap_latest(latest: Self::Latest) -> Self {
-		Self::V6(latest)
+		Self::V7(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
 		match self {
-			Self::V6(x) => Ok(x),
+			Self::V7(x) => Ok(x),
 			_ => bail!("version not latest"),
 		}
 	}
@@ -531,6 +589,7 @@ impl OwnedVersionedData for ToGateway {
 			4 => Ok(Self::V4(serde_bare::from_slice(payload)?)),
 			5 => Ok(Self::V5(serde_bare::from_slice(payload)?)),
 			6 => Ok(Self::V6(serde_bare::from_slice(payload)?)),
+			7 => Ok(Self::V7(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -543,6 +602,7 @@ impl OwnedVersionedData for ToGateway {
 			Self::V4(x) => serde_bare::to_vec(&x).map_err(Into::into),
 			Self::V5(x) => serde_bare::to_vec(&x).map_err(Into::into),
 			Self::V6(x) => serde_bare::to_vec(&x).map_err(Into::into),
+			Self::V7(x) => serde_bare::to_vec(&x).map_err(Into::into),
 		}
 	}
 
@@ -553,11 +613,13 @@ impl OwnedVersionedData for ToGateway {
 			Self::v3_to_v4,
 			Self::v4_to_v5,
 			Self::v5_to_v6,
+			Self::v6_to_v7,
 		]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
 		vec![
+			Self::v7_to_v6,
 			Self::v6_to_v5,
 			Self::v5_to_v4,
 			Self::v4_to_v3,
@@ -628,6 +690,18 @@ impl ToGateway {
 			_ => bail!("unexpected version"),
 		}
 	}
+	fn v6_to_v7(self) -> Result<Self> {
+		match self {
+			Self::V6(x) => Ok(Self::V7(v6_to_v7::convert_to_gateway_v6_to_v7(x)?)),
+			_ => bail!("unexpected version"),
+		}
+	}
+	fn v7_to_v6(self) -> Result<Self> {
+		match self {
+			Self::V7(x) => Ok(Self::V6(v7_to_v6::convert_to_gateway_v7_to_v6(x)?)),
+			_ => bail!("unexpected version"),
+		}
+	}
 }
 
 // MARK: ToOutbound
@@ -639,18 +713,19 @@ pub enum ToOutbound {
 	V4(v4::ToOutbound),
 	V5(v5::ToOutbound),
 	V6(v6::ToOutbound),
+	V7(v7::ToOutbound),
 }
 
 impl OwnedVersionedData for ToOutbound {
-	type Latest = v6::ToOutbound;
+	type Latest = v7::ToOutbound;
 
 	fn wrap_latest(latest: Self::Latest) -> Self {
-		Self::V6(latest)
+		Self::V7(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
 		match self {
-			Self::V6(x) => Ok(x),
+			Self::V7(x) => Ok(x),
 			_ => bail!("version not latest"),
 		}
 	}
@@ -663,6 +738,7 @@ impl OwnedVersionedData for ToOutbound {
 			4 => Ok(Self::V4(serde_bare::from_slice(payload)?)),
 			5 => Ok(Self::V5(serde_bare::from_slice(payload)?)),
 			6 => Ok(Self::V6(serde_bare::from_slice(payload)?)),
+			7 => Ok(Self::V7(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -675,6 +751,7 @@ impl OwnedVersionedData for ToOutbound {
 			Self::V4(x) => serde_bare::to_vec(&x).map_err(Into::into),
 			Self::V5(x) => serde_bare::to_vec(&x).map_err(Into::into),
 			Self::V6(x) => serde_bare::to_vec(&x).map_err(Into::into),
+			Self::V7(x) => serde_bare::to_vec(&x).map_err(Into::into),
 		}
 	}
 
@@ -685,11 +762,13 @@ impl OwnedVersionedData for ToOutbound {
 			Self::v3_to_v4,
 			Self::v4_to_v5,
 			Self::v5_to_v6,
+			Self::v6_to_v7,
 		]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
 		vec![
+			Self::v7_to_v6,
 			Self::v6_to_v5,
 			Self::v5_to_v4,
 			Self::v4_to_v3,
@@ -760,6 +839,18 @@ impl ToOutbound {
 			_ => bail!("unexpected version"),
 		}
 	}
+	fn v6_to_v7(self) -> Result<Self> {
+		match self {
+			Self::V6(x) => Ok(Self::V7(v6_to_v7::convert_to_outbound_v6_to_v7(x)?)),
+			_ => bail!("unexpected version"),
+		}
+	}
+	fn v7_to_v6(self) -> Result<Self> {
+		match self {
+			Self::V7(x) => Ok(Self::V6(v7_to_v6::convert_to_outbound_v7_to_v6(x)?)),
+			_ => bail!("unexpected version"),
+		}
+	}
 }
 
 // MARK: ActorCommandKeyData
@@ -771,18 +862,19 @@ pub enum ActorCommandKeyData {
 	V4(v4::ActorCommandKeyData),
 	V5(v5::ActorCommandKeyData),
 	V6(v6::ActorCommandKeyData),
+	V7(v7::ActorCommandKeyData),
 }
 
 impl OwnedVersionedData for ActorCommandKeyData {
-	type Latest = v6::ActorCommandKeyData;
+	type Latest = v7::ActorCommandKeyData;
 
 	fn wrap_latest(latest: Self::Latest) -> Self {
-		Self::V6(latest)
+		Self::V7(latest)
 	}
 
 	fn unwrap_latest(self) -> Result<Self::Latest> {
 		match self {
-			Self::V6(x) => Ok(x),
+			Self::V7(x) => Ok(x),
 			_ => bail!("version not latest"),
 		}
 	}
@@ -795,6 +887,7 @@ impl OwnedVersionedData for ActorCommandKeyData {
 			4 => Ok(Self::V4(serde_bare::from_slice(payload)?)),
 			5 => Ok(Self::V5(serde_bare::from_slice(payload)?)),
 			6 => Ok(Self::V6(serde_bare::from_slice(payload)?)),
+			7 => Ok(Self::V7(serde_bare::from_slice(payload)?)),
 			_ => bail!("invalid version: {version}"),
 		}
 	}
@@ -807,6 +900,7 @@ impl OwnedVersionedData for ActorCommandKeyData {
 			Self::V4(x) => serde_bare::to_vec(&x).map_err(Into::into),
 			Self::V5(x) => serde_bare::to_vec(&x).map_err(Into::into),
 			Self::V6(x) => serde_bare::to_vec(&x).map_err(Into::into),
+			Self::V7(x) => serde_bare::to_vec(&x).map_err(Into::into),
 		}
 	}
 
@@ -817,11 +911,13 @@ impl OwnedVersionedData for ActorCommandKeyData {
 			Self::v3_to_v4,
 			Self::v4_to_v5,
 			Self::v5_to_v6,
+			Self::v6_to_v7,
 		]
 	}
 
 	fn serialize_converters() -> Vec<impl Fn(Self) -> Result<Self>> {
 		vec![
+			Self::v7_to_v6,
 			Self::v6_to_v5,
 			Self::v5_to_v4,
 			Self::v4_to_v3,
@@ -912,6 +1008,22 @@ impl ActorCommandKeyData {
 			_ => bail!("unexpected version"),
 		}
 	}
+	fn v6_to_v7(self) -> Result<Self> {
+		match self {
+			Self::V6(x) => Ok(Self::V7(v6_to_v7::convert_actor_command_key_data_v6_to_v7(
+				x,
+			)?)),
+			_ => bail!("unexpected version"),
+		}
+	}
+	fn v7_to_v6(self) -> Result<Self> {
+		match self {
+			Self::V7(x) => Ok(Self::V6(v7_to_v6::convert_actor_command_key_data_v7_to_v6(
+				x,
+			)?)),
+			_ => bail!("unexpected version"),
+		}
+	}
 }
 
 // MARK: Tests
@@ -924,12 +1036,12 @@ mod tests {
 	use super::{ActorCommandKeyData, ToEnvoy};
 	use crate::{
 		PROTOCOL_VERSION,
-		generated::{v1, v2, v6},
+		generated::{v1, v2, v6, v7},
 	};
 
 	#[test]
 	fn protocol_version_constant_matches_schema_version() {
-		assert_eq!(PROTOCOL_VERSION, 6);
+		assert_eq!(PROTOCOL_VERSION, 7);
 	}
 
 	#[test]
@@ -954,10 +1066,10 @@ mod tests {
 			}]))?;
 
 		let decoded = ToEnvoy::deserialize(&payload, 1)?;
-		let v6::ToEnvoy::ToEnvoyCommands(commands) = decoded else {
+		let v7::ToEnvoy::ToEnvoyCommands(commands) = decoded else {
 			panic!("expected commands");
 		};
-		let v6::Command::CommandStartActor(start) = &commands[0].inner else {
+		let v7::Command::CommandStartActor(start) = &commands[0].inner else {
 			panic!("expected start actor");
 		};
 
@@ -984,9 +1096,9 @@ mod tests {
 
 	#[test]
 	fn actor_command_key_data_round_trips_to_v1() -> Result<()> {
-		let encoded = ActorCommandKeyData::wrap_latest(v6::ActorCommandKeyData::CommandStartActor(
-			v6::CommandStartActor {
-				config: v6::ActorConfig {
+		let encoded = ActorCommandKeyData::wrap_latest(v7::ActorCommandKeyData::CommandStartActor(
+			v7::CommandStartActor {
+				config: v7::ActorConfig {
 					name: "demo".into(),
 					key: None,
 					create_ts: 7,
@@ -999,11 +1111,69 @@ mod tests {
 		.serialize(1)?;
 
 		let decoded = ActorCommandKeyData::deserialize(&encoded, 1)?;
-		let v6::ActorCommandKeyData::CommandStartActor(start) = decoded else {
+		let v7::ActorCommandKeyData::CommandStartActor(start) = decoded else {
 			panic!("expected start actor");
 		};
 		assert_eq!(start.config.name, "demo");
 
+		Ok(())
+	}
+
+	#[test]
+	fn v6_request_abort_deserializes_with_unknown_reason() -> Result<()> {
+		let payload = serde_bare::to_vec(&v6::ToEnvoy::ToEnvoyTunnelMessage(
+			v6::ToEnvoyTunnelMessage {
+				message_id: v6::MessageId {
+					gateway_id: [1; 4],
+					request_id: [7; 4],
+					message_index: 1,
+				},
+				message_kind: v6::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort,
+			},
+		))?;
+
+		let decoded = ToEnvoy::deserialize(&payload, 6)?;
+		let v7::ToEnvoy::ToEnvoyTunnelMessage(msg) = decoded else {
+			panic!("expected tunnel message");
+		};
+		let v7::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort(abort) = msg.message_kind else {
+			panic!("expected request abort");
+		};
+
+		assert_eq!(abort.reason.kind, v7::HttpStreamAbortReasonKind::Unknown);
+		assert!(abort.reason.detail.is_none());
+		Ok(())
+	}
+
+	#[test]
+	fn v7_request_abort_serializes_to_v6_void_abort() -> Result<()> {
+		let encoded = ToEnvoy::wrap_latest(v7::ToEnvoy::ToEnvoyTunnelMessage(
+			v7::ToEnvoyTunnelMessage {
+				message_id: v7::MessageId {
+					gateway_id: [1; 4],
+					request_id: [7; 4],
+					message_index: 1,
+				},
+				message_kind: v7::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort(
+					v7::ToEnvoyRequestAbort {
+						reason: v7::HttpStreamAbortReason {
+							kind: v7::HttpStreamAbortReasonKind::ClientDisconnect,
+							detail: Some("client closed connection".into()),
+						},
+					},
+				),
+			},
+		))
+		.serialize(6)?;
+
+		let decoded: v6::ToEnvoy = serde_bare::from_slice(&encoded)?;
+		let v6::ToEnvoy::ToEnvoyTunnelMessage(msg) = decoded else {
+			panic!("expected tunnel message");
+		};
+		assert!(matches!(
+			msg.message_kind,
+			v6::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort
+		));
 		Ok(())
 	}
 }

--- a/engine/sdks/rust/envoy-protocol/src/versioned/v6_to_v7.rs
+++ b/engine/sdks/rust/envoy-protocol/src/versioned/v6_to_v7.rs
@@ -1,0 +1,829 @@
+// from: v6.bare, to: v7.bare
+
+#![allow(dead_code, unused_variables)]
+
+use anyhow::Result;
+
+use crate::generated::{v6, v7};
+
+pub fn convert_kv_metadata_v6_to_v7(x: v6::KvMetadata) -> Result<v7::KvMetadata> {
+	Ok(v7::KvMetadata {
+		version: x.version,
+		update_ts: x.update_ts,
+	})
+}
+
+pub fn convert_kv_list_range_query_v6_to_v7(x: v6::KvListRangeQuery) -> Result<v7::KvListRangeQuery> {
+	Ok(v7::KvListRangeQuery {
+		start: x.start,
+		end: x.end,
+		exclusive: x.exclusive,
+	})
+}
+
+pub fn convert_kv_list_prefix_query_v6_to_v7(x: v6::KvListPrefixQuery) -> Result<v7::KvListPrefixQuery> {
+	Ok(v7::KvListPrefixQuery {
+		key: x.key,
+	})
+}
+
+pub fn convert_kv_list_query_v6_to_v7(x: v6::KvListQuery) -> Result<v7::KvListQuery> {
+	Ok(match x {
+		v6::KvListQuery::KvListAllQuery => v7::KvListQuery::KvListAllQuery,
+		v6::KvListQuery::KvListRangeQuery(v) => v7::KvListQuery::KvListRangeQuery(convert_kv_list_range_query_v6_to_v7(v)?),
+		v6::KvListQuery::KvListPrefixQuery(v) => v7::KvListQuery::KvListPrefixQuery(convert_kv_list_prefix_query_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_kv_get_request_v6_to_v7(x: v6::KvGetRequest) -> Result<v7::KvGetRequest> {
+	Ok(v7::KvGetRequest {
+		keys: x.keys,
+	})
+}
+
+pub fn convert_kv_list_request_v6_to_v7(x: v6::KvListRequest) -> Result<v7::KvListRequest> {
+	Ok(v7::KvListRequest {
+		query: convert_kv_list_query_v6_to_v7(x.query)?,
+		reverse: x.reverse,
+		limit: x.limit,
+	})
+}
+
+pub fn convert_kv_put_request_v6_to_v7(x: v6::KvPutRequest) -> Result<v7::KvPutRequest> {
+	Ok(v7::KvPutRequest {
+		keys: x.keys,
+		values: x.values,
+	})
+}
+
+pub fn convert_kv_delete_request_v6_to_v7(x: v6::KvDeleteRequest) -> Result<v7::KvDeleteRequest> {
+	Ok(v7::KvDeleteRequest {
+		keys: x.keys,
+	})
+}
+
+pub fn convert_kv_delete_range_request_v6_to_v7(x: v6::KvDeleteRangeRequest) -> Result<v7::KvDeleteRangeRequest> {
+	Ok(v7::KvDeleteRangeRequest {
+		start: x.start,
+		end: x.end,
+	})
+}
+
+pub fn convert_kv_error_response_v6_to_v7(x: v6::KvErrorResponse) -> Result<v7::KvErrorResponse> {
+	Ok(v7::KvErrorResponse {
+		message: x.message,
+	})
+}
+
+pub fn convert_kv_get_response_v6_to_v7(x: v6::KvGetResponse) -> Result<v7::KvGetResponse> {
+	Ok(v7::KvGetResponse {
+		keys: x.keys,
+		values: x.values,
+		metadata: x.metadata.into_iter().map(|v| convert_kv_metadata_v6_to_v7(v)).collect::<Result<Vec<_>>>()?,
+	})
+}
+
+pub fn convert_kv_list_response_v6_to_v7(x: v6::KvListResponse) -> Result<v7::KvListResponse> {
+	Ok(v7::KvListResponse {
+		keys: x.keys,
+		values: x.values,
+		metadata: x.metadata.into_iter().map(|v| convert_kv_metadata_v6_to_v7(v)).collect::<Result<Vec<_>>>()?,
+	})
+}
+
+pub fn convert_kv_request_data_v6_to_v7(x: v6::KvRequestData) -> Result<v7::KvRequestData> {
+	Ok(match x {
+		v6::KvRequestData::KvGetRequest(v) => v7::KvRequestData::KvGetRequest(convert_kv_get_request_v6_to_v7(v)?),
+		v6::KvRequestData::KvListRequest(v) => v7::KvRequestData::KvListRequest(convert_kv_list_request_v6_to_v7(v)?),
+		v6::KvRequestData::KvPutRequest(v) => v7::KvRequestData::KvPutRequest(convert_kv_put_request_v6_to_v7(v)?),
+		v6::KvRequestData::KvDeleteRequest(v) => v7::KvRequestData::KvDeleteRequest(convert_kv_delete_request_v6_to_v7(v)?),
+		v6::KvRequestData::KvDeleteRangeRequest(v) => v7::KvRequestData::KvDeleteRangeRequest(convert_kv_delete_range_request_v6_to_v7(v)?),
+		v6::KvRequestData::KvDropRequest => v7::KvRequestData::KvDropRequest,
+	})
+}
+
+pub fn convert_kv_response_data_v6_to_v7(x: v6::KvResponseData) -> Result<v7::KvResponseData> {
+	Ok(match x {
+		v6::KvResponseData::KvErrorResponse(v) => v7::KvResponseData::KvErrorResponse(convert_kv_error_response_v6_to_v7(v)?),
+		v6::KvResponseData::KvGetResponse(v) => v7::KvResponseData::KvGetResponse(convert_kv_get_response_v6_to_v7(v)?),
+		v6::KvResponseData::KvListResponse(v) => v7::KvResponseData::KvListResponse(convert_kv_list_response_v6_to_v7(v)?),
+		v6::KvResponseData::KvPutResponse => v7::KvResponseData::KvPutResponse,
+		v6::KvResponseData::KvDeleteResponse => v7::KvResponseData::KvDeleteResponse,
+		v6::KvResponseData::KvDropResponse => v7::KvResponseData::KvDropResponse,
+	})
+}
+
+pub fn convert_sqlite_dirty_page_v6_to_v7(x: v6::SqliteDirtyPage) -> Result<v7::SqliteDirtyPage> {
+	Ok(v7::SqliteDirtyPage {
+		pgno: x.pgno,
+		bytes: x.bytes,
+	})
+}
+
+pub fn convert_sqlite_fetched_page_v6_to_v7(x: v6::SqliteFetchedPage) -> Result<v7::SqliteFetchedPage> {
+	Ok(v7::SqliteFetchedPage {
+		pgno: x.pgno,
+		bytes: x.bytes,
+	})
+}
+
+pub fn convert_sqlite_get_pages_request_v6_to_v7(x: v6::SqliteGetPagesRequest) -> Result<v7::SqliteGetPagesRequest> {
+	Ok(v7::SqliteGetPagesRequest {
+		actor_id: x.actor_id,
+		pgnos: x.pgnos,
+		expected_generation: x.expected_generation,
+		expected_head_txid: x.expected_head_txid,
+	})
+}
+
+pub fn convert_sqlite_get_pages_ok_v6_to_v7(x: v6::SqliteGetPagesOk) -> Result<v7::SqliteGetPagesOk> {
+	Ok(v7::SqliteGetPagesOk {
+		pages: x.pages.into_iter().map(|v| convert_sqlite_fetched_page_v6_to_v7(v)).collect::<Result<Vec<_>>>()?,
+		head_txid: x.head_txid,
+	})
+}
+
+pub fn convert_sqlite_error_response_v6_to_v7(x: v6::SqliteErrorResponse) -> Result<v7::SqliteErrorResponse> {
+	Ok(v7::SqliteErrorResponse {
+		group: x.group,
+		code: x.code,
+		message: x.message,
+	})
+}
+
+pub fn convert_sqlite_get_pages_response_v6_to_v7(x: v6::SqliteGetPagesResponse) -> Result<v7::SqliteGetPagesResponse> {
+	Ok(match x {
+		v6::SqliteGetPagesResponse::SqliteGetPagesOk(v) => v7::SqliteGetPagesResponse::SqliteGetPagesOk(convert_sqlite_get_pages_ok_v6_to_v7(v)?),
+		v6::SqliteGetPagesResponse::SqliteErrorResponse(v) => v7::SqliteGetPagesResponse::SqliteErrorResponse(convert_sqlite_error_response_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_sqlite_commit_request_v6_to_v7(x: v6::SqliteCommitRequest) -> Result<v7::SqliteCommitRequest> {
+	Ok(v7::SqliteCommitRequest {
+		actor_id: x.actor_id,
+		dirty_pages: x.dirty_pages.into_iter().map(|v| convert_sqlite_dirty_page_v6_to_v7(v)).collect::<Result<Vec<_>>>()?,
+		db_size_pages: x.db_size_pages,
+		now_ms: x.now_ms,
+		expected_generation: x.expected_generation,
+		expected_head_txid: x.expected_head_txid,
+	})
+}
+
+pub fn convert_sqlite_commit_ok_v6_to_v7(x: v6::SqliteCommitOk) -> Result<v7::SqliteCommitOk> {
+	Ok(v7::SqliteCommitOk {
+		head_txid: x.head_txid,
+	})
+}
+
+pub fn convert_sqlite_commit_response_v6_to_v7(x: v6::SqliteCommitResponse) -> Result<v7::SqliteCommitResponse> {
+	Ok(match x {
+		v6::SqliteCommitResponse::SqliteCommitOk(v) => v7::SqliteCommitResponse::SqliteCommitOk(convert_sqlite_commit_ok_v6_to_v7(v)?),
+		v6::SqliteCommitResponse::SqliteErrorResponse(v) => v7::SqliteCommitResponse::SqliteErrorResponse(convert_sqlite_error_response_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_sqlite_value_integer_v6_to_v7(x: v6::SqliteValueInteger) -> Result<v7::SqliteValueInteger> {
+	Ok(v7::SqliteValueInteger {
+		value: x.value,
+	})
+}
+
+pub fn convert_sqlite_value_float_v6_to_v7(x: v6::SqliteValueFloat) -> Result<v7::SqliteValueFloat> {
+	Ok(v7::SqliteValueFloat {
+		value: x.value,
+	})
+}
+
+pub fn convert_sqlite_value_text_v6_to_v7(x: v6::SqliteValueText) -> Result<v7::SqliteValueText> {
+	Ok(v7::SqliteValueText {
+		value: x.value,
+	})
+}
+
+pub fn convert_sqlite_value_blob_v6_to_v7(x: v6::SqliteValueBlob) -> Result<v7::SqliteValueBlob> {
+	Ok(v7::SqliteValueBlob {
+		value: x.value,
+	})
+}
+
+pub fn convert_sqlite_bind_param_v6_to_v7(x: v6::SqliteBindParam) -> Result<v7::SqliteBindParam> {
+	Ok(match x {
+		v6::SqliteBindParam::SqliteValueNull => v7::SqliteBindParam::SqliteValueNull,
+		v6::SqliteBindParam::SqliteValueInteger(v) => v7::SqliteBindParam::SqliteValueInteger(convert_sqlite_value_integer_v6_to_v7(v)?),
+		v6::SqliteBindParam::SqliteValueFloat(v) => v7::SqliteBindParam::SqliteValueFloat(convert_sqlite_value_float_v6_to_v7(v)?),
+		v6::SqliteBindParam::SqliteValueText(v) => v7::SqliteBindParam::SqliteValueText(convert_sqlite_value_text_v6_to_v7(v)?),
+		v6::SqliteBindParam::SqliteValueBlob(v) => v7::SqliteBindParam::SqliteValueBlob(convert_sqlite_value_blob_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_sqlite_column_value_v6_to_v7(x: v6::SqliteColumnValue) -> Result<v7::SqliteColumnValue> {
+	Ok(match x {
+		v6::SqliteColumnValue::SqliteValueNull => v7::SqliteColumnValue::SqliteValueNull,
+		v6::SqliteColumnValue::SqliteValueInteger(v) => v7::SqliteColumnValue::SqliteValueInteger(convert_sqlite_value_integer_v6_to_v7(v)?),
+		v6::SqliteColumnValue::SqliteValueFloat(v) => v7::SqliteColumnValue::SqliteValueFloat(convert_sqlite_value_float_v6_to_v7(v)?),
+		v6::SqliteColumnValue::SqliteValueText(v) => v7::SqliteColumnValue::SqliteValueText(convert_sqlite_value_text_v6_to_v7(v)?),
+		v6::SqliteColumnValue::SqliteValueBlob(v) => v7::SqliteColumnValue::SqliteValueBlob(convert_sqlite_value_blob_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_sqlite_query_result_v6_to_v7(x: v6::SqliteQueryResult) -> Result<v7::SqliteQueryResult> {
+	Ok(v7::SqliteQueryResult {
+		columns: x.columns,
+		rows: x.rows.into_iter().map(|v| v.into_iter().map(|v| convert_sqlite_column_value_v6_to_v7(v)).collect::<Result<Vec<_>>>()).collect::<Result<Vec<_>>>()?,
+	})
+}
+
+pub fn convert_sqlite_execute_result_v6_to_v7(x: v6::SqliteExecuteResult) -> Result<v7::SqliteExecuteResult> {
+	Ok(v7::SqliteExecuteResult {
+		columns: x.columns,
+		rows: x.rows.into_iter().map(|v| v.into_iter().map(|v| convert_sqlite_column_value_v6_to_v7(v)).collect::<Result<Vec<_>>>()).collect::<Result<Vec<_>>>()?,
+		changes: x.changes,
+		last_insert_row_id: x.last_insert_row_id,
+	})
+}
+
+pub fn convert_sqlite_exec_request_v6_to_v7(x: v6::SqliteExecRequest) -> Result<v7::SqliteExecRequest> {
+	Ok(v7::SqliteExecRequest {
+		namespace_id: x.namespace_id,
+		actor_id: x.actor_id,
+		generation: x.generation,
+		sql: x.sql,
+	})
+}
+
+pub fn convert_sqlite_execute_request_v6_to_v7(x: v6::SqliteExecuteRequest) -> Result<v7::SqliteExecuteRequest> {
+	Ok(v7::SqliteExecuteRequest {
+		namespace_id: x.namespace_id,
+		actor_id: x.actor_id,
+		generation: x.generation,
+		sql: x.sql,
+		params: x.params.map(|v| v.into_iter().map(|v| convert_sqlite_bind_param_v6_to_v7(v)).collect::<Result<Vec<_>>>()).transpose()?,
+	})
+}
+
+pub fn convert_sqlite_batch_statement_v6_to_v7(x: v6::SqliteBatchStatement) -> Result<v7::SqliteBatchStatement> {
+	Ok(v7::SqliteBatchStatement {
+		sql: x.sql,
+		params: x.params.map(|v| v.into_iter().map(|v| convert_sqlite_bind_param_v6_to_v7(v)).collect::<Result<Vec<_>>>()).transpose()?,
+	})
+}
+
+pub fn convert_sqlite_execute_batch_request_v6_to_v7(x: v6::SqliteExecuteBatchRequest) -> Result<v7::SqliteExecuteBatchRequest> {
+	Ok(v7::SqliteExecuteBatchRequest {
+		namespace_id: x.namespace_id,
+		actor_id: x.actor_id,
+		generation: x.generation,
+		statements: x.statements.into_iter().map(|v| convert_sqlite_batch_statement_v6_to_v7(v)).collect::<Result<Vec<_>>>()?,
+	})
+}
+
+pub fn convert_sqlite_exec_ok_v6_to_v7(x: v6::SqliteExecOk) -> Result<v7::SqliteExecOk> {
+	Ok(v7::SqliteExecOk {
+		result: convert_sqlite_query_result_v6_to_v7(x.result)?,
+	})
+}
+
+pub fn convert_sqlite_execute_ok_v6_to_v7(x: v6::SqliteExecuteOk) -> Result<v7::SqliteExecuteOk> {
+	Ok(v7::SqliteExecuteOk {
+		result: convert_sqlite_execute_result_v6_to_v7(x.result)?,
+	})
+}
+
+pub fn convert_sqlite_execute_batch_ok_v6_to_v7(x: v6::SqliteExecuteBatchOk) -> Result<v7::SqliteExecuteBatchOk> {
+	Ok(v7::SqliteExecuteBatchOk {
+		results: x.results.into_iter().map(|v| convert_sqlite_execute_result_v6_to_v7(v)).collect::<Result<Vec<_>>>()?,
+	})
+}
+
+pub fn convert_sqlite_exec_response_v6_to_v7(x: v6::SqliteExecResponse) -> Result<v7::SqliteExecResponse> {
+	Ok(match x {
+		v6::SqliteExecResponse::SqliteExecOk(v) => v7::SqliteExecResponse::SqliteExecOk(convert_sqlite_exec_ok_v6_to_v7(v)?),
+		v6::SqliteExecResponse::SqliteErrorResponse(v) => v7::SqliteExecResponse::SqliteErrorResponse(convert_sqlite_error_response_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_sqlite_execute_response_v6_to_v7(x: v6::SqliteExecuteResponse) -> Result<v7::SqliteExecuteResponse> {
+	Ok(match x {
+		v6::SqliteExecuteResponse::SqliteExecuteOk(v) => v7::SqliteExecuteResponse::SqliteExecuteOk(convert_sqlite_execute_ok_v6_to_v7(v)?),
+		v6::SqliteExecuteResponse::SqliteErrorResponse(v) => v7::SqliteExecuteResponse::SqliteErrorResponse(convert_sqlite_error_response_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_sqlite_execute_batch_response_v6_to_v7(x: v6::SqliteExecuteBatchResponse) -> Result<v7::SqliteExecuteBatchResponse> {
+	Ok(match x {
+		v6::SqliteExecuteBatchResponse::SqliteExecuteBatchOk(v) => v7::SqliteExecuteBatchResponse::SqliteExecuteBatchOk(convert_sqlite_execute_batch_ok_v6_to_v7(v)?),
+		v6::SqliteExecuteBatchResponse::SqliteErrorResponse(v) => v7::SqliteExecuteBatchResponse::SqliteErrorResponse(convert_sqlite_error_response_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_stop_code_v6_to_v7(x: v6::StopCode) -> Result<v7::StopCode> {
+	Ok(match x {
+		v6::StopCode::Ok => v7::StopCode::Ok,
+		v6::StopCode::Error => v7::StopCode::Error,
+	})
+}
+
+pub fn convert_actor_name_v6_to_v7(x: v6::ActorName) -> Result<v7::ActorName> {
+	Ok(v7::ActorName {
+		metadata: x.metadata,
+	})
+}
+
+pub fn convert_actor_config_v6_to_v7(x: v6::ActorConfig) -> Result<v7::ActorConfig> {
+	Ok(v7::ActorConfig {
+		name: x.name,
+		key: x.key,
+		create_ts: x.create_ts,
+		input: x.input,
+	})
+}
+
+pub fn convert_actor_checkpoint_v6_to_v7(x: v6::ActorCheckpoint) -> Result<v7::ActorCheckpoint> {
+	Ok(v7::ActorCheckpoint {
+		actor_id: x.actor_id,
+		generation: x.generation,
+		index: x.index,
+	})
+}
+
+pub fn convert_actor_intent_v6_to_v7(x: v6::ActorIntent) -> Result<v7::ActorIntent> {
+	Ok(match x {
+		v6::ActorIntent::ActorIntentSleep => v7::ActorIntent::ActorIntentSleep,
+		v6::ActorIntent::ActorIntentStop => v7::ActorIntent::ActorIntentStop,
+	})
+}
+
+pub fn convert_actor_state_stopped_v6_to_v7(x: v6::ActorStateStopped) -> Result<v7::ActorStateStopped> {
+	Ok(v7::ActorStateStopped {
+		code: convert_stop_code_v6_to_v7(x.code)?,
+		message: x.message,
+	})
+}
+
+pub fn convert_actor_state_v6_to_v7(x: v6::ActorState) -> Result<v7::ActorState> {
+	Ok(match x {
+		v6::ActorState::ActorStateRunning => v7::ActorState::ActorStateRunning,
+		v6::ActorState::ActorStateStopped(v) => v7::ActorState::ActorStateStopped(convert_actor_state_stopped_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_event_actor_intent_v6_to_v7(x: v6::EventActorIntent) -> Result<v7::EventActorIntent> {
+	Ok(v7::EventActorIntent {
+		intent: convert_actor_intent_v6_to_v7(x.intent)?,
+	})
+}
+
+pub fn convert_event_actor_state_update_v6_to_v7(x: v6::EventActorStateUpdate) -> Result<v7::EventActorStateUpdate> {
+	Ok(v7::EventActorStateUpdate {
+		state: convert_actor_state_v6_to_v7(x.state)?,
+	})
+}
+
+pub fn convert_event_actor_set_alarm_v6_to_v7(x: v6::EventActorSetAlarm) -> Result<v7::EventActorSetAlarm> {
+	Ok(v7::EventActorSetAlarm {
+		alarm_ts: x.alarm_ts,
+	})
+}
+
+pub fn convert_event_v6_to_v7(x: v6::Event) -> Result<v7::Event> {
+	Ok(match x {
+		v6::Event::EventActorIntent(v) => v7::Event::EventActorIntent(convert_event_actor_intent_v6_to_v7(v)?),
+		v6::Event::EventActorStateUpdate(v) => v7::Event::EventActorStateUpdate(convert_event_actor_state_update_v6_to_v7(v)?),
+		v6::Event::EventActorSetAlarm(v) => v7::Event::EventActorSetAlarm(convert_event_actor_set_alarm_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_event_wrapper_v6_to_v7(x: v6::EventWrapper) -> Result<v7::EventWrapper> {
+	Ok(v7::EventWrapper {
+		checkpoint: convert_actor_checkpoint_v6_to_v7(x.checkpoint)?,
+		inner: convert_event_v6_to_v7(x.inner)?,
+	})
+}
+
+pub fn convert_preloaded_kv_entry_v6_to_v7(x: v6::PreloadedKvEntry) -> Result<v7::PreloadedKvEntry> {
+	Ok(v7::PreloadedKvEntry {
+		key: x.key,
+		value: x.value,
+		metadata: convert_kv_metadata_v6_to_v7(x.metadata)?,
+	})
+}
+
+pub fn convert_preloaded_kv_v6_to_v7(x: v6::PreloadedKv) -> Result<v7::PreloadedKv> {
+	Ok(v7::PreloadedKv {
+		entries: x.entries.into_iter().map(|v| convert_preloaded_kv_entry_v6_to_v7(v)).collect::<Result<Vec<_>>>()?,
+		requested_get_keys: x.requested_get_keys,
+		requested_prefixes: x.requested_prefixes,
+	})
+}
+
+pub fn convert_hibernating_request_v6_to_v7(x: v6::HibernatingRequest) -> Result<v7::HibernatingRequest> {
+	Ok(v7::HibernatingRequest {
+		gateway_id: x.gateway_id,
+		request_id: x.request_id,
+	})
+}
+
+pub fn convert_command_start_actor_v6_to_v7(x: v6::CommandStartActor) -> Result<v7::CommandStartActor> {
+	Ok(v7::CommandStartActor {
+		config: convert_actor_config_v6_to_v7(x.config)?,
+		hibernating_requests: x.hibernating_requests.into_iter().map(|v| convert_hibernating_request_v6_to_v7(v)).collect::<Result<Vec<_>>>()?,
+		preloaded_kv: x.preloaded_kv.map(|v| convert_preloaded_kv_v6_to_v7(v)).transpose()?,
+	})
+}
+
+pub fn convert_stop_actor_reason_v6_to_v7(x: v6::StopActorReason) -> Result<v7::StopActorReason> {
+	Ok(match x {
+		v6::StopActorReason::SleepIntent => v7::StopActorReason::SleepIntent,
+		v6::StopActorReason::StopIntent => v7::StopActorReason::StopIntent,
+		v6::StopActorReason::Destroy => v7::StopActorReason::Destroy,
+		v6::StopActorReason::GoingAway => v7::StopActorReason::GoingAway,
+		v6::StopActorReason::Lost => v7::StopActorReason::Lost,
+	})
+}
+
+pub fn convert_command_stop_actor_v6_to_v7(x: v6::CommandStopActor) -> Result<v7::CommandStopActor> {
+	Ok(v7::CommandStopActor {
+		reason: convert_stop_actor_reason_v6_to_v7(x.reason)?,
+	})
+}
+
+pub fn convert_command_v6_to_v7(x: v6::Command) -> Result<v7::Command> {
+	Ok(match x {
+		v6::Command::CommandStartActor(v) => v7::Command::CommandStartActor(convert_command_start_actor_v6_to_v7(v)?),
+		v6::Command::CommandStopActor(v) => v7::Command::CommandStopActor(convert_command_stop_actor_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_command_wrapper_v6_to_v7(x: v6::CommandWrapper) -> Result<v7::CommandWrapper> {
+	Ok(v7::CommandWrapper {
+		checkpoint: convert_actor_checkpoint_v6_to_v7(x.checkpoint)?,
+		inner: convert_command_v6_to_v7(x.inner)?,
+	})
+}
+
+pub fn convert_actor_command_key_data_v6_to_v7(x: v6::ActorCommandKeyData) -> Result<v7::ActorCommandKeyData> {
+	Ok(match x {
+		v6::ActorCommandKeyData::CommandStartActor(v) => v7::ActorCommandKeyData::CommandStartActor(convert_command_start_actor_v6_to_v7(v)?),
+		v6::ActorCommandKeyData::CommandStopActor(v) => v7::ActorCommandKeyData::CommandStopActor(convert_command_stop_actor_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_message_id_v6_to_v7(x: v6::MessageId) -> Result<v7::MessageId> {
+	Ok(v7::MessageId {
+		gateway_id: x.gateway_id,
+		request_id: x.request_id,
+		message_index: x.message_index,
+	})
+}
+
+pub fn convert_to_envoy_request_start_v6_to_v7(x: v6::ToEnvoyRequestStart) -> Result<v7::ToEnvoyRequestStart> {
+	Ok(v7::ToEnvoyRequestStart {
+		actor_id: x.actor_id,
+		method: x.method,
+		path: x.path,
+		headers: x.headers,
+		body: x.body,
+		stream: x.stream,
+	})
+}
+
+pub fn convert_to_envoy_request_chunk_v6_to_v7(x: v6::ToEnvoyRequestChunk) -> Result<v7::ToEnvoyRequestChunk> {
+	Ok(v7::ToEnvoyRequestChunk {
+		body: x.body,
+		finish: x.finish,
+	})
+}
+
+pub fn convert_to_rivet_response_start_v6_to_v7(x: v6::ToRivetResponseStart) -> Result<v7::ToRivetResponseStart> {
+	Ok(v7::ToRivetResponseStart {
+		status: x.status,
+		headers: x.headers,
+		body: x.body,
+		stream: x.stream,
+	})
+}
+
+pub fn convert_to_rivet_response_chunk_v6_to_v7(x: v6::ToRivetResponseChunk) -> Result<v7::ToRivetResponseChunk> {
+	Ok(v7::ToRivetResponseChunk {
+		body: x.body,
+		finish: x.finish,
+	})
+}
+
+pub fn convert_to_envoy_web_socket_open_v6_to_v7(x: v6::ToEnvoyWebSocketOpen) -> Result<v7::ToEnvoyWebSocketOpen> {
+	Ok(v7::ToEnvoyWebSocketOpen {
+		actor_id: x.actor_id,
+		path: x.path,
+		headers: x.headers,
+	})
+}
+
+pub fn convert_to_envoy_web_socket_message_v6_to_v7(x: v6::ToEnvoyWebSocketMessage) -> Result<v7::ToEnvoyWebSocketMessage> {
+	Ok(v7::ToEnvoyWebSocketMessage {
+		data: x.data,
+		binary: x.binary,
+	})
+}
+
+pub fn convert_to_envoy_web_socket_close_v6_to_v7(x: v6::ToEnvoyWebSocketClose) -> Result<v7::ToEnvoyWebSocketClose> {
+	Ok(v7::ToEnvoyWebSocketClose {
+		code: x.code,
+		reason: x.reason,
+	})
+}
+
+pub fn convert_to_rivet_web_socket_open_v6_to_v7(x: v6::ToRivetWebSocketOpen) -> Result<v7::ToRivetWebSocketOpen> {
+	Ok(v7::ToRivetWebSocketOpen {
+		can_hibernate: x.can_hibernate,
+	})
+}
+
+pub fn convert_to_rivet_web_socket_message_v6_to_v7(x: v6::ToRivetWebSocketMessage) -> Result<v7::ToRivetWebSocketMessage> {
+	Ok(v7::ToRivetWebSocketMessage {
+		data: x.data,
+		binary: x.binary,
+	})
+}
+
+pub fn convert_to_rivet_web_socket_message_ack_v6_to_v7(x: v6::ToRivetWebSocketMessageAck) -> Result<v7::ToRivetWebSocketMessageAck> {
+	Ok(v7::ToRivetWebSocketMessageAck {
+		index: x.index,
+	})
+}
+
+pub fn convert_to_rivet_web_socket_close_v6_to_v7(x: v6::ToRivetWebSocketClose) -> Result<v7::ToRivetWebSocketClose> {
+	Ok(v7::ToRivetWebSocketClose {
+		code: x.code,
+		reason: x.reason,
+		hibernate: x.hibernate,
+	})
+}
+
+pub fn convert_to_rivet_tunnel_message_kind_v6_to_v7(x: v6::ToRivetTunnelMessageKind) -> Result<v7::ToRivetTunnelMessageKind> {
+	Ok(match x {
+		v6::ToRivetTunnelMessageKind::ToRivetResponseStart(v) => v7::ToRivetTunnelMessageKind::ToRivetResponseStart(convert_to_rivet_response_start_v6_to_v7(v)?),
+		v6::ToRivetTunnelMessageKind::ToRivetResponseChunk(v) => v7::ToRivetTunnelMessageKind::ToRivetResponseChunk(convert_to_rivet_response_chunk_v6_to_v7(v)?),
+		v6::ToRivetTunnelMessageKind::ToRivetResponseAbort => {
+			v7::ToRivetTunnelMessageKind::ToRivetResponseAbort(v7::ToRivetResponseAbort {
+				reason: v7::HttpStreamAbortReason {
+					kind: v7::HttpStreamAbortReasonKind::Unknown,
+					detail: None,
+				},
+			})
+		}
+		v6::ToRivetTunnelMessageKind::ToRivetWebSocketOpen(v) => v7::ToRivetTunnelMessageKind::ToRivetWebSocketOpen(convert_to_rivet_web_socket_open_v6_to_v7(v)?),
+		v6::ToRivetTunnelMessageKind::ToRivetWebSocketMessage(v) => v7::ToRivetTunnelMessageKind::ToRivetWebSocketMessage(convert_to_rivet_web_socket_message_v6_to_v7(v)?),
+		v6::ToRivetTunnelMessageKind::ToRivetWebSocketMessageAck(v) => v7::ToRivetTunnelMessageKind::ToRivetWebSocketMessageAck(convert_to_rivet_web_socket_message_ack_v6_to_v7(v)?),
+		v6::ToRivetTunnelMessageKind::ToRivetWebSocketClose(v) => v7::ToRivetTunnelMessageKind::ToRivetWebSocketClose(convert_to_rivet_web_socket_close_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_to_rivet_tunnel_message_v6_to_v7(x: v6::ToRivetTunnelMessage) -> Result<v7::ToRivetTunnelMessage> {
+	Ok(v7::ToRivetTunnelMessage {
+		message_id: convert_message_id_v6_to_v7(x.message_id)?,
+		message_kind: convert_to_rivet_tunnel_message_kind_v6_to_v7(x.message_kind)?,
+	})
+}
+
+pub fn convert_to_envoy_tunnel_message_kind_v6_to_v7(x: v6::ToEnvoyTunnelMessageKind) -> Result<v7::ToEnvoyTunnelMessageKind> {
+	Ok(match x {
+		v6::ToEnvoyTunnelMessageKind::ToEnvoyRequestStart(v) => v7::ToEnvoyTunnelMessageKind::ToEnvoyRequestStart(convert_to_envoy_request_start_v6_to_v7(v)?),
+		v6::ToEnvoyTunnelMessageKind::ToEnvoyRequestChunk(v) => v7::ToEnvoyTunnelMessageKind::ToEnvoyRequestChunk(convert_to_envoy_request_chunk_v6_to_v7(v)?),
+		v6::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort => {
+			v7::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort(v7::ToEnvoyRequestAbort {
+				reason: v7::HttpStreamAbortReason {
+					kind: v7::HttpStreamAbortReasonKind::Unknown,
+					detail: None,
+				},
+			})
+		}
+		v6::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketOpen(v) => v7::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketOpen(convert_to_envoy_web_socket_open_v6_to_v7(v)?),
+		v6::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketMessage(v) => v7::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketMessage(convert_to_envoy_web_socket_message_v6_to_v7(v)?),
+		v6::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketClose(v) => v7::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketClose(convert_to_envoy_web_socket_close_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_to_envoy_tunnel_message_v6_to_v7(x: v6::ToEnvoyTunnelMessage) -> Result<v7::ToEnvoyTunnelMessage> {
+	Ok(v7::ToEnvoyTunnelMessage {
+		message_id: convert_message_id_v6_to_v7(x.message_id)?,
+		message_kind: convert_to_envoy_tunnel_message_kind_v6_to_v7(x.message_kind)?,
+	})
+}
+
+pub fn convert_to_envoy_ping_v6_to_v7(x: v6::ToEnvoyPing) -> Result<v7::ToEnvoyPing> {
+	Ok(v7::ToEnvoyPing {
+		ts: x.ts,
+	})
+}
+
+pub fn convert_to_rivet_metadata_v6_to_v7(x: v6::ToRivetMetadata) -> Result<v7::ToRivetMetadata> {
+	Ok(v7::ToRivetMetadata {
+		prepopulate_actor_names: x.prepopulate_actor_names.map(|v| v.into_iter().map(|(k, v)| -> Result<_> { Ok((k, convert_actor_name_v6_to_v7(v)?)) }).collect::<Result<_>>()).transpose()?,
+		metadata: x.metadata,
+	})
+}
+
+pub fn convert_to_rivet_events_v6_to_v7(x: v6::ToRivetEvents) -> Result<v7::ToRivetEvents> {
+	Ok(x.into_iter().map(|v| convert_event_wrapper_v6_to_v7(v)).collect::<Result<Vec<_>>>()?)
+}
+
+pub fn convert_to_rivet_ack_commands_v6_to_v7(x: v6::ToRivetAckCommands) -> Result<v7::ToRivetAckCommands> {
+	Ok(v7::ToRivetAckCommands {
+		last_command_checkpoints: x.last_command_checkpoints.into_iter().map(|v| convert_actor_checkpoint_v6_to_v7(v)).collect::<Result<Vec<_>>>()?,
+	})
+}
+
+pub fn convert_to_rivet_pong_v6_to_v7(x: v6::ToRivetPong) -> Result<v7::ToRivetPong> {
+	Ok(v7::ToRivetPong {
+		ts: x.ts,
+	})
+}
+
+pub fn convert_to_rivet_kv_request_v6_to_v7(x: v6::ToRivetKvRequest) -> Result<v7::ToRivetKvRequest> {
+	Ok(v7::ToRivetKvRequest {
+		actor_id: x.actor_id,
+		request_id: x.request_id,
+		data: convert_kv_request_data_v6_to_v7(x.data)?,
+	})
+}
+
+pub fn convert_to_rivet_sqlite_get_pages_request_v6_to_v7(x: v6::ToRivetSqliteGetPagesRequest) -> Result<v7::ToRivetSqliteGetPagesRequest> {
+	Ok(v7::ToRivetSqliteGetPagesRequest {
+		request_id: x.request_id,
+		data: convert_sqlite_get_pages_request_v6_to_v7(x.data)?,
+	})
+}
+
+pub fn convert_to_rivet_sqlite_commit_request_v6_to_v7(x: v6::ToRivetSqliteCommitRequest) -> Result<v7::ToRivetSqliteCommitRequest> {
+	Ok(v7::ToRivetSqliteCommitRequest {
+		request_id: x.request_id,
+		data: convert_sqlite_commit_request_v6_to_v7(x.data)?,
+	})
+}
+
+pub fn convert_to_rivet_sqlite_exec_request_v6_to_v7(x: v6::ToRivetSqliteExecRequest) -> Result<v7::ToRivetSqliteExecRequest> {
+	Ok(v7::ToRivetSqliteExecRequest {
+		request_id: x.request_id,
+		data: convert_sqlite_exec_request_v6_to_v7(x.data)?,
+	})
+}
+
+pub fn convert_to_rivet_sqlite_execute_request_v6_to_v7(x: v6::ToRivetSqliteExecuteRequest) -> Result<v7::ToRivetSqliteExecuteRequest> {
+	Ok(v7::ToRivetSqliteExecuteRequest {
+		request_id: x.request_id,
+		data: convert_sqlite_execute_request_v6_to_v7(x.data)?,
+	})
+}
+
+pub fn convert_to_rivet_sqlite_execute_batch_request_v6_to_v7(x: v6::ToRivetSqliteExecuteBatchRequest) -> Result<v7::ToRivetSqliteExecuteBatchRequest> {
+	Ok(v7::ToRivetSqliteExecuteBatchRequest {
+		request_id: x.request_id,
+		data: convert_sqlite_execute_batch_request_v6_to_v7(x.data)?,
+	})
+}
+
+pub fn convert_to_rivet_v6_to_v7(x: v6::ToRivet) -> Result<v7::ToRivet> {
+	Ok(match x {
+		v6::ToRivet::ToRivetMetadata(v) => v7::ToRivet::ToRivetMetadata(convert_to_rivet_metadata_v6_to_v7(v)?),
+		v6::ToRivet::ToRivetEvents(v) => v7::ToRivet::ToRivetEvents(convert_to_rivet_events_v6_to_v7(v)?),
+		v6::ToRivet::ToRivetAckCommands(v) => v7::ToRivet::ToRivetAckCommands(convert_to_rivet_ack_commands_v6_to_v7(v)?),
+		v6::ToRivet::ToRivetStopping => v7::ToRivet::ToRivetStopping,
+		v6::ToRivet::ToRivetPong(v) => v7::ToRivet::ToRivetPong(convert_to_rivet_pong_v6_to_v7(v)?),
+		v6::ToRivet::ToRivetKvRequest(v) => v7::ToRivet::ToRivetKvRequest(convert_to_rivet_kv_request_v6_to_v7(v)?),
+		v6::ToRivet::ToRivetTunnelMessage(v) => v7::ToRivet::ToRivetTunnelMessage(convert_to_rivet_tunnel_message_v6_to_v7(v)?),
+		v6::ToRivet::ToRivetSqliteGetPagesRequest(v) => v7::ToRivet::ToRivetSqliteGetPagesRequest(convert_to_rivet_sqlite_get_pages_request_v6_to_v7(v)?),
+		v6::ToRivet::ToRivetSqliteCommitRequest(v) => v7::ToRivet::ToRivetSqliteCommitRequest(convert_to_rivet_sqlite_commit_request_v6_to_v7(v)?),
+		v6::ToRivet::ToRivetSqliteExecRequest(v) => v7::ToRivet::ToRivetSqliteExecRequest(convert_to_rivet_sqlite_exec_request_v6_to_v7(v)?),
+		v6::ToRivet::ToRivetSqliteExecuteRequest(v) => v7::ToRivet::ToRivetSqliteExecuteRequest(convert_to_rivet_sqlite_execute_request_v6_to_v7(v)?),
+		v6::ToRivet::ToRivetSqliteExecuteBatchRequest(v) => v7::ToRivet::ToRivetSqliteExecuteBatchRequest(convert_to_rivet_sqlite_execute_batch_request_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_protocol_metadata_v6_to_v7(x: v6::ProtocolMetadata) -> Result<v7::ProtocolMetadata> {
+	Ok(v7::ProtocolMetadata {
+		envoy_lost_threshold: x.envoy_lost_threshold,
+		actor_stop_threshold: x.actor_stop_threshold,
+		max_response_payload_size: x.max_response_payload_size,
+	})
+}
+
+pub fn convert_to_envoy_init_v6_to_v7(x: v6::ToEnvoyInit) -> Result<v7::ToEnvoyInit> {
+	Ok(v7::ToEnvoyInit {
+		metadata: convert_protocol_metadata_v6_to_v7(x.metadata)?,
+	})
+}
+
+pub fn convert_to_envoy_commands_v6_to_v7(x: v6::ToEnvoyCommands) -> Result<v7::ToEnvoyCommands> {
+	Ok(x.into_iter().map(|v| convert_command_wrapper_v6_to_v7(v)).collect::<Result<Vec<_>>>()?)
+}
+
+pub fn convert_to_envoy_ack_events_v6_to_v7(x: v6::ToEnvoyAckEvents) -> Result<v7::ToEnvoyAckEvents> {
+	Ok(v7::ToEnvoyAckEvents {
+		last_event_checkpoints: x.last_event_checkpoints.into_iter().map(|v| convert_actor_checkpoint_v6_to_v7(v)).collect::<Result<Vec<_>>>()?,
+	})
+}
+
+pub fn convert_to_envoy_kv_response_v6_to_v7(x: v6::ToEnvoyKvResponse) -> Result<v7::ToEnvoyKvResponse> {
+	Ok(v7::ToEnvoyKvResponse {
+		request_id: x.request_id,
+		data: convert_kv_response_data_v6_to_v7(x.data)?,
+	})
+}
+
+pub fn convert_to_envoy_sqlite_get_pages_response_v6_to_v7(x: v6::ToEnvoySqliteGetPagesResponse) -> Result<v7::ToEnvoySqliteGetPagesResponse> {
+	Ok(v7::ToEnvoySqliteGetPagesResponse {
+		request_id: x.request_id,
+		data: convert_sqlite_get_pages_response_v6_to_v7(x.data)?,
+	})
+}
+
+pub fn convert_to_envoy_sqlite_commit_response_v6_to_v7(x: v6::ToEnvoySqliteCommitResponse) -> Result<v7::ToEnvoySqliteCommitResponse> {
+	Ok(v7::ToEnvoySqliteCommitResponse {
+		request_id: x.request_id,
+		data: convert_sqlite_commit_response_v6_to_v7(x.data)?,
+	})
+}
+
+pub fn convert_to_envoy_sqlite_exec_response_v6_to_v7(x: v6::ToEnvoySqliteExecResponse) -> Result<v7::ToEnvoySqliteExecResponse> {
+	Ok(v7::ToEnvoySqliteExecResponse {
+		request_id: x.request_id,
+		data: convert_sqlite_exec_response_v6_to_v7(x.data)?,
+	})
+}
+
+pub fn convert_to_envoy_sqlite_execute_response_v6_to_v7(x: v6::ToEnvoySqliteExecuteResponse) -> Result<v7::ToEnvoySqliteExecuteResponse> {
+	Ok(v7::ToEnvoySqliteExecuteResponse {
+		request_id: x.request_id,
+		data: convert_sqlite_execute_response_v6_to_v7(x.data)?,
+	})
+}
+
+pub fn convert_to_envoy_sqlite_execute_batch_response_v6_to_v7(x: v6::ToEnvoySqliteExecuteBatchResponse) -> Result<v7::ToEnvoySqliteExecuteBatchResponse> {
+	Ok(v7::ToEnvoySqliteExecuteBatchResponse {
+		request_id: x.request_id,
+		data: convert_sqlite_execute_batch_response_v6_to_v7(x.data)?,
+	})
+}
+
+pub fn convert_to_envoy_v6_to_v7(x: v6::ToEnvoy) -> Result<v7::ToEnvoy> {
+	Ok(match x {
+		v6::ToEnvoy::ToEnvoyInit(v) => v7::ToEnvoy::ToEnvoyInit(convert_to_envoy_init_v6_to_v7(v)?),
+		v6::ToEnvoy::ToEnvoyCommands(v) => v7::ToEnvoy::ToEnvoyCommands(convert_to_envoy_commands_v6_to_v7(v)?),
+		v6::ToEnvoy::ToEnvoyAckEvents(v) => v7::ToEnvoy::ToEnvoyAckEvents(convert_to_envoy_ack_events_v6_to_v7(v)?),
+		v6::ToEnvoy::ToEnvoyKvResponse(v) => v7::ToEnvoy::ToEnvoyKvResponse(convert_to_envoy_kv_response_v6_to_v7(v)?),
+		v6::ToEnvoy::ToEnvoyTunnelMessage(v) => v7::ToEnvoy::ToEnvoyTunnelMessage(convert_to_envoy_tunnel_message_v6_to_v7(v)?),
+		v6::ToEnvoy::ToEnvoyPing(v) => v7::ToEnvoy::ToEnvoyPing(convert_to_envoy_ping_v6_to_v7(v)?),
+		v6::ToEnvoy::ToEnvoySqliteGetPagesResponse(v) => v7::ToEnvoy::ToEnvoySqliteGetPagesResponse(convert_to_envoy_sqlite_get_pages_response_v6_to_v7(v)?),
+		v6::ToEnvoy::ToEnvoySqliteCommitResponse(v) => v7::ToEnvoy::ToEnvoySqliteCommitResponse(convert_to_envoy_sqlite_commit_response_v6_to_v7(v)?),
+		v6::ToEnvoy::ToEnvoySqliteExecResponse(v) => v7::ToEnvoy::ToEnvoySqliteExecResponse(convert_to_envoy_sqlite_exec_response_v6_to_v7(v)?),
+		v6::ToEnvoy::ToEnvoySqliteExecuteResponse(v) => v7::ToEnvoy::ToEnvoySqliteExecuteResponse(convert_to_envoy_sqlite_execute_response_v6_to_v7(v)?),
+		v6::ToEnvoy::ToEnvoySqliteExecuteBatchResponse(v) => v7::ToEnvoy::ToEnvoySqliteExecuteBatchResponse(convert_to_envoy_sqlite_execute_batch_response_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_to_envoy_conn_ping_v6_to_v7(x: v6::ToEnvoyConnPing) -> Result<v7::ToEnvoyConnPing> {
+	Ok(v7::ToEnvoyConnPing {
+		gateway_id: x.gateway_id,
+		request_id: x.request_id,
+		ts: x.ts,
+	})
+}
+
+pub fn convert_to_envoy_conn_v6_to_v7(x: v6::ToEnvoyConn) -> Result<v7::ToEnvoyConn> {
+	Ok(match x {
+		v6::ToEnvoyConn::ToEnvoyConnPing(v) => v7::ToEnvoyConn::ToEnvoyConnPing(convert_to_envoy_conn_ping_v6_to_v7(v)?),
+		v6::ToEnvoyConn::ToEnvoyConnClose => v7::ToEnvoyConn::ToEnvoyConnClose,
+		v6::ToEnvoyConn::ToEnvoyCommands(v) => v7::ToEnvoyConn::ToEnvoyCommands(convert_to_envoy_commands_v6_to_v7(v)?),
+		v6::ToEnvoyConn::ToEnvoyAckEvents(v) => v7::ToEnvoyConn::ToEnvoyAckEvents(convert_to_envoy_ack_events_v6_to_v7(v)?),
+		v6::ToEnvoyConn::ToEnvoyTunnelMessage(v) => v7::ToEnvoyConn::ToEnvoyTunnelMessage(convert_to_envoy_tunnel_message_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_to_gateway_pong_v6_to_v7(x: v6::ToGatewayPong) -> Result<v7::ToGatewayPong> {
+	Ok(v7::ToGatewayPong {
+		request_id: x.request_id,
+		ts: x.ts,
+	})
+}
+
+pub fn convert_to_gateway_v6_to_v7(x: v6::ToGateway) -> Result<v7::ToGateway> {
+	Ok(match x {
+		v6::ToGateway::ToGatewayPong(v) => v7::ToGateway::ToGatewayPong(convert_to_gateway_pong_v6_to_v7(v)?),
+		v6::ToGateway::ToRivetTunnelMessage(v) => v7::ToGateway::ToRivetTunnelMessage(convert_to_rivet_tunnel_message_v6_to_v7(v)?),
+	})
+}
+
+pub fn convert_to_outbound_actor_start_v6_to_v7(x: v6::ToOutboundActorStart) -> Result<v7::ToOutboundActorStart> {
+	Ok(v7::ToOutboundActorStart {
+		namespace_id: x.namespace_id,
+		pool_name: x.pool_name,
+		checkpoint: convert_actor_checkpoint_v6_to_v7(x.checkpoint)?,
+		actor_config: convert_actor_config_v6_to_v7(x.actor_config)?,
+	})
+}
+
+pub fn convert_to_outbound_v6_to_v7(x: v6::ToOutbound) -> Result<v7::ToOutbound> {
+	Ok(match x {
+		v6::ToOutbound::ToOutboundActorStart(v) => v7::ToOutbound::ToOutboundActorStart(convert_to_outbound_actor_start_v6_to_v7(v)?),
+	})
+}

--- a/engine/sdks/rust/envoy-protocol/src/versioned/v7_to_v6.rs
+++ b/engine/sdks/rust/envoy-protocol/src/versioned/v7_to_v6.rs
@@ -1,0 +1,819 @@
+// from: v7.bare, to: v6.bare
+
+#![allow(dead_code, unused_variables)]
+
+use anyhow::Result;
+
+use crate::generated::{v7, v6};
+
+pub fn convert_kv_metadata_v7_to_v6(x: v7::KvMetadata) -> Result<v6::KvMetadata> {
+	Ok(v6::KvMetadata {
+		version: x.version,
+		update_ts: x.update_ts,
+	})
+}
+
+pub fn convert_kv_list_range_query_v7_to_v6(x: v7::KvListRangeQuery) -> Result<v6::KvListRangeQuery> {
+	Ok(v6::KvListRangeQuery {
+		start: x.start,
+		end: x.end,
+		exclusive: x.exclusive,
+	})
+}
+
+pub fn convert_kv_list_prefix_query_v7_to_v6(x: v7::KvListPrefixQuery) -> Result<v6::KvListPrefixQuery> {
+	Ok(v6::KvListPrefixQuery {
+		key: x.key,
+	})
+}
+
+pub fn convert_kv_list_query_v7_to_v6(x: v7::KvListQuery) -> Result<v6::KvListQuery> {
+	Ok(match x {
+		v7::KvListQuery::KvListAllQuery => v6::KvListQuery::KvListAllQuery,
+		v7::KvListQuery::KvListRangeQuery(v) => v6::KvListQuery::KvListRangeQuery(convert_kv_list_range_query_v7_to_v6(v)?),
+		v7::KvListQuery::KvListPrefixQuery(v) => v6::KvListQuery::KvListPrefixQuery(convert_kv_list_prefix_query_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_kv_get_request_v7_to_v6(x: v7::KvGetRequest) -> Result<v6::KvGetRequest> {
+	Ok(v6::KvGetRequest {
+		keys: x.keys,
+	})
+}
+
+pub fn convert_kv_list_request_v7_to_v6(x: v7::KvListRequest) -> Result<v6::KvListRequest> {
+	Ok(v6::KvListRequest {
+		query: convert_kv_list_query_v7_to_v6(x.query)?,
+		reverse: x.reverse,
+		limit: x.limit,
+	})
+}
+
+pub fn convert_kv_put_request_v7_to_v6(x: v7::KvPutRequest) -> Result<v6::KvPutRequest> {
+	Ok(v6::KvPutRequest {
+		keys: x.keys,
+		values: x.values,
+	})
+}
+
+pub fn convert_kv_delete_request_v7_to_v6(x: v7::KvDeleteRequest) -> Result<v6::KvDeleteRequest> {
+	Ok(v6::KvDeleteRequest {
+		keys: x.keys,
+	})
+}
+
+pub fn convert_kv_delete_range_request_v7_to_v6(x: v7::KvDeleteRangeRequest) -> Result<v6::KvDeleteRangeRequest> {
+	Ok(v6::KvDeleteRangeRequest {
+		start: x.start,
+		end: x.end,
+	})
+}
+
+pub fn convert_kv_error_response_v7_to_v6(x: v7::KvErrorResponse) -> Result<v6::KvErrorResponse> {
+	Ok(v6::KvErrorResponse {
+		message: x.message,
+	})
+}
+
+pub fn convert_kv_get_response_v7_to_v6(x: v7::KvGetResponse) -> Result<v6::KvGetResponse> {
+	Ok(v6::KvGetResponse {
+		keys: x.keys,
+		values: x.values,
+		metadata: x.metadata.into_iter().map(|v| convert_kv_metadata_v7_to_v6(v)).collect::<Result<Vec<_>>>()?,
+	})
+}
+
+pub fn convert_kv_list_response_v7_to_v6(x: v7::KvListResponse) -> Result<v6::KvListResponse> {
+	Ok(v6::KvListResponse {
+		keys: x.keys,
+		values: x.values,
+		metadata: x.metadata.into_iter().map(|v| convert_kv_metadata_v7_to_v6(v)).collect::<Result<Vec<_>>>()?,
+	})
+}
+
+pub fn convert_kv_request_data_v7_to_v6(x: v7::KvRequestData) -> Result<v6::KvRequestData> {
+	Ok(match x {
+		v7::KvRequestData::KvGetRequest(v) => v6::KvRequestData::KvGetRequest(convert_kv_get_request_v7_to_v6(v)?),
+		v7::KvRequestData::KvListRequest(v) => v6::KvRequestData::KvListRequest(convert_kv_list_request_v7_to_v6(v)?),
+		v7::KvRequestData::KvPutRequest(v) => v6::KvRequestData::KvPutRequest(convert_kv_put_request_v7_to_v6(v)?),
+		v7::KvRequestData::KvDeleteRequest(v) => v6::KvRequestData::KvDeleteRequest(convert_kv_delete_request_v7_to_v6(v)?),
+		v7::KvRequestData::KvDeleteRangeRequest(v) => v6::KvRequestData::KvDeleteRangeRequest(convert_kv_delete_range_request_v7_to_v6(v)?),
+		v7::KvRequestData::KvDropRequest => v6::KvRequestData::KvDropRequest,
+	})
+}
+
+pub fn convert_kv_response_data_v7_to_v6(x: v7::KvResponseData) -> Result<v6::KvResponseData> {
+	Ok(match x {
+		v7::KvResponseData::KvErrorResponse(v) => v6::KvResponseData::KvErrorResponse(convert_kv_error_response_v7_to_v6(v)?),
+		v7::KvResponseData::KvGetResponse(v) => v6::KvResponseData::KvGetResponse(convert_kv_get_response_v7_to_v6(v)?),
+		v7::KvResponseData::KvListResponse(v) => v6::KvResponseData::KvListResponse(convert_kv_list_response_v7_to_v6(v)?),
+		v7::KvResponseData::KvPutResponse => v6::KvResponseData::KvPutResponse,
+		v7::KvResponseData::KvDeleteResponse => v6::KvResponseData::KvDeleteResponse,
+		v7::KvResponseData::KvDropResponse => v6::KvResponseData::KvDropResponse,
+	})
+}
+
+pub fn convert_sqlite_dirty_page_v7_to_v6(x: v7::SqliteDirtyPage) -> Result<v6::SqliteDirtyPage> {
+	Ok(v6::SqliteDirtyPage {
+		pgno: x.pgno,
+		bytes: x.bytes,
+	})
+}
+
+pub fn convert_sqlite_fetched_page_v7_to_v6(x: v7::SqliteFetchedPage) -> Result<v6::SqliteFetchedPage> {
+	Ok(v6::SqliteFetchedPage {
+		pgno: x.pgno,
+		bytes: x.bytes,
+	})
+}
+
+pub fn convert_sqlite_get_pages_request_v7_to_v6(x: v7::SqliteGetPagesRequest) -> Result<v6::SqliteGetPagesRequest> {
+	Ok(v6::SqliteGetPagesRequest {
+		actor_id: x.actor_id,
+		pgnos: x.pgnos,
+		expected_generation: x.expected_generation,
+		expected_head_txid: x.expected_head_txid,
+	})
+}
+
+pub fn convert_sqlite_get_pages_ok_v7_to_v6(x: v7::SqliteGetPagesOk) -> Result<v6::SqliteGetPagesOk> {
+	Ok(v6::SqliteGetPagesOk {
+		pages: x.pages.into_iter().map(|v| convert_sqlite_fetched_page_v7_to_v6(v)).collect::<Result<Vec<_>>>()?,
+		head_txid: x.head_txid,
+	})
+}
+
+pub fn convert_sqlite_error_response_v7_to_v6(x: v7::SqliteErrorResponse) -> Result<v6::SqliteErrorResponse> {
+	Ok(v6::SqliteErrorResponse {
+		group: x.group,
+		code: x.code,
+		message: x.message,
+	})
+}
+
+pub fn convert_sqlite_get_pages_response_v7_to_v6(x: v7::SqliteGetPagesResponse) -> Result<v6::SqliteGetPagesResponse> {
+	Ok(match x {
+		v7::SqliteGetPagesResponse::SqliteGetPagesOk(v) => v6::SqliteGetPagesResponse::SqliteGetPagesOk(convert_sqlite_get_pages_ok_v7_to_v6(v)?),
+		v7::SqliteGetPagesResponse::SqliteErrorResponse(v) => v6::SqliteGetPagesResponse::SqliteErrorResponse(convert_sqlite_error_response_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_sqlite_commit_request_v7_to_v6(x: v7::SqliteCommitRequest) -> Result<v6::SqliteCommitRequest> {
+	Ok(v6::SqliteCommitRequest {
+		actor_id: x.actor_id,
+		dirty_pages: x.dirty_pages.into_iter().map(|v| convert_sqlite_dirty_page_v7_to_v6(v)).collect::<Result<Vec<_>>>()?,
+		db_size_pages: x.db_size_pages,
+		now_ms: x.now_ms,
+		expected_generation: x.expected_generation,
+		expected_head_txid: x.expected_head_txid,
+	})
+}
+
+pub fn convert_sqlite_commit_ok_v7_to_v6(x: v7::SqliteCommitOk) -> Result<v6::SqliteCommitOk> {
+	Ok(v6::SqliteCommitOk {
+		head_txid: x.head_txid,
+	})
+}
+
+pub fn convert_sqlite_commit_response_v7_to_v6(x: v7::SqliteCommitResponse) -> Result<v6::SqliteCommitResponse> {
+	Ok(match x {
+		v7::SqliteCommitResponse::SqliteCommitOk(v) => v6::SqliteCommitResponse::SqliteCommitOk(convert_sqlite_commit_ok_v7_to_v6(v)?),
+		v7::SqliteCommitResponse::SqliteErrorResponse(v) => v6::SqliteCommitResponse::SqliteErrorResponse(convert_sqlite_error_response_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_sqlite_value_integer_v7_to_v6(x: v7::SqliteValueInteger) -> Result<v6::SqliteValueInteger> {
+	Ok(v6::SqliteValueInteger {
+		value: x.value,
+	})
+}
+
+pub fn convert_sqlite_value_float_v7_to_v6(x: v7::SqliteValueFloat) -> Result<v6::SqliteValueFloat> {
+	Ok(v6::SqliteValueFloat {
+		value: x.value,
+	})
+}
+
+pub fn convert_sqlite_value_text_v7_to_v6(x: v7::SqliteValueText) -> Result<v6::SqliteValueText> {
+	Ok(v6::SqliteValueText {
+		value: x.value,
+	})
+}
+
+pub fn convert_sqlite_value_blob_v7_to_v6(x: v7::SqliteValueBlob) -> Result<v6::SqliteValueBlob> {
+	Ok(v6::SqliteValueBlob {
+		value: x.value,
+	})
+}
+
+pub fn convert_sqlite_bind_param_v7_to_v6(x: v7::SqliteBindParam) -> Result<v6::SqliteBindParam> {
+	Ok(match x {
+		v7::SqliteBindParam::SqliteValueNull => v6::SqliteBindParam::SqliteValueNull,
+		v7::SqliteBindParam::SqliteValueInteger(v) => v6::SqliteBindParam::SqliteValueInteger(convert_sqlite_value_integer_v7_to_v6(v)?),
+		v7::SqliteBindParam::SqliteValueFloat(v) => v6::SqliteBindParam::SqliteValueFloat(convert_sqlite_value_float_v7_to_v6(v)?),
+		v7::SqliteBindParam::SqliteValueText(v) => v6::SqliteBindParam::SqliteValueText(convert_sqlite_value_text_v7_to_v6(v)?),
+		v7::SqliteBindParam::SqliteValueBlob(v) => v6::SqliteBindParam::SqliteValueBlob(convert_sqlite_value_blob_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_sqlite_column_value_v7_to_v6(x: v7::SqliteColumnValue) -> Result<v6::SqliteColumnValue> {
+	Ok(match x {
+		v7::SqliteColumnValue::SqliteValueNull => v6::SqliteColumnValue::SqliteValueNull,
+		v7::SqliteColumnValue::SqliteValueInteger(v) => v6::SqliteColumnValue::SqliteValueInteger(convert_sqlite_value_integer_v7_to_v6(v)?),
+		v7::SqliteColumnValue::SqliteValueFloat(v) => v6::SqliteColumnValue::SqliteValueFloat(convert_sqlite_value_float_v7_to_v6(v)?),
+		v7::SqliteColumnValue::SqliteValueText(v) => v6::SqliteColumnValue::SqliteValueText(convert_sqlite_value_text_v7_to_v6(v)?),
+		v7::SqliteColumnValue::SqliteValueBlob(v) => v6::SqliteColumnValue::SqliteValueBlob(convert_sqlite_value_blob_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_sqlite_query_result_v7_to_v6(x: v7::SqliteQueryResult) -> Result<v6::SqliteQueryResult> {
+	Ok(v6::SqliteQueryResult {
+		columns: x.columns,
+		rows: x.rows.into_iter().map(|v| v.into_iter().map(|v| convert_sqlite_column_value_v7_to_v6(v)).collect::<Result<Vec<_>>>()).collect::<Result<Vec<_>>>()?,
+	})
+}
+
+pub fn convert_sqlite_execute_result_v7_to_v6(x: v7::SqliteExecuteResult) -> Result<v6::SqliteExecuteResult> {
+	Ok(v6::SqliteExecuteResult {
+		columns: x.columns,
+		rows: x.rows.into_iter().map(|v| v.into_iter().map(|v| convert_sqlite_column_value_v7_to_v6(v)).collect::<Result<Vec<_>>>()).collect::<Result<Vec<_>>>()?,
+		changes: x.changes,
+		last_insert_row_id: x.last_insert_row_id,
+	})
+}
+
+pub fn convert_sqlite_exec_request_v7_to_v6(x: v7::SqliteExecRequest) -> Result<v6::SqliteExecRequest> {
+	Ok(v6::SqliteExecRequest {
+		namespace_id: x.namespace_id,
+		actor_id: x.actor_id,
+		generation: x.generation,
+		sql: x.sql,
+	})
+}
+
+pub fn convert_sqlite_execute_request_v7_to_v6(x: v7::SqliteExecuteRequest) -> Result<v6::SqliteExecuteRequest> {
+	Ok(v6::SqliteExecuteRequest {
+		namespace_id: x.namespace_id,
+		actor_id: x.actor_id,
+		generation: x.generation,
+		sql: x.sql,
+		params: x.params.map(|v| v.into_iter().map(|v| convert_sqlite_bind_param_v7_to_v6(v)).collect::<Result<Vec<_>>>()).transpose()?,
+	})
+}
+
+pub fn convert_sqlite_batch_statement_v7_to_v6(x: v7::SqliteBatchStatement) -> Result<v6::SqliteBatchStatement> {
+	Ok(v6::SqliteBatchStatement {
+		sql: x.sql,
+		params: x.params.map(|v| v.into_iter().map(|v| convert_sqlite_bind_param_v7_to_v6(v)).collect::<Result<Vec<_>>>()).transpose()?,
+	})
+}
+
+pub fn convert_sqlite_execute_batch_request_v7_to_v6(x: v7::SqliteExecuteBatchRequest) -> Result<v6::SqliteExecuteBatchRequest> {
+	Ok(v6::SqliteExecuteBatchRequest {
+		namespace_id: x.namespace_id,
+		actor_id: x.actor_id,
+		generation: x.generation,
+		statements: x.statements.into_iter().map(|v| convert_sqlite_batch_statement_v7_to_v6(v)).collect::<Result<Vec<_>>>()?,
+	})
+}
+
+pub fn convert_sqlite_exec_ok_v7_to_v6(x: v7::SqliteExecOk) -> Result<v6::SqliteExecOk> {
+	Ok(v6::SqliteExecOk {
+		result: convert_sqlite_query_result_v7_to_v6(x.result)?,
+	})
+}
+
+pub fn convert_sqlite_execute_ok_v7_to_v6(x: v7::SqliteExecuteOk) -> Result<v6::SqliteExecuteOk> {
+	Ok(v6::SqliteExecuteOk {
+		result: convert_sqlite_execute_result_v7_to_v6(x.result)?,
+	})
+}
+
+pub fn convert_sqlite_execute_batch_ok_v7_to_v6(x: v7::SqliteExecuteBatchOk) -> Result<v6::SqliteExecuteBatchOk> {
+	Ok(v6::SqliteExecuteBatchOk {
+		results: x.results.into_iter().map(|v| convert_sqlite_execute_result_v7_to_v6(v)).collect::<Result<Vec<_>>>()?,
+	})
+}
+
+pub fn convert_sqlite_exec_response_v7_to_v6(x: v7::SqliteExecResponse) -> Result<v6::SqliteExecResponse> {
+	Ok(match x {
+		v7::SqliteExecResponse::SqliteExecOk(v) => v6::SqliteExecResponse::SqliteExecOk(convert_sqlite_exec_ok_v7_to_v6(v)?),
+		v7::SqliteExecResponse::SqliteErrorResponse(v) => v6::SqliteExecResponse::SqliteErrorResponse(convert_sqlite_error_response_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_sqlite_execute_response_v7_to_v6(x: v7::SqliteExecuteResponse) -> Result<v6::SqliteExecuteResponse> {
+	Ok(match x {
+		v7::SqliteExecuteResponse::SqliteExecuteOk(v) => v6::SqliteExecuteResponse::SqliteExecuteOk(convert_sqlite_execute_ok_v7_to_v6(v)?),
+		v7::SqliteExecuteResponse::SqliteErrorResponse(v) => v6::SqliteExecuteResponse::SqliteErrorResponse(convert_sqlite_error_response_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_sqlite_execute_batch_response_v7_to_v6(x: v7::SqliteExecuteBatchResponse) -> Result<v6::SqliteExecuteBatchResponse> {
+	Ok(match x {
+		v7::SqliteExecuteBatchResponse::SqliteExecuteBatchOk(v) => v6::SqliteExecuteBatchResponse::SqliteExecuteBatchOk(convert_sqlite_execute_batch_ok_v7_to_v6(v)?),
+		v7::SqliteExecuteBatchResponse::SqliteErrorResponse(v) => v6::SqliteExecuteBatchResponse::SqliteErrorResponse(convert_sqlite_error_response_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_stop_code_v7_to_v6(x: v7::StopCode) -> Result<v6::StopCode> {
+	Ok(match x {
+		v7::StopCode::Ok => v6::StopCode::Ok,
+		v7::StopCode::Error => v6::StopCode::Error,
+	})
+}
+
+pub fn convert_actor_name_v7_to_v6(x: v7::ActorName) -> Result<v6::ActorName> {
+	Ok(v6::ActorName {
+		metadata: x.metadata,
+	})
+}
+
+pub fn convert_actor_config_v7_to_v6(x: v7::ActorConfig) -> Result<v6::ActorConfig> {
+	Ok(v6::ActorConfig {
+		name: x.name,
+		key: x.key,
+		create_ts: x.create_ts,
+		input: x.input,
+	})
+}
+
+pub fn convert_actor_checkpoint_v7_to_v6(x: v7::ActorCheckpoint) -> Result<v6::ActorCheckpoint> {
+	Ok(v6::ActorCheckpoint {
+		actor_id: x.actor_id,
+		generation: x.generation,
+		index: x.index,
+	})
+}
+
+pub fn convert_actor_intent_v7_to_v6(x: v7::ActorIntent) -> Result<v6::ActorIntent> {
+	Ok(match x {
+		v7::ActorIntent::ActorIntentSleep => v6::ActorIntent::ActorIntentSleep,
+		v7::ActorIntent::ActorIntentStop => v6::ActorIntent::ActorIntentStop,
+	})
+}
+
+pub fn convert_actor_state_stopped_v7_to_v6(x: v7::ActorStateStopped) -> Result<v6::ActorStateStopped> {
+	Ok(v6::ActorStateStopped {
+		code: convert_stop_code_v7_to_v6(x.code)?,
+		message: x.message,
+	})
+}
+
+pub fn convert_actor_state_v7_to_v6(x: v7::ActorState) -> Result<v6::ActorState> {
+	Ok(match x {
+		v7::ActorState::ActorStateRunning => v6::ActorState::ActorStateRunning,
+		v7::ActorState::ActorStateStopped(v) => v6::ActorState::ActorStateStopped(convert_actor_state_stopped_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_event_actor_intent_v7_to_v6(x: v7::EventActorIntent) -> Result<v6::EventActorIntent> {
+	Ok(v6::EventActorIntent {
+		intent: convert_actor_intent_v7_to_v6(x.intent)?,
+	})
+}
+
+pub fn convert_event_actor_state_update_v7_to_v6(x: v7::EventActorStateUpdate) -> Result<v6::EventActorStateUpdate> {
+	Ok(v6::EventActorStateUpdate {
+		state: convert_actor_state_v7_to_v6(x.state)?,
+	})
+}
+
+pub fn convert_event_actor_set_alarm_v7_to_v6(x: v7::EventActorSetAlarm) -> Result<v6::EventActorSetAlarm> {
+	Ok(v6::EventActorSetAlarm {
+		alarm_ts: x.alarm_ts,
+	})
+}
+
+pub fn convert_event_v7_to_v6(x: v7::Event) -> Result<v6::Event> {
+	Ok(match x {
+		v7::Event::EventActorIntent(v) => v6::Event::EventActorIntent(convert_event_actor_intent_v7_to_v6(v)?),
+		v7::Event::EventActorStateUpdate(v) => v6::Event::EventActorStateUpdate(convert_event_actor_state_update_v7_to_v6(v)?),
+		v7::Event::EventActorSetAlarm(v) => v6::Event::EventActorSetAlarm(convert_event_actor_set_alarm_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_event_wrapper_v7_to_v6(x: v7::EventWrapper) -> Result<v6::EventWrapper> {
+	Ok(v6::EventWrapper {
+		checkpoint: convert_actor_checkpoint_v7_to_v6(x.checkpoint)?,
+		inner: convert_event_v7_to_v6(x.inner)?,
+	})
+}
+
+pub fn convert_preloaded_kv_entry_v7_to_v6(x: v7::PreloadedKvEntry) -> Result<v6::PreloadedKvEntry> {
+	Ok(v6::PreloadedKvEntry {
+		key: x.key,
+		value: x.value,
+		metadata: convert_kv_metadata_v7_to_v6(x.metadata)?,
+	})
+}
+
+pub fn convert_preloaded_kv_v7_to_v6(x: v7::PreloadedKv) -> Result<v6::PreloadedKv> {
+	Ok(v6::PreloadedKv {
+		entries: x.entries.into_iter().map(|v| convert_preloaded_kv_entry_v7_to_v6(v)).collect::<Result<Vec<_>>>()?,
+		requested_get_keys: x.requested_get_keys,
+		requested_prefixes: x.requested_prefixes,
+	})
+}
+
+pub fn convert_hibernating_request_v7_to_v6(x: v7::HibernatingRequest) -> Result<v6::HibernatingRequest> {
+	Ok(v6::HibernatingRequest {
+		gateway_id: x.gateway_id,
+		request_id: x.request_id,
+	})
+}
+
+pub fn convert_command_start_actor_v7_to_v6(x: v7::CommandStartActor) -> Result<v6::CommandStartActor> {
+	Ok(v6::CommandStartActor {
+		config: convert_actor_config_v7_to_v6(x.config)?,
+		hibernating_requests: x.hibernating_requests.into_iter().map(|v| convert_hibernating_request_v7_to_v6(v)).collect::<Result<Vec<_>>>()?,
+		preloaded_kv: x.preloaded_kv.map(|v| convert_preloaded_kv_v7_to_v6(v)).transpose()?,
+	})
+}
+
+pub fn convert_stop_actor_reason_v7_to_v6(x: v7::StopActorReason) -> Result<v6::StopActorReason> {
+	Ok(match x {
+		v7::StopActorReason::SleepIntent => v6::StopActorReason::SleepIntent,
+		v7::StopActorReason::StopIntent => v6::StopActorReason::StopIntent,
+		v7::StopActorReason::Destroy => v6::StopActorReason::Destroy,
+		v7::StopActorReason::GoingAway => v6::StopActorReason::GoingAway,
+		v7::StopActorReason::Lost => v6::StopActorReason::Lost,
+	})
+}
+
+pub fn convert_command_stop_actor_v7_to_v6(x: v7::CommandStopActor) -> Result<v6::CommandStopActor> {
+	Ok(v6::CommandStopActor {
+		reason: convert_stop_actor_reason_v7_to_v6(x.reason)?,
+	})
+}
+
+pub fn convert_command_v7_to_v6(x: v7::Command) -> Result<v6::Command> {
+	Ok(match x {
+		v7::Command::CommandStartActor(v) => v6::Command::CommandStartActor(convert_command_start_actor_v7_to_v6(v)?),
+		v7::Command::CommandStopActor(v) => v6::Command::CommandStopActor(convert_command_stop_actor_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_command_wrapper_v7_to_v6(x: v7::CommandWrapper) -> Result<v6::CommandWrapper> {
+	Ok(v6::CommandWrapper {
+		checkpoint: convert_actor_checkpoint_v7_to_v6(x.checkpoint)?,
+		inner: convert_command_v7_to_v6(x.inner)?,
+	})
+}
+
+pub fn convert_actor_command_key_data_v7_to_v6(x: v7::ActorCommandKeyData) -> Result<v6::ActorCommandKeyData> {
+	Ok(match x {
+		v7::ActorCommandKeyData::CommandStartActor(v) => v6::ActorCommandKeyData::CommandStartActor(convert_command_start_actor_v7_to_v6(v)?),
+		v7::ActorCommandKeyData::CommandStopActor(v) => v6::ActorCommandKeyData::CommandStopActor(convert_command_stop_actor_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_message_id_v7_to_v6(x: v7::MessageId) -> Result<v6::MessageId> {
+	Ok(v6::MessageId {
+		gateway_id: x.gateway_id,
+		request_id: x.request_id,
+		message_index: x.message_index,
+	})
+}
+
+pub fn convert_to_envoy_request_start_v7_to_v6(x: v7::ToEnvoyRequestStart) -> Result<v6::ToEnvoyRequestStart> {
+	Ok(v6::ToEnvoyRequestStart {
+		actor_id: x.actor_id,
+		method: x.method,
+		path: x.path,
+		headers: x.headers,
+		body: x.body,
+		stream: x.stream,
+	})
+}
+
+pub fn convert_to_envoy_request_chunk_v7_to_v6(x: v7::ToEnvoyRequestChunk) -> Result<v6::ToEnvoyRequestChunk> {
+	Ok(v6::ToEnvoyRequestChunk {
+		body: x.body,
+		finish: x.finish,
+	})
+}
+
+pub fn convert_to_rivet_response_start_v7_to_v6(x: v7::ToRivetResponseStart) -> Result<v6::ToRivetResponseStart> {
+	Ok(v6::ToRivetResponseStart {
+		status: x.status,
+		headers: x.headers,
+		body: x.body,
+		stream: x.stream,
+	})
+}
+
+pub fn convert_to_rivet_response_chunk_v7_to_v6(x: v7::ToRivetResponseChunk) -> Result<v6::ToRivetResponseChunk> {
+	Ok(v6::ToRivetResponseChunk {
+		body: x.body,
+		finish: x.finish,
+	})
+}
+
+pub fn convert_to_envoy_web_socket_open_v7_to_v6(x: v7::ToEnvoyWebSocketOpen) -> Result<v6::ToEnvoyWebSocketOpen> {
+	Ok(v6::ToEnvoyWebSocketOpen {
+		actor_id: x.actor_id,
+		path: x.path,
+		headers: x.headers,
+	})
+}
+
+pub fn convert_to_envoy_web_socket_message_v7_to_v6(x: v7::ToEnvoyWebSocketMessage) -> Result<v6::ToEnvoyWebSocketMessage> {
+	Ok(v6::ToEnvoyWebSocketMessage {
+		data: x.data,
+		binary: x.binary,
+	})
+}
+
+pub fn convert_to_envoy_web_socket_close_v7_to_v6(x: v7::ToEnvoyWebSocketClose) -> Result<v6::ToEnvoyWebSocketClose> {
+	Ok(v6::ToEnvoyWebSocketClose {
+		code: x.code,
+		reason: x.reason,
+	})
+}
+
+pub fn convert_to_rivet_web_socket_open_v7_to_v6(x: v7::ToRivetWebSocketOpen) -> Result<v6::ToRivetWebSocketOpen> {
+	Ok(v6::ToRivetWebSocketOpen {
+		can_hibernate: x.can_hibernate,
+	})
+}
+
+pub fn convert_to_rivet_web_socket_message_v7_to_v6(x: v7::ToRivetWebSocketMessage) -> Result<v6::ToRivetWebSocketMessage> {
+	Ok(v6::ToRivetWebSocketMessage {
+		data: x.data,
+		binary: x.binary,
+	})
+}
+
+pub fn convert_to_rivet_web_socket_message_ack_v7_to_v6(x: v7::ToRivetWebSocketMessageAck) -> Result<v6::ToRivetWebSocketMessageAck> {
+	Ok(v6::ToRivetWebSocketMessageAck {
+		index: x.index,
+	})
+}
+
+pub fn convert_to_rivet_web_socket_close_v7_to_v6(x: v7::ToRivetWebSocketClose) -> Result<v6::ToRivetWebSocketClose> {
+	Ok(v6::ToRivetWebSocketClose {
+		code: x.code,
+		reason: x.reason,
+		hibernate: x.hibernate,
+	})
+}
+
+pub fn convert_to_rivet_tunnel_message_kind_v7_to_v6(x: v7::ToRivetTunnelMessageKind) -> Result<v6::ToRivetTunnelMessageKind> {
+	Ok(match x {
+		v7::ToRivetTunnelMessageKind::ToRivetResponseStart(v) => v6::ToRivetTunnelMessageKind::ToRivetResponseStart(convert_to_rivet_response_start_v7_to_v6(v)?),
+		v7::ToRivetTunnelMessageKind::ToRivetResponseChunk(v) => v6::ToRivetTunnelMessageKind::ToRivetResponseChunk(convert_to_rivet_response_chunk_v7_to_v6(v)?),
+		v7::ToRivetTunnelMessageKind::ToRivetResponseAbort(_) => {
+			v6::ToRivetTunnelMessageKind::ToRivetResponseAbort
+		}
+		v7::ToRivetTunnelMessageKind::ToRivetWebSocketOpen(v) => v6::ToRivetTunnelMessageKind::ToRivetWebSocketOpen(convert_to_rivet_web_socket_open_v7_to_v6(v)?),
+		v7::ToRivetTunnelMessageKind::ToRivetWebSocketMessage(v) => v6::ToRivetTunnelMessageKind::ToRivetWebSocketMessage(convert_to_rivet_web_socket_message_v7_to_v6(v)?),
+		v7::ToRivetTunnelMessageKind::ToRivetWebSocketMessageAck(v) => v6::ToRivetTunnelMessageKind::ToRivetWebSocketMessageAck(convert_to_rivet_web_socket_message_ack_v7_to_v6(v)?),
+		v7::ToRivetTunnelMessageKind::ToRivetWebSocketClose(v) => v6::ToRivetTunnelMessageKind::ToRivetWebSocketClose(convert_to_rivet_web_socket_close_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_to_rivet_tunnel_message_v7_to_v6(x: v7::ToRivetTunnelMessage) -> Result<v6::ToRivetTunnelMessage> {
+	Ok(v6::ToRivetTunnelMessage {
+		message_id: convert_message_id_v7_to_v6(x.message_id)?,
+		message_kind: convert_to_rivet_tunnel_message_kind_v7_to_v6(x.message_kind)?,
+	})
+}
+
+pub fn convert_to_envoy_tunnel_message_kind_v7_to_v6(x: v7::ToEnvoyTunnelMessageKind) -> Result<v6::ToEnvoyTunnelMessageKind> {
+	Ok(match x {
+		v7::ToEnvoyTunnelMessageKind::ToEnvoyRequestStart(v) => v6::ToEnvoyTunnelMessageKind::ToEnvoyRequestStart(convert_to_envoy_request_start_v7_to_v6(v)?),
+		v7::ToEnvoyTunnelMessageKind::ToEnvoyRequestChunk(v) => v6::ToEnvoyTunnelMessageKind::ToEnvoyRequestChunk(convert_to_envoy_request_chunk_v7_to_v6(v)?),
+		v7::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort(_) => {
+			v6::ToEnvoyTunnelMessageKind::ToEnvoyRequestAbort
+		}
+		v7::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketOpen(v) => v6::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketOpen(convert_to_envoy_web_socket_open_v7_to_v6(v)?),
+		v7::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketMessage(v) => v6::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketMessage(convert_to_envoy_web_socket_message_v7_to_v6(v)?),
+		v7::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketClose(v) => v6::ToEnvoyTunnelMessageKind::ToEnvoyWebSocketClose(convert_to_envoy_web_socket_close_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_to_envoy_tunnel_message_v7_to_v6(x: v7::ToEnvoyTunnelMessage) -> Result<v6::ToEnvoyTunnelMessage> {
+	Ok(v6::ToEnvoyTunnelMessage {
+		message_id: convert_message_id_v7_to_v6(x.message_id)?,
+		message_kind: convert_to_envoy_tunnel_message_kind_v7_to_v6(x.message_kind)?,
+	})
+}
+
+pub fn convert_to_envoy_ping_v7_to_v6(x: v7::ToEnvoyPing) -> Result<v6::ToEnvoyPing> {
+	Ok(v6::ToEnvoyPing {
+		ts: x.ts,
+	})
+}
+
+pub fn convert_to_rivet_metadata_v7_to_v6(x: v7::ToRivetMetadata) -> Result<v6::ToRivetMetadata> {
+	Ok(v6::ToRivetMetadata {
+		prepopulate_actor_names: x.prepopulate_actor_names.map(|v| v.into_iter().map(|(k, v)| -> Result<_> { Ok((k, convert_actor_name_v7_to_v6(v)?)) }).collect::<Result<_>>()).transpose()?,
+		metadata: x.metadata,
+	})
+}
+
+pub fn convert_to_rivet_events_v7_to_v6(x: v7::ToRivetEvents) -> Result<v6::ToRivetEvents> {
+	Ok(x.into_iter().map(|v| convert_event_wrapper_v7_to_v6(v)).collect::<Result<Vec<_>>>()?)
+}
+
+pub fn convert_to_rivet_ack_commands_v7_to_v6(x: v7::ToRivetAckCommands) -> Result<v6::ToRivetAckCommands> {
+	Ok(v6::ToRivetAckCommands {
+		last_command_checkpoints: x.last_command_checkpoints.into_iter().map(|v| convert_actor_checkpoint_v7_to_v6(v)).collect::<Result<Vec<_>>>()?,
+	})
+}
+
+pub fn convert_to_rivet_pong_v7_to_v6(x: v7::ToRivetPong) -> Result<v6::ToRivetPong> {
+	Ok(v6::ToRivetPong {
+		ts: x.ts,
+	})
+}
+
+pub fn convert_to_rivet_kv_request_v7_to_v6(x: v7::ToRivetKvRequest) -> Result<v6::ToRivetKvRequest> {
+	Ok(v6::ToRivetKvRequest {
+		actor_id: x.actor_id,
+		request_id: x.request_id,
+		data: convert_kv_request_data_v7_to_v6(x.data)?,
+	})
+}
+
+pub fn convert_to_rivet_sqlite_get_pages_request_v7_to_v6(x: v7::ToRivetSqliteGetPagesRequest) -> Result<v6::ToRivetSqliteGetPagesRequest> {
+	Ok(v6::ToRivetSqliteGetPagesRequest {
+		request_id: x.request_id,
+		data: convert_sqlite_get_pages_request_v7_to_v6(x.data)?,
+	})
+}
+
+pub fn convert_to_rivet_sqlite_commit_request_v7_to_v6(x: v7::ToRivetSqliteCommitRequest) -> Result<v6::ToRivetSqliteCommitRequest> {
+	Ok(v6::ToRivetSqliteCommitRequest {
+		request_id: x.request_id,
+		data: convert_sqlite_commit_request_v7_to_v6(x.data)?,
+	})
+}
+
+pub fn convert_to_rivet_sqlite_exec_request_v7_to_v6(x: v7::ToRivetSqliteExecRequest) -> Result<v6::ToRivetSqliteExecRequest> {
+	Ok(v6::ToRivetSqliteExecRequest {
+		request_id: x.request_id,
+		data: convert_sqlite_exec_request_v7_to_v6(x.data)?,
+	})
+}
+
+pub fn convert_to_rivet_sqlite_execute_request_v7_to_v6(x: v7::ToRivetSqliteExecuteRequest) -> Result<v6::ToRivetSqliteExecuteRequest> {
+	Ok(v6::ToRivetSqliteExecuteRequest {
+		request_id: x.request_id,
+		data: convert_sqlite_execute_request_v7_to_v6(x.data)?,
+	})
+}
+
+pub fn convert_to_rivet_sqlite_execute_batch_request_v7_to_v6(x: v7::ToRivetSqliteExecuteBatchRequest) -> Result<v6::ToRivetSqliteExecuteBatchRequest> {
+	Ok(v6::ToRivetSqliteExecuteBatchRequest {
+		request_id: x.request_id,
+		data: convert_sqlite_execute_batch_request_v7_to_v6(x.data)?,
+	})
+}
+
+pub fn convert_to_rivet_v7_to_v6(x: v7::ToRivet) -> Result<v6::ToRivet> {
+	Ok(match x {
+		v7::ToRivet::ToRivetMetadata(v) => v6::ToRivet::ToRivetMetadata(convert_to_rivet_metadata_v7_to_v6(v)?),
+		v7::ToRivet::ToRivetEvents(v) => v6::ToRivet::ToRivetEvents(convert_to_rivet_events_v7_to_v6(v)?),
+		v7::ToRivet::ToRivetAckCommands(v) => v6::ToRivet::ToRivetAckCommands(convert_to_rivet_ack_commands_v7_to_v6(v)?),
+		v7::ToRivet::ToRivetStopping => v6::ToRivet::ToRivetStopping,
+		v7::ToRivet::ToRivetPong(v) => v6::ToRivet::ToRivetPong(convert_to_rivet_pong_v7_to_v6(v)?),
+		v7::ToRivet::ToRivetKvRequest(v) => v6::ToRivet::ToRivetKvRequest(convert_to_rivet_kv_request_v7_to_v6(v)?),
+		v7::ToRivet::ToRivetTunnelMessage(v) => v6::ToRivet::ToRivetTunnelMessage(convert_to_rivet_tunnel_message_v7_to_v6(v)?),
+		v7::ToRivet::ToRivetSqliteGetPagesRequest(v) => v6::ToRivet::ToRivetSqliteGetPagesRequest(convert_to_rivet_sqlite_get_pages_request_v7_to_v6(v)?),
+		v7::ToRivet::ToRivetSqliteCommitRequest(v) => v6::ToRivet::ToRivetSqliteCommitRequest(convert_to_rivet_sqlite_commit_request_v7_to_v6(v)?),
+		v7::ToRivet::ToRivetSqliteExecRequest(v) => v6::ToRivet::ToRivetSqliteExecRequest(convert_to_rivet_sqlite_exec_request_v7_to_v6(v)?),
+		v7::ToRivet::ToRivetSqliteExecuteRequest(v) => v6::ToRivet::ToRivetSqliteExecuteRequest(convert_to_rivet_sqlite_execute_request_v7_to_v6(v)?),
+		v7::ToRivet::ToRivetSqliteExecuteBatchRequest(v) => v6::ToRivet::ToRivetSqliteExecuteBatchRequest(convert_to_rivet_sqlite_execute_batch_request_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_protocol_metadata_v7_to_v6(x: v7::ProtocolMetadata) -> Result<v6::ProtocolMetadata> {
+	Ok(v6::ProtocolMetadata {
+		envoy_lost_threshold: x.envoy_lost_threshold,
+		actor_stop_threshold: x.actor_stop_threshold,
+		max_response_payload_size: x.max_response_payload_size,
+	})
+}
+
+pub fn convert_to_envoy_init_v7_to_v6(x: v7::ToEnvoyInit) -> Result<v6::ToEnvoyInit> {
+	Ok(v6::ToEnvoyInit {
+		metadata: convert_protocol_metadata_v7_to_v6(x.metadata)?,
+	})
+}
+
+pub fn convert_to_envoy_commands_v7_to_v6(x: v7::ToEnvoyCommands) -> Result<v6::ToEnvoyCommands> {
+	Ok(x.into_iter().map(|v| convert_command_wrapper_v7_to_v6(v)).collect::<Result<Vec<_>>>()?)
+}
+
+pub fn convert_to_envoy_ack_events_v7_to_v6(x: v7::ToEnvoyAckEvents) -> Result<v6::ToEnvoyAckEvents> {
+	Ok(v6::ToEnvoyAckEvents {
+		last_event_checkpoints: x.last_event_checkpoints.into_iter().map(|v| convert_actor_checkpoint_v7_to_v6(v)).collect::<Result<Vec<_>>>()?,
+	})
+}
+
+pub fn convert_to_envoy_kv_response_v7_to_v6(x: v7::ToEnvoyKvResponse) -> Result<v6::ToEnvoyKvResponse> {
+	Ok(v6::ToEnvoyKvResponse {
+		request_id: x.request_id,
+		data: convert_kv_response_data_v7_to_v6(x.data)?,
+	})
+}
+
+pub fn convert_to_envoy_sqlite_get_pages_response_v7_to_v6(x: v7::ToEnvoySqliteGetPagesResponse) -> Result<v6::ToEnvoySqliteGetPagesResponse> {
+	Ok(v6::ToEnvoySqliteGetPagesResponse {
+		request_id: x.request_id,
+		data: convert_sqlite_get_pages_response_v7_to_v6(x.data)?,
+	})
+}
+
+pub fn convert_to_envoy_sqlite_commit_response_v7_to_v6(x: v7::ToEnvoySqliteCommitResponse) -> Result<v6::ToEnvoySqliteCommitResponse> {
+	Ok(v6::ToEnvoySqliteCommitResponse {
+		request_id: x.request_id,
+		data: convert_sqlite_commit_response_v7_to_v6(x.data)?,
+	})
+}
+
+pub fn convert_to_envoy_sqlite_exec_response_v7_to_v6(x: v7::ToEnvoySqliteExecResponse) -> Result<v6::ToEnvoySqliteExecResponse> {
+	Ok(v6::ToEnvoySqliteExecResponse {
+		request_id: x.request_id,
+		data: convert_sqlite_exec_response_v7_to_v6(x.data)?,
+	})
+}
+
+pub fn convert_to_envoy_sqlite_execute_response_v7_to_v6(x: v7::ToEnvoySqliteExecuteResponse) -> Result<v6::ToEnvoySqliteExecuteResponse> {
+	Ok(v6::ToEnvoySqliteExecuteResponse {
+		request_id: x.request_id,
+		data: convert_sqlite_execute_response_v7_to_v6(x.data)?,
+	})
+}
+
+pub fn convert_to_envoy_sqlite_execute_batch_response_v7_to_v6(x: v7::ToEnvoySqliteExecuteBatchResponse) -> Result<v6::ToEnvoySqliteExecuteBatchResponse> {
+	Ok(v6::ToEnvoySqliteExecuteBatchResponse {
+		request_id: x.request_id,
+		data: convert_sqlite_execute_batch_response_v7_to_v6(x.data)?,
+	})
+}
+
+pub fn convert_to_envoy_v7_to_v6(x: v7::ToEnvoy) -> Result<v6::ToEnvoy> {
+	Ok(match x {
+		v7::ToEnvoy::ToEnvoyInit(v) => v6::ToEnvoy::ToEnvoyInit(convert_to_envoy_init_v7_to_v6(v)?),
+		v7::ToEnvoy::ToEnvoyCommands(v) => v6::ToEnvoy::ToEnvoyCommands(convert_to_envoy_commands_v7_to_v6(v)?),
+		v7::ToEnvoy::ToEnvoyAckEvents(v) => v6::ToEnvoy::ToEnvoyAckEvents(convert_to_envoy_ack_events_v7_to_v6(v)?),
+		v7::ToEnvoy::ToEnvoyKvResponse(v) => v6::ToEnvoy::ToEnvoyKvResponse(convert_to_envoy_kv_response_v7_to_v6(v)?),
+		v7::ToEnvoy::ToEnvoyTunnelMessage(v) => v6::ToEnvoy::ToEnvoyTunnelMessage(convert_to_envoy_tunnel_message_v7_to_v6(v)?),
+		v7::ToEnvoy::ToEnvoyPing(v) => v6::ToEnvoy::ToEnvoyPing(convert_to_envoy_ping_v7_to_v6(v)?),
+		v7::ToEnvoy::ToEnvoySqliteGetPagesResponse(v) => v6::ToEnvoy::ToEnvoySqliteGetPagesResponse(convert_to_envoy_sqlite_get_pages_response_v7_to_v6(v)?),
+		v7::ToEnvoy::ToEnvoySqliteCommitResponse(v) => v6::ToEnvoy::ToEnvoySqliteCommitResponse(convert_to_envoy_sqlite_commit_response_v7_to_v6(v)?),
+		v7::ToEnvoy::ToEnvoySqliteExecResponse(v) => v6::ToEnvoy::ToEnvoySqliteExecResponse(convert_to_envoy_sqlite_exec_response_v7_to_v6(v)?),
+		v7::ToEnvoy::ToEnvoySqliteExecuteResponse(v) => v6::ToEnvoy::ToEnvoySqliteExecuteResponse(convert_to_envoy_sqlite_execute_response_v7_to_v6(v)?),
+		v7::ToEnvoy::ToEnvoySqliteExecuteBatchResponse(v) => v6::ToEnvoy::ToEnvoySqliteExecuteBatchResponse(convert_to_envoy_sqlite_execute_batch_response_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_to_envoy_conn_ping_v7_to_v6(x: v7::ToEnvoyConnPing) -> Result<v6::ToEnvoyConnPing> {
+	Ok(v6::ToEnvoyConnPing {
+		gateway_id: x.gateway_id,
+		request_id: x.request_id,
+		ts: x.ts,
+	})
+}
+
+pub fn convert_to_envoy_conn_v7_to_v6(x: v7::ToEnvoyConn) -> Result<v6::ToEnvoyConn> {
+	Ok(match x {
+		v7::ToEnvoyConn::ToEnvoyConnPing(v) => v6::ToEnvoyConn::ToEnvoyConnPing(convert_to_envoy_conn_ping_v7_to_v6(v)?),
+		v7::ToEnvoyConn::ToEnvoyConnClose => v6::ToEnvoyConn::ToEnvoyConnClose,
+		v7::ToEnvoyConn::ToEnvoyCommands(v) => v6::ToEnvoyConn::ToEnvoyCommands(convert_to_envoy_commands_v7_to_v6(v)?),
+		v7::ToEnvoyConn::ToEnvoyAckEvents(v) => v6::ToEnvoyConn::ToEnvoyAckEvents(convert_to_envoy_ack_events_v7_to_v6(v)?),
+		v7::ToEnvoyConn::ToEnvoyTunnelMessage(v) => v6::ToEnvoyConn::ToEnvoyTunnelMessage(convert_to_envoy_tunnel_message_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_to_gateway_pong_v7_to_v6(x: v7::ToGatewayPong) -> Result<v6::ToGatewayPong> {
+	Ok(v6::ToGatewayPong {
+		request_id: x.request_id,
+		ts: x.ts,
+	})
+}
+
+pub fn convert_to_gateway_v7_to_v6(x: v7::ToGateway) -> Result<v6::ToGateway> {
+	Ok(match x {
+		v7::ToGateway::ToGatewayPong(v) => v6::ToGateway::ToGatewayPong(convert_to_gateway_pong_v7_to_v6(v)?),
+		v7::ToGateway::ToRivetTunnelMessage(v) => v6::ToGateway::ToRivetTunnelMessage(convert_to_rivet_tunnel_message_v7_to_v6(v)?),
+	})
+}
+
+pub fn convert_to_outbound_actor_start_v7_to_v6(x: v7::ToOutboundActorStart) -> Result<v6::ToOutboundActorStart> {
+	Ok(v6::ToOutboundActorStart {
+		namespace_id: x.namespace_id,
+		pool_name: x.pool_name,
+		checkpoint: convert_actor_checkpoint_v7_to_v6(x.checkpoint)?,
+		actor_config: convert_actor_config_v7_to_v6(x.actor_config)?,
+	})
+}
+
+pub fn convert_to_outbound_v7_to_v6(x: v7::ToOutbound) -> Result<v6::ToOutbound> {
+	Ok(match x {
+		v7::ToOutbound::ToOutboundActorStart(v) => v6::ToOutbound::ToOutboundActorStart(convert_to_outbound_actor_start_v7_to_v6(v)?),
+	})
+}

--- a/engine/sdks/rust/envoy-protocol/tests/remote_sql_compat.rs
+++ b/engine/sdks/rust/envoy-protocol/tests/remote_sql_compat.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use rivet_envoy_protocol::{
-	generated::{v4, v6},
+	generated::{v4, v7},
 	versioned::{
 		ProtocolCompatibilityDirection, ProtocolCompatibilityError, ProtocolCompatibilityFeature,
 		ToEnvoy, ToRivet,
@@ -8,10 +8,10 @@ use rivet_envoy_protocol::{
 };
 use vbare::OwnedVersionedData;
 
-fn remote_sql_request_exec() -> v6::ToRivet {
-	v6::ToRivet::ToRivetSqliteExecRequest(v6::ToRivetSqliteExecRequest {
+fn remote_sql_request_exec() -> v7::ToRivet {
+	v7::ToRivet::ToRivetSqliteExecRequest(v7::ToRivetSqliteExecRequest {
 		request_id: 1,
-		data: v6::SqliteExecRequest {
+		data: v7::SqliteExecRequest {
 			namespace_id: "namespace".into(),
 			actor_id: "actor".into(),
 			generation: 7,
@@ -20,25 +20,25 @@ fn remote_sql_request_exec() -> v6::ToRivet {
 	})
 }
 
-fn remote_sql_request_execute() -> v6::ToRivet {
-	v6::ToRivet::ToRivetSqliteExecuteRequest(v6::ToRivetSqliteExecuteRequest {
+fn remote_sql_request_execute() -> v7::ToRivet {
+	v7::ToRivet::ToRivetSqliteExecuteRequest(v7::ToRivetSqliteExecuteRequest {
 		request_id: 2,
-		data: v6::SqliteExecuteRequest {
+		data: v7::SqliteExecuteRequest {
 			namespace_id: "namespace".into(),
 			actor_id: "actor".into(),
 			generation: 7,
 			sql: "select ?".into(),
-			params: Some(vec![v6::SqliteBindParam::SqliteValueInteger(
-				v6::SqliteValueInteger { value: 1 },
+			params: Some(vec![v7::SqliteBindParam::SqliteValueInteger(
+				v7::SqliteValueInteger { value: 1 },
 			)]),
 		},
 	})
 }
 
-fn remote_sql_response_exec() -> v6::ToEnvoy {
-	v6::ToEnvoy::ToEnvoySqliteExecResponse(v6::ToEnvoySqliteExecResponse {
+fn remote_sql_response_exec() -> v7::ToEnvoy {
+	v7::ToEnvoy::ToEnvoySqliteExecResponse(v7::ToEnvoySqliteExecResponse {
 		request_id: 1,
-		data: v6::SqliteExecResponse::SqliteErrorResponse(v6::SqliteErrorResponse {
+		data: v7::SqliteExecResponse::SqliteErrorResponse(v7::SqliteErrorResponse {
 			group: "sqlite".into(),
 			code: "remote_unavailable".into(),
 			message: "remote sql execution is unavailable".into(),
@@ -46,10 +46,10 @@ fn remote_sql_response_exec() -> v6::ToEnvoy {
 	})
 }
 
-fn remote_sql_response_execute() -> v6::ToEnvoy {
-	v6::ToEnvoy::ToEnvoySqliteExecuteResponse(v6::ToEnvoySqliteExecuteResponse {
+fn remote_sql_response_execute() -> v7::ToEnvoy {
+	v7::ToEnvoy::ToEnvoySqliteExecuteResponse(v7::ToEnvoySqliteExecuteResponse {
 		request_id: 2,
-		data: v6::SqliteExecuteResponse::SqliteErrorResponse(v6::SqliteErrorResponse {
+		data: v7::SqliteExecuteResponse::SqliteErrorResponse(v7::SqliteErrorResponse {
 			group: "sqlite".into(),
 			code: "remote_unavailable".into(),
 			message: "remote sql execution is unavailable".into(),
@@ -57,27 +57,27 @@ fn remote_sql_response_execute() -> v6::ToEnvoy {
 	})
 }
 
-fn remote_sql_request_execute_batch() -> v6::ToRivet {
-	v6::ToRivet::ToRivetSqliteExecuteBatchRequest(v6::ToRivetSqliteExecuteBatchRequest {
+fn remote_sql_request_execute_batch() -> v7::ToRivet {
+	v7::ToRivet::ToRivetSqliteExecuteBatchRequest(v7::ToRivetSqliteExecuteBatchRequest {
 		request_id: 3,
-		data: v6::SqliteExecuteBatchRequest {
+		data: v7::SqliteExecuteBatchRequest {
 			namespace_id: "namespace".into(),
 			actor_id: "actor".into(),
 			generation: 7,
-			statements: vec![v6::SqliteBatchStatement {
+			statements: vec![v7::SqliteBatchStatement {
 				sql: "insert into t values (?)".into(),
-				params: Some(vec![v6::SqliteBindParam::SqliteValueInteger(
-					v6::SqliteValueInteger { value: 1 },
+				params: Some(vec![v7::SqliteBindParam::SqliteValueInteger(
+					v7::SqliteValueInteger { value: 1 },
 				)]),
 			}],
 		},
 	})
 }
 
-fn remote_sql_response_execute_batch() -> v6::ToEnvoy {
-	v6::ToEnvoy::ToEnvoySqliteExecuteBatchResponse(v6::ToEnvoySqliteExecuteBatchResponse {
+fn remote_sql_response_execute_batch() -> v7::ToEnvoy {
+	v7::ToEnvoy::ToEnvoySqliteExecuteBatchResponse(v7::ToEnvoySqliteExecuteBatchResponse {
 		request_id: 3,
-		data: v6::SqliteExecuteBatchResponse::SqliteExecuteBatchOk(v6::SqliteExecuteBatchOk {
+		data: v7::SqliteExecuteBatchResponse::SqliteExecuteBatchOk(v7::SqliteExecuteBatchOk {
 			results: Vec::new(),
 		}),
 	})
@@ -139,11 +139,11 @@ fn new_core_new_pegboard_envoy_allows_remote_sql_both_directions() -> Result<()>
 
 	assert!(matches!(
 		ToRivet::deserialize(&request, 4)?,
-		v6::ToRivet::ToRivetSqliteExecRequest(_)
+		v7::ToRivet::ToRivetSqliteExecRequest(_)
 	));
 	assert!(matches!(
 		ToEnvoy::deserialize(&response, 4)?,
-		v6::ToEnvoy::ToEnvoySqliteExecResponse(_)
+		v7::ToEnvoy::ToEnvoySqliteExecResponse(_)
 	));
 
 	Ok(())
@@ -235,11 +235,11 @@ fn remote_sql_batch_requires_v6() -> Result<()> {
 	let response = ToEnvoy::wrap_latest(remote_sql_response_execute_batch()).serialize(6)?;
 	assert!(matches!(
 		ToRivet::deserialize(&request, 6)?,
-		v6::ToRivet::ToRivetSqliteExecuteBatchRequest(_)
+		v7::ToRivet::ToRivetSqliteExecuteBatchRequest(_)
 	));
 	assert!(matches!(
 		ToEnvoy::deserialize(&response, 6)?,
-		v6::ToEnvoy::ToEnvoySqliteExecuteBatchResponse(_)
+		v7::ToEnvoy::ToEnvoySqliteExecuteBatchResponse(_)
 	));
 	Ok(())
 }

--- a/engine/sdks/rust/envoy-protocol/tests/stateless_sqlite_v3.rs
+++ b/engine/sdks/rust/envoy-protocol/tests/stateless_sqlite_v3.rs
@@ -168,7 +168,7 @@ fn expected_generation_optional_present_and_absent() -> anyhow::Result<()> {
 
 #[test]
 fn protocol_version_constant_matches_schema_version() {
-	assert_eq!(PROTOCOL_VERSION, 6);
+	assert_eq!(PROTOCOL_VERSION, 7);
 }
 
 #[test]

--- a/engine/sdks/schemas/envoy-protocol/v7.bare
+++ b/engine/sdks/schemas/envoy-protocol/v7.bare
@@ -1,0 +1,696 @@
+# MARK: Core Primitives
+
+type Id str
+type Json str
+
+type GatewayId data[4]
+type RequestId data[4]
+type MessageIndex u16
+
+# MARK: KV
+
+# Basic types
+type KvKey data
+type KvValue data
+type KvMetadata struct {
+	version: data
+	updateTs: i64
+}
+
+# Query types
+type KvListAllQuery void
+type KvListRangeQuery struct {
+	start: KvKey
+	end: KvKey
+	exclusive: bool
+}
+
+type KvListPrefixQuery struct {
+	key: KvKey
+}
+
+type KvListQuery union {
+	KvListAllQuery |
+	KvListRangeQuery |
+	KvListPrefixQuery
+}
+
+# Request types
+type KvGetRequest struct {
+	keys: list<KvKey>
+}
+
+type KvListRequest struct {
+	query: KvListQuery
+	reverse: optional<bool>
+	limit: optional<u64>
+}
+
+type KvPutRequest struct {
+	keys: list<KvKey>
+	values: list<KvValue>
+}
+
+type KvDeleteRequest struct {
+	keys: list<KvKey>
+}
+
+type KvDeleteRangeRequest struct {
+	start: KvKey
+	end: KvKey
+}
+
+type KvDropRequest void
+
+# Response types
+type KvErrorResponse struct {
+	message: str
+}
+
+type KvGetResponse struct {
+	keys: list<KvKey>
+	values: list<KvValue>
+	metadata: list<KvMetadata>
+}
+
+type KvListResponse struct {
+	keys: list<KvKey>
+	values: list<KvValue>
+	metadata: list<KvMetadata>
+}
+
+type KvPutResponse void
+type KvDeleteResponse void
+type KvDropResponse void
+
+# Request/Response unions
+type KvRequestData union {
+	KvGetRequest |
+	KvListRequest |
+	KvPutRequest |
+	KvDeleteRequest |
+	KvDeleteRangeRequest |
+	KvDropRequest
+}
+
+type KvResponseData union {
+	KvErrorResponse |
+	KvGetResponse |
+	KvListResponse |
+	KvPutResponse |
+	KvDeleteResponse |
+	KvDropResponse
+}
+
+# MARK: SQLite
+
+type SqlitePgno u32
+type SqliteGeneration u64
+type SqlitePageBytes data
+
+type SqliteDirtyPage struct {
+	pgno: SqlitePgno
+	bytes: SqlitePageBytes
+}
+
+type SqliteFetchedPage struct {
+	pgno: SqlitePgno
+	bytes: optional<SqlitePageBytes>
+}
+
+type SqliteGetPagesRequest struct {
+	actorId: Id
+	pgnos: list<SqlitePgno>
+	expectedGeneration: optional<u64>
+	expectedHeadTxid: optional<u64>
+}
+
+type SqliteGetPagesOk struct {
+	pages: list<SqliteFetchedPage>
+	headTxid: optional<u64>
+}
+
+type SqliteErrorResponse struct {
+	group: str
+	code: str
+	message: str
+}
+
+type SqliteGetPagesResponse union {
+	SqliteGetPagesOk |
+	SqliteErrorResponse
+}
+
+type SqliteCommitRequest struct {
+	actorId: Id
+	dirtyPages: list<SqliteDirtyPage>
+	dbSizePages: u32
+	nowMs: i64
+	expectedGeneration: optional<u64>
+	expectedHeadTxid: optional<u64>
+}
+
+type SqliteCommitOk struct {
+	headTxid: optional<u64>
+}
+
+type SqliteCommitResponse union {
+	SqliteCommitOk |
+	SqliteErrorResponse
+}
+
+# MARK: SQLite Remote Execution
+
+type SqliteValueNull void
+
+type SqliteValueInteger struct {
+	value: i64
+}
+
+type SqliteValueFloat struct {
+	value: data[8]
+}
+
+type SqliteValueText struct {
+	value: str
+}
+
+type SqliteValueBlob struct {
+	value: data
+}
+
+type SqliteBindParam union {
+	SqliteValueNull |
+	SqliteValueInteger |
+	SqliteValueFloat |
+	SqliteValueText |
+	SqliteValueBlob
+}
+
+type SqliteColumnValue union {
+	SqliteValueNull |
+	SqliteValueInteger |
+	SqliteValueFloat |
+	SqliteValueText |
+	SqliteValueBlob
+}
+
+type SqliteQueryResult struct {
+	columns: list<str>
+	rows: list<list<SqliteColumnValue>>
+}
+
+type SqliteExecuteResult struct {
+	columns: list<str>
+	rows: list<list<SqliteColumnValue>>
+	changes: i64
+	lastInsertRowId: optional<i64>
+}
+
+type SqliteExecRequest struct {
+	namespaceId: Id
+	actorId: Id
+	generation: SqliteGeneration
+	sql: str
+}
+
+type SqliteExecuteRequest struct {
+	namespaceId: Id
+	actorId: Id
+	generation: SqliteGeneration
+	sql: str
+	params: optional<list<SqliteBindParam>>
+}
+
+type SqliteBatchStatement struct {
+	sql: str
+	params: optional<list<SqliteBindParam>>
+}
+
+type SqliteExecuteBatchRequest struct {
+	namespaceId: Id
+	actorId: Id
+	generation: SqliteGeneration
+	statements: list<SqliteBatchStatement>
+}
+
+type SqliteExecOk struct {
+	result: SqliteQueryResult
+}
+
+type SqliteExecuteOk struct {
+	result: SqliteExecuteResult
+}
+
+type SqliteExecuteBatchOk struct {
+	results: list<SqliteExecuteResult>
+}
+
+type SqliteExecResponse union {
+	SqliteExecOk |
+	SqliteErrorResponse
+}
+
+type SqliteExecuteResponse union {
+	SqliteExecuteOk |
+	SqliteErrorResponse
+}
+
+type SqliteExecuteBatchResponse union {
+	SqliteExecuteBatchOk |
+	SqliteErrorResponse
+}
+
+# MARK: Actor
+
+# Core
+type StopCode enum {
+	OK
+	ERROR
+}
+
+type ActorName struct {
+	metadata: Json
+}
+
+type ActorConfig struct {
+	name: str
+	key: optional<str>
+	createTs: i64
+	input: optional<data>
+}
+
+type ActorCheckpoint struct {
+	actorId: Id
+	generation: u32
+	index: i64
+}
+
+# Intent
+type ActorIntentSleep void
+
+type ActorIntentStop void
+
+type ActorIntent union {
+	ActorIntentSleep |
+	ActorIntentStop
+}
+
+# State
+type ActorStateRunning void
+
+type ActorStateStopped struct {
+	code: StopCode
+	message: optional<str>
+}
+
+type ActorState union {
+	ActorStateRunning |
+	ActorStateStopped
+}
+
+# MARK: Events
+type EventActorIntent struct {
+	intent: ActorIntent
+}
+
+type EventActorStateUpdate struct {
+	state: ActorState
+}
+
+type EventActorSetAlarm struct {
+	alarmTs: optional<i64>
+}
+
+type Event union {
+	EventActorIntent |
+	EventActorStateUpdate |
+	EventActorSetAlarm
+}
+
+type EventWrapper struct {
+	checkpoint: ActorCheckpoint
+	inner: Event
+}
+
+# MARK: Preloaded KV
+
+type PreloadedKvEntry struct {
+	key: KvKey
+	value: KvValue
+	metadata: KvMetadata
+}
+
+type PreloadedKv struct {
+	entries: list<PreloadedKvEntry>
+	requestedGetKeys: list<KvKey>
+	requestedPrefixes: list<KvKey>
+}
+
+# MARK: Commands
+
+type HibernatingRequest struct {
+	gatewayId: GatewayId
+	requestId: RequestId
+}
+
+type CommandStartActor struct {
+	config: ActorConfig
+	hibernatingRequests: list<HibernatingRequest>
+	preloadedKv: optional<PreloadedKv>
+}
+
+type StopActorReason enum {
+	SLEEP_INTENT
+	STOP_INTENT
+	DESTROY
+	GOING_AWAY
+	LOST
+}
+
+type CommandStopActor struct {
+	reason: StopActorReason
+}
+
+type Command union {
+	CommandStartActor |
+	CommandStopActor
+}
+
+type CommandWrapper struct {
+	checkpoint: ActorCheckpoint
+	inner: Command
+}
+
+# We redeclare this so its top level
+type ActorCommandKeyData union {
+	CommandStartActor |
+	CommandStopActor
+}
+
+# MARK: Tunnel
+
+# Message ID
+
+type MessageId struct {
+	# Globally unique ID
+	gatewayId: GatewayId
+	# Unique ID to the gateway
+	requestId: RequestId
+	# Unique ID to the request
+	messageIndex: MessageIndex
+}
+
+# HTTP
+type ToEnvoyRequestStart struct {
+	actorId: Id
+	method: str
+	path: str
+	headers: map<str><str>
+	body: optional<data>
+	stream: bool
+}
+
+type ToEnvoyRequestChunk struct {
+	body: data
+	finish: bool
+}
+
+type HttpStreamAbortReasonKind enum {
+	UNKNOWN
+	CLIENT_DISCONNECT
+	HANDLER_ERROR
+	IDLE_TIMEOUT
+	OVERLOADED
+	BODY_TOO_LARGE
+	OUT_OF_MEMORY
+	SHUTDOWN
+	INTERNAL_ERROR
+}
+
+type HttpStreamAbortReason struct {
+	kind: HttpStreamAbortReasonKind
+	detail: optional<str>
+}
+
+type ToEnvoyRequestAbort struct {
+	reason: HttpStreamAbortReason
+}
+
+type ToRivetResponseStart struct {
+	status: u16
+	headers: map<str><str>
+	body: optional<data>
+	stream: bool
+}
+
+type ToRivetResponseChunk struct {
+	body: data
+	finish: bool
+}
+
+type ToRivetResponseAbort struct {
+	reason: HttpStreamAbortReason
+}
+
+# WebSocket
+type ToEnvoyWebSocketOpen struct {
+	actorId: Id
+	path: str
+	headers: map<str><str>
+}
+
+type ToEnvoyWebSocketMessage struct {
+	data: data
+	binary: bool
+}
+
+type ToEnvoyWebSocketClose struct {
+	code: optional<u16>
+	reason: optional<str>
+}
+
+type ToRivetWebSocketOpen struct {
+	canHibernate: bool
+}
+
+type ToRivetWebSocketMessage struct {
+	data: data
+	binary: bool
+}
+
+type ToRivetWebSocketMessageAck struct {
+	index: MessageIndex
+}
+
+type ToRivetWebSocketClose struct {
+	code: optional<u16>
+	reason: optional<str>
+	hibernate: bool
+}
+
+# To Rivet
+type ToRivetTunnelMessageKind union {
+	# HTTP
+	ToRivetResponseStart |
+	ToRivetResponseChunk |
+	ToRivetResponseAbort |
+
+	# WebSocket
+	ToRivetWebSocketOpen |
+	ToRivetWebSocketMessage |
+	ToRivetWebSocketMessageAck |
+	ToRivetWebSocketClose
+}
+
+type ToRivetTunnelMessage struct {
+	messageId: MessageId
+	messageKind: ToRivetTunnelMessageKind
+}
+
+# To Envoy
+type ToEnvoyTunnelMessageKind union {
+	# HTTP
+	ToEnvoyRequestStart |
+	ToEnvoyRequestChunk |
+	ToEnvoyRequestAbort |
+
+	# WebSocket
+	ToEnvoyWebSocketOpen |
+	ToEnvoyWebSocketMessage |
+	ToEnvoyWebSocketClose
+}
+
+type ToEnvoyTunnelMessage struct {
+	messageId: MessageId
+	messageKind: ToEnvoyTunnelMessageKind
+}
+
+type ToEnvoyPing struct {
+	ts: i64
+}
+
+# MARK: To Rivet
+type ToRivetMetadata struct {
+	prepopulateActorNames: optional<map<str><ActorName>>
+	metadata: optional<Json>
+}
+
+type ToRivetEvents list<EventWrapper>
+
+type ToRivetAckCommands struct {
+	lastCommandCheckpoints: list<ActorCheckpoint>
+}
+
+type ToRivetStopping void
+
+type ToRivetPong struct {
+	ts: i64
+}
+
+type ToRivetKvRequest struct {
+	actorId: Id
+	requestId: u32
+	data: KvRequestData
+}
+
+type ToRivetSqliteGetPagesRequest struct {
+	requestId: u32
+	data: SqliteGetPagesRequest
+}
+
+type ToRivetSqliteCommitRequest struct {
+	requestId: u32
+	data: SqliteCommitRequest
+}
+
+type ToRivetSqliteExecRequest struct {
+	requestId: u32
+	data: SqliteExecRequest
+}
+
+type ToRivetSqliteExecuteRequest struct {
+	requestId: u32
+	data: SqliteExecuteRequest
+}
+
+type ToRivetSqliteExecuteBatchRequest struct {
+	requestId: u32
+	data: SqliteExecuteBatchRequest
+}
+
+type ToRivet union {
+	ToRivetMetadata |
+	ToRivetEvents |
+	ToRivetAckCommands |
+	ToRivetStopping |
+	ToRivetPong |
+	ToRivetKvRequest |
+	ToRivetTunnelMessage |
+	ToRivetSqliteGetPagesRequest |
+	ToRivetSqliteCommitRequest |
+	ToRivetSqliteExecRequest |
+	ToRivetSqliteExecuteRequest |
+	ToRivetSqliteExecuteBatchRequest
+}
+
+# MARK: To Envoy
+type ProtocolMetadata struct {
+	envoyLostThreshold: i64
+	actorStopThreshold: i64
+	maxResponsePayloadSize: u64
+}
+
+type ToEnvoyInit struct {
+	metadata: ProtocolMetadata
+}
+
+type ToEnvoyCommands list<CommandWrapper>
+
+type ToEnvoyAckEvents struct {
+	lastEventCheckpoints: list<ActorCheckpoint>
+}
+
+type ToEnvoyKvResponse struct {
+	requestId: u32
+	data: KvResponseData
+}
+
+type ToEnvoySqliteGetPagesResponse struct {
+	requestId: u32
+	data: SqliteGetPagesResponse
+}
+
+type ToEnvoySqliteCommitResponse struct {
+	requestId: u32
+	data: SqliteCommitResponse
+}
+
+type ToEnvoySqliteExecResponse struct {
+	requestId: u32
+	data: SqliteExecResponse
+}
+
+type ToEnvoySqliteExecuteResponse struct {
+	requestId: u32
+	data: SqliteExecuteResponse
+}
+
+type ToEnvoySqliteExecuteBatchResponse struct {
+	requestId: u32
+	data: SqliteExecuteBatchResponse
+}
+
+type ToEnvoy union {
+	ToEnvoyInit |
+	ToEnvoyCommands |
+	ToEnvoyAckEvents |
+	ToEnvoyKvResponse |
+	ToEnvoyTunnelMessage |
+	ToEnvoyPing |
+	ToEnvoySqliteGetPagesResponse |
+	ToEnvoySqliteCommitResponse |
+	ToEnvoySqliteExecResponse |
+	ToEnvoySqliteExecuteResponse |
+	ToEnvoySqliteExecuteBatchResponse
+}
+
+# MARK: To Envoy Conn
+type ToEnvoyConnPing struct {
+	gatewayId: GatewayId
+	requestId: RequestId
+	ts: i64
+}
+
+type ToEnvoyConnClose void
+
+type ToEnvoyConn union {
+	ToEnvoyConnPing |
+	ToEnvoyConnClose |
+	ToEnvoyCommands |
+	ToEnvoyAckEvents |
+	ToEnvoyTunnelMessage
+}
+
+# MARK: To Gateway
+type ToGatewayPong struct {
+	requestId: RequestId
+	ts: i64
+}
+
+type ToGateway union {
+	ToGatewayPong |
+	ToRivetTunnelMessage
+}
+
+# MARK: To Outbound
+type ToOutboundActorStart struct {
+	namespaceId: Id
+	poolName: str
+	checkpoint: ActorCheckpoint
+	actorConfig: ActorConfig
+}
+
+type ToOutbound union {
+	ToOutboundActorStart
+}

--- a/engine/sdks/typescript/envoy-protocol/src/index.ts
+++ b/engine/sdks/typescript/envoy-protocol/src/index.ts
@@ -2143,7 +2143,118 @@ export function writeToEnvoyRequestChunk(bc: bare.ByteCursor, x: ToEnvoyRequestC
     bare.writeBool(bc, x.finish)
 }
 
-export type ToEnvoyRequestAbort = null
+export enum HttpStreamAbortReasonKind {
+    Unknown = "Unknown",
+    ClientDisconnect = "ClientDisconnect",
+    HandlerError = "HandlerError",
+    IdleTimeout = "IdleTimeout",
+    Overloaded = "Overloaded",
+    BodyTooLarge = "BodyTooLarge",
+    OutOfMemory = "OutOfMemory",
+    Shutdown = "Shutdown",
+    InternalError = "InternalError",
+}
+
+export function readHttpStreamAbortReasonKind(bc: bare.ByteCursor): HttpStreamAbortReasonKind {
+    const offset = bc.offset
+    const tag = bare.readU8(bc)
+    switch (tag) {
+        case 0:
+            return HttpStreamAbortReasonKind.Unknown
+        case 1:
+            return HttpStreamAbortReasonKind.ClientDisconnect
+        case 2:
+            return HttpStreamAbortReasonKind.HandlerError
+        case 3:
+            return HttpStreamAbortReasonKind.IdleTimeout
+        case 4:
+            return HttpStreamAbortReasonKind.Overloaded
+        case 5:
+            return HttpStreamAbortReasonKind.BodyTooLarge
+        case 6:
+            return HttpStreamAbortReasonKind.OutOfMemory
+        case 7:
+            return HttpStreamAbortReasonKind.Shutdown
+        case 8:
+            return HttpStreamAbortReasonKind.InternalError
+        default: {
+            bc.offset = offset
+            throw new bare.BareError(offset, "invalid tag")
+        }
+    }
+}
+
+export function writeHttpStreamAbortReasonKind(bc: bare.ByteCursor, x: HttpStreamAbortReasonKind): void {
+    switch (x) {
+        case HttpStreamAbortReasonKind.Unknown: {
+            bare.writeU8(bc, 0)
+            break
+        }
+        case HttpStreamAbortReasonKind.ClientDisconnect: {
+            bare.writeU8(bc, 1)
+            break
+        }
+        case HttpStreamAbortReasonKind.HandlerError: {
+            bare.writeU8(bc, 2)
+            break
+        }
+        case HttpStreamAbortReasonKind.IdleTimeout: {
+            bare.writeU8(bc, 3)
+            break
+        }
+        case HttpStreamAbortReasonKind.Overloaded: {
+            bare.writeU8(bc, 4)
+            break
+        }
+        case HttpStreamAbortReasonKind.BodyTooLarge: {
+            bare.writeU8(bc, 5)
+            break
+        }
+        case HttpStreamAbortReasonKind.OutOfMemory: {
+            bare.writeU8(bc, 6)
+            break
+        }
+        case HttpStreamAbortReasonKind.Shutdown: {
+            bare.writeU8(bc, 7)
+            break
+        }
+        case HttpStreamAbortReasonKind.InternalError: {
+            bare.writeU8(bc, 8)
+            break
+        }
+    }
+}
+
+export type HttpStreamAbortReason = {
+    readonly kind: HttpStreamAbortReasonKind
+    readonly detail: string | null
+}
+
+export function readHttpStreamAbortReason(bc: bare.ByteCursor): HttpStreamAbortReason {
+    return {
+        kind: readHttpStreamAbortReasonKind(bc),
+        detail: read17(bc),
+    }
+}
+
+export function writeHttpStreamAbortReason(bc: bare.ByteCursor, x: HttpStreamAbortReason): void {
+    writeHttpStreamAbortReasonKind(bc, x.kind)
+    write17(bc, x.detail)
+}
+
+export type ToEnvoyRequestAbort = {
+    readonly reason: HttpStreamAbortReason
+}
+
+export function readToEnvoyRequestAbort(bc: bare.ByteCursor): ToEnvoyRequestAbort {
+    return {
+        reason: readHttpStreamAbortReason(bc),
+    }
+}
+
+export function writeToEnvoyRequestAbort(bc: bare.ByteCursor, x: ToEnvoyRequestAbort): void {
+    writeHttpStreamAbortReason(bc, x.reason)
+}
 
 export type ToRivetResponseStart = {
     readonly status: u16
@@ -2185,7 +2296,19 @@ export function writeToRivetResponseChunk(bc: bare.ByteCursor, x: ToRivetRespons
     bare.writeBool(bc, x.finish)
 }
 
-export type ToRivetResponseAbort = null
+export type ToRivetResponseAbort = {
+    readonly reason: HttpStreamAbortReason
+}
+
+export function readToRivetResponseAbort(bc: bare.ByteCursor): ToRivetResponseAbort {
+    return {
+        reason: readHttpStreamAbortReason(bc),
+    }
+}
+
+export function writeToRivetResponseAbort(bc: bare.ByteCursor, x: ToRivetResponseAbort): void {
+    writeHttpStreamAbortReason(bc, x.reason)
+}
 
 /**
  * WebSocket
@@ -2347,7 +2470,7 @@ export function readToRivetTunnelMessageKind(bc: bare.ByteCursor): ToRivetTunnel
         case 1:
             return { tag: "ToRivetResponseChunk", val: readToRivetResponseChunk(bc) }
         case 2:
-            return { tag: "ToRivetResponseAbort", val: null }
+            return { tag: "ToRivetResponseAbort", val: readToRivetResponseAbort(bc) }
         case 3:
             return { tag: "ToRivetWebSocketOpen", val: readToRivetWebSocketOpen(bc) }
         case 4:
@@ -2377,6 +2500,7 @@ export function writeToRivetTunnelMessageKind(bc: bare.ByteCursor, x: ToRivetTun
         }
         case "ToRivetResponseAbort": {
             bare.writeU8(bc, 2)
+            writeToRivetResponseAbort(bc, x.val)
             break
         }
         case "ToRivetWebSocketOpen": {
@@ -2445,7 +2569,7 @@ export function readToEnvoyTunnelMessageKind(bc: bare.ByteCursor): ToEnvoyTunnel
         case 1:
             return { tag: "ToEnvoyRequestChunk", val: readToEnvoyRequestChunk(bc) }
         case 2:
-            return { tag: "ToEnvoyRequestAbort", val: null }
+            return { tag: "ToEnvoyRequestAbort", val: readToEnvoyRequestAbort(bc) }
         case 3:
             return { tag: "ToEnvoyWebSocketOpen", val: readToEnvoyWebSocketOpen(bc) }
         case 4:
@@ -2473,6 +2597,7 @@ export function writeToEnvoyTunnelMessageKind(bc: bare.ByteCursor, x: ToEnvoyTun
         }
         case "ToEnvoyRequestAbort": {
             bare.writeU8(bc, 2)
+            writeToEnvoyRequestAbort(bc, x.val)
             break
         }
         case "ToEnvoyWebSocketOpen": {
@@ -3445,4 +3570,4 @@ function assert(condition: boolean, message?: string): asserts condition {
     if (!condition) throw new Error(message ?? "Assertion failed")
 }
 
-export const VERSION = 6;
+export const VERSION = 7;

--- a/rivetkit-rust/packages/rivetkit-core/src/actor/factory.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/actor/factory.rs
@@ -17,6 +17,7 @@ pub struct ActorFactory {
 	config: ActorConfig,
 	entry: Box<ActorEntryFn>,
 	manual_startup_ready: bool,
+	streams_request_body: bool,
 }
 
 #[cfg(feature = "wasm-runtime")]
@@ -34,6 +35,7 @@ impl ActorFactory {
 			config,
 			entry: Box::new(entry),
 			manual_startup_ready: false,
+			streams_request_body: false,
 		}
 	}
 
@@ -47,7 +49,14 @@ impl ActorFactory {
 			config,
 			entry: Box::new(entry),
 			manual_startup_ready: true,
+			streams_request_body: false,
 		}
+	}
+
+	/// Declares that this runtime consumes request bodies incrementally.
+	pub fn with_streaming_request_body(mut self) -> Self {
+		self.streams_request_body = true;
+		self
 	}
 
 	pub fn config(&self) -> &ActorConfig {
@@ -56,6 +65,10 @@ impl ActorFactory {
 
 	pub(crate) fn requires_manual_startup_ready(&self) -> bool {
 		self.manual_startup_ready
+	}
+
+	pub(crate) fn streams_request_body(&self) -> bool {
+		self.streams_request_body
 	}
 
 	pub async fn start(&self, start: ActorStart) -> Result<()> {
@@ -86,6 +99,7 @@ impl fmt::Debug for ActorFactory {
 		f.debug_struct("ActorFactory")
 			.field("config", &self.config)
 			.field("manual_startup_ready", &self.manual_startup_ready)
+			.field("streams_request_body", &self.streams_request_body)
 			.field("entry", &"<boxed entry>")
 			.finish()
 	}

--- a/rivetkit-rust/packages/rivetkit-core/src/actor/messages.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/actor/messages.rs
@@ -1,8 +1,12 @@
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
 
 use anyhow::Result;
+use rivet_envoy_client::config::{HttpRequestBodyStream, ResponseChunk};
 use serde::{Deserialize, Serialize};
+use tokio::sync::{Mutex, mpsc};
+use tokio_util::sync::CancellationToken;
 
 use crate::actor::connection::ConnHandle;
 use crate::actor::lifecycle_hooks::Reply;
@@ -13,11 +17,19 @@ use crate::types::ConnId;
 use crate::websocket::WebSocket;
 
 #[derive(Clone, Debug)]
-pub struct Request(http::Request<Vec<u8>>);
+pub struct Request {
+	inner: http::Request<Vec<u8>>,
+	body_stream: Option<Arc<Mutex<Option<HttpRequestBodyStream>>>>,
+	cancel_token: CancellationToken,
+}
 
 impl Request {
 	pub fn new(body: Vec<u8>) -> Self {
-		Self(http::Request::new(body))
+		Self {
+			inner: http::Request::new(body),
+			body_stream: None,
+			cancel_token: CancellationToken::new(),
+		}
 	}
 
 	pub fn from_parts(
@@ -25,6 +37,16 @@ impl Request {
 		uri: &str,
 		headers: HashMap<String, String>,
 		body: Vec<u8>,
+	) -> Result<Self> {
+		Self::from_parts_with_stream(method, uri, headers, body, None)
+	}
+
+	pub fn from_parts_with_stream(
+		method: &str,
+		uri: &str,
+		headers: HashMap<String, String>,
+		body: Vec<u8>,
+		body_stream: Option<HttpRequestBodyStream>,
 	) -> Result<Self> {
 		let method = method
 			.parse::<http::Method>()
@@ -47,7 +69,11 @@ impl Request {
 			request.headers_mut().insert(header_name, header_value);
 		}
 
-		Ok(Self(request))
+		Ok(Self {
+			inner: request,
+			body_stream: body_stream.map(|rx| Arc::new(Mutex::new(Some(rx)))),
+			cancel_token: CancellationToken::new(),
+		})
 	}
 
 	pub fn to_parts(&self) -> (String, String, HashMap<String, String>, Vec<u8>) {
@@ -67,12 +93,40 @@ impl Request {
 		)
 	}
 
+	pub fn has_body_stream(&self) -> bool {
+		self.body_stream.is_some()
+	}
+
+	pub fn take_body_stream(&self) -> Option<HttpRequestBodyStream> {
+		self.body_stream
+			.as_ref()
+			.and_then(|body_stream| body_stream.try_lock().ok())
+			.and_then(|mut body_stream| body_stream.take())
+	}
+
+	pub fn cancellation_token(&self) -> CancellationToken {
+		self.cancel_token.clone()
+	}
+
+	pub async fn into_buffered(mut self) -> Result<Self> {
+		if let Some(body_stream) = &self.body_stream {
+			let mut body_stream = body_stream.lock().await.take();
+			if let Some(mut body_stream) = body_stream.take() {
+				while let Some(chunk) = body_stream.recv().await? {
+					self.inner.body_mut().extend_from_slice(&chunk);
+				}
+			}
+		}
+		self.body_stream = None;
+		Ok(self)
+	}
+
 	pub fn into_inner(self) -> http::Request<Vec<u8>> {
-		self.0
+		self.inner
 	}
 
 	pub fn into_body(self) -> Vec<u8> {
-		self.0.into_body()
+		self.inner.into_body()
 	}
 }
 
@@ -86,25 +140,29 @@ impl Deref for Request {
 	type Target = http::Request<Vec<u8>>;
 
 	fn deref(&self) -> &Self::Target {
-		&self.0
+		&self.inner
 	}
 }
 
 impl DerefMut for Request {
 	fn deref_mut(&mut self) -> &mut Self::Target {
-		&mut self.0
+		&mut self.inner
 	}
 }
 
 impl From<http::Request<Vec<u8>>> for Request {
 	fn from(value: http::Request<Vec<u8>>) -> Self {
-		Self(value)
+		Self {
+			inner: value,
+			body_stream: None,
+			cancel_token: CancellationToken::new(),
+		}
 	}
 }
 
 impl From<Request> for http::Request<Vec<u8>> {
 	fn from(value: Request) -> Self {
-		value.0
+		value.inner
 	}
 }
 
@@ -212,6 +270,59 @@ impl From<Response> for http::Response<Vec<u8>> {
 	}
 }
 
+pub struct StreamingResponse {
+	status: u16,
+	headers: HashMap<String, String>,
+	body_stream: mpsc::Receiver<ResponseChunk>,
+}
+
+impl StreamingResponse {
+	pub fn from_parts(
+		status: u16,
+		headers: HashMap<String, String>,
+		body_stream: mpsc::Receiver<ResponseChunk>,
+	) -> Result<Self> {
+		let status_code: http::StatusCode = status
+			.try_into()
+			.map_err(|error| invalid_http_response("status", format!("{status}: {error}")))?;
+		for (name, value) in &headers {
+			let _: http::header::HeaderName = name.parse().map_err(|error| {
+				invalid_http_response("header name", format!("{name}: {error}"))
+			})?;
+			let _: http::header::HeaderValue = value.parse().map_err(|error| {
+				invalid_http_response("header value", format!("{name}: {error}"))
+			})?;
+		}
+
+		Ok(Self {
+			status: status_code.as_u16(),
+			headers,
+			body_stream,
+		})
+	}
+
+	pub fn into_parts(self) -> (u16, HashMap<String, String>, mpsc::Receiver<ResponseChunk>) {
+		(self.status, self.headers, self.body_stream)
+	}
+}
+
+pub enum ActorHttpResponse {
+	Buffered(Response),
+	Stream(StreamingResponse),
+}
+
+impl From<Response> for ActorHttpResponse {
+	fn from(value: Response) -> Self {
+		Self::Buffered(value)
+	}
+}
+
+impl From<StreamingResponse> for ActorHttpResponse {
+	fn from(value: StreamingResponse) -> Self {
+		Self::Stream(value)
+	}
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StateDelta {
 	ActorState(Vec<u8>),
@@ -283,7 +394,7 @@ pub enum ActorEvent {
 	},
 	HttpRequest {
 		request: Request,
-		reply: Reply<Response>,
+		reply: Reply<ActorHttpResponse>,
 	},
 	QueueSend {
 		name: String,

--- a/rivetkit-rust/packages/rivetkit-core/src/actor/task.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/actor/task.rs
@@ -48,7 +48,7 @@ use crate::actor::context::ActorContext;
 use crate::actor::factory::ActorFactory;
 use crate::actor::lifecycle_hooks::{ActorEvents, ActorStart, Reply};
 use crate::actor::messages::{
-	ActorEvent, QueueSendResult, Request, Response, SerializeStateReason, StateDelta,
+	ActorEvent, ActorHttpResponse, QueueSendResult, Request, SerializeStateReason, StateDelta,
 	WorkflowKvWrite,
 };
 use crate::actor::metrics::startup_phase::StartupPhase;
@@ -64,7 +64,7 @@ use crate::types::{SaveStateOpts, format_actor_key};
 use crate::websocket::WebSocket;
 
 pub type ActionDispatchResult = std::result::Result<Vec<u8>, ActionDispatchError>;
-pub type HttpDispatchResult = Result<Response>;
+pub type HttpDispatchResult = Result<ActorHttpResponse>;
 
 const SERIALIZE_STATE_SHUTDOWN_SANITY_CAP: Duration = Duration::from_secs(15);
 #[cfg(test)]

--- a/rivetkit-rust/packages/rivetkit-core/src/lib.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/lib.rs
@@ -127,8 +127,8 @@ pub use actor::context::{
 pub use actor::factory::{ActorEntryFn, ActorFactory};
 pub use actor::lifecycle_hooks::{ActorEvents, ActorStart, Reply};
 pub use actor::messages::{
-	ActorEvent, QueueSendResult, QueueSendStatus, Request, Response, SerializeStateReason,
-	StateDelta, WorkflowKvWrite,
+	ActorEvent, ActorHttpResponse, QueueSendResult, QueueSendStatus, Request, Response,
+	SerializeStateReason, StateDelta, StreamingResponse, WorkflowKvWrite,
 };
 pub use actor::queue::{
 	CompletableQueueMessage, EnqueueAndWaitOpts, QueueMessage, QueueNextBatchOpts, QueueNextOpts,
@@ -142,6 +142,9 @@ pub use actor::state::RequestSaveOpts;
 pub use actor::task::{
 	ActionDispatchResult, ActorTask, DispatchCommand, HttpDispatchResult, LifecycleCommand,
 	LifecycleEvent, LifecycleState,
+};
+pub use rivet_envoy_client::config::{
+	HTTP_BODY_STREAM_CHANNEL_CAPACITY, HttpRequestBodyStream, ResponseChunk,
 };
 pub use actor::task_types::ShutdownKind;
 pub use actor::work_registry::{ActorWorkKind, ActorWorkPolicy};

--- a/rivetkit-rust/packages/rivetkit-core/src/registry/http.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/registry/http.rs
@@ -8,6 +8,36 @@ const HEADER_RIVET_ACTOR: &str = "x-rivet-actor";
 const HEADER_RIVET_ACTOR_GENERATION: &str = "x-rivet-actor-generation";
 const HEADER_RIVET_ACTOR_KEY: &str = "x-rivet-actor-key";
 
+struct RequestCancellationGuard {
+	token: Option<tokio_util::sync::CancellationToken>,
+}
+
+impl RequestCancellationGuard {
+	fn new(token: tokio_util::sync::CancellationToken) -> Self {
+		Self { token: Some(token) }
+	}
+
+	fn disarm(&mut self) {
+		self.token = None;
+	}
+}
+
+impl Drop for RequestCancellationGuard {
+	fn drop(&mut self) {
+		if let Some(token) = self.token.take() {
+			token.cancel();
+		}
+	}
+}
+
+async fn prepare_user_request(request: Request, streams_request_body: bool) -> Result<Request> {
+	if streams_request_body {
+		Ok(request)
+	} else {
+		request.into_buffered().await
+	}
+}
+
 impl RegistryDispatcher {
 	pub(super) async fn handle_fetch(
 		&self,
@@ -15,12 +45,20 @@ impl RegistryDispatcher {
 		request: HttpRequest,
 	) -> Result<HttpResponse> {
 		let original_path = request.path.clone();
-		let request = build_http_request(request).await?;
+		let request = build_http_request(request)?;
 		let route = RegistryHttpRoute::from_paths(
 			&original_path,
 			request.uri().path(),
 			self.handle_inspector_http_in_runtime,
 		)?;
+		let built_in_inspector_route =
+			request.uri().path().starts_with("/inspector/") && !self.handle_inspector_http_in_runtime;
+		let request = if matches!(route, RegistryHttpRoute::Framework(_)) || built_in_inspector_route
+		{
+			request.into_buffered().await?
+		} else {
+			request
+		};
 		if matches!(
 			route,
 			RegistryHttpRoute::Framework(FrameworkHttpRoute::Metrics)
@@ -45,6 +83,12 @@ impl RegistryDispatcher {
 			attach_actor_response_headers(&mut response, &actor);
 			return Ok(response);
 		}
+		let request = if matches!(route, RegistryHttpRoute::UserRawRequest)
+		{
+			prepare_user_request(request, instance.factory.streams_request_body()).await?
+		} else {
+			request
+		};
 
 		instance.ctx.cancel_sleep_timer();
 
@@ -70,6 +114,9 @@ impl RegistryDispatcher {
 		request: Request,
 	) -> Result<HttpResponse> {
 		let encoding = request_encoding(request.headers());
+		let request_method = request.method().clone();
+		let mut cancellation_guard =
+			RequestCancellationGuard::new(request.cancellation_token());
 		let (reply_tx, reply_rx) = oneshot::channel();
 		try_send_dispatch_command(
 			&instance.dispatch,
@@ -80,13 +127,24 @@ impl RegistryDispatcher {
 		)
 		.context("send actor task HTTP dispatch command")?;
 
-		match reply_rx
+		let reply = reply_rx
 			.await
-			.context("receive actor task HTTP dispatch reply")?
-		{
+			.context("receive actor task HTTP dispatch reply")?;
+
+		match reply {
 			Ok(response) => {
 				rearm_sleep_after_request(instance.ctx.clone());
-				build_envoy_response(response)
+				let mut response = build_envoy_response(response, &request_method)?;
+				if let Some(body_stream) = response.body_stream.as_mut() {
+					let token = cancellation_guard
+						.token
+						.take()
+						.expect("request cancellation token must be armed");
+					body_stream.set_on_drop(move || token.cancel());
+				} else {
+					cancellation_guard.disarm();
+				}
+				Ok(response)
 			}
 			Err(error) => {
 				tracing::error!(
@@ -622,16 +680,16 @@ pub(super) fn authorization_bearer_token_map(headers: &HashMap<String, String>) 
 		.and_then(|(_, value)| bearer_token_from_authorization(value))
 }
 
-pub(super) async fn build_http_request(request: HttpRequest) -> Result<Request> {
-	let mut body = request.body.unwrap_or_default();
-	if let Some(mut body_stream) = request.body_stream {
-		while let Some(chunk) = body_stream.recv().await {
-			body.extend_from_slice(&chunk);
-		}
-	}
-
+pub(super) fn build_http_request(request: HttpRequest) -> Result<Request> {
+	let body = request.body.unwrap_or_default();
 	let request_path = normalize_actor_request_path(&request.path);
-	Request::from_parts(&request.method, &request_path, request.headers, body)
+	Request::from_parts_with_stream(
+		&request.method,
+		&request_path,
+		request.headers,
+		body,
+		request.body_stream,
+	)
 		.with_context(|| format!("build actor request for `{}`", request.path))
 }
 
@@ -663,15 +721,47 @@ pub(super) fn is_actor_request_path(path: &str) -> bool {
 			.is_some_and(|byte| matches!(byte, b'/' | b'?'))
 }
 
-pub(super) fn build_envoy_response(response: Response) -> Result<HttpResponse> {
-	let (status, headers, body) = response.to_parts();
+pub(super) fn build_envoy_response(
+	response: ActorHttpResponse,
+	request_method: &http::Method,
+) -> Result<HttpResponse> {
+	match response {
+		ActorHttpResponse::Buffered(response) => {
+			let (status, headers, body) = response.to_parts();
+			Ok(HttpResponse {
+				status,
+				headers,
+				body: Some(if response_body_forbidden(request_method, status) {
+					Vec::new()
+				} else {
+					body
+				}),
+				body_stream: None,
+			})
+		}
+		ActorHttpResponse::Stream(response) => {
+			let (status, headers, body_stream) = response.into_parts();
+			if response_body_forbidden(request_method, status) {
+				Ok(HttpResponse {
+					status,
+					headers,
+					body: Some(Vec::new()),
+					body_stream: None,
+				})
+			} else {
+				Ok(HttpResponse {
+					status,
+					headers,
+					body: None,
+					body_stream: Some(body_stream.into()),
+				})
+			}
+		}
+	}
+}
 
-	Ok(HttpResponse {
-		status,
-		headers,
-		body: Some(body),
-		body_stream: None,
-	})
+pub(super) fn response_body_forbidden(request_method: &http::Method, status: u16) -> bool {
+	*request_method == http::Method::HEAD || matches!(status, 100..=199 | 204 | 304)
 }
 
 fn actor_specifier_for_instance(instance: &ActorTaskHandle) -> ActorSpecifier {

--- a/rivetkit-rust/packages/rivetkit-core/src/registry/mod.rs
+++ b/rivetkit-rust/packages/rivetkit-core/src/registry/mod.rs
@@ -40,7 +40,9 @@ use crate::actor::context::{ActorContext, InspectorAttachGuard};
 use crate::actor::factory::ActorFactory;
 use crate::actor::kv::LegacyActorKv;
 use crate::actor::lifecycle_hooks::Reply;
-use crate::actor::messages::{ActorEvent, QueueSendResult, Request, Response, StateDelta};
+use crate::actor::messages::{
+	ActorEvent, ActorHttpResponse, QueueSendResult, Request, StateDelta,
+};
 use crate::actor::task::{
 	ActorTask, DispatchCommand, LifecycleCommand, try_send_dispatch_command,
 	try_send_lifecycle_command,

--- a/rivetkit-rust/packages/rivetkit-core/tests/registry_http.rs
+++ b/rivetkit-rust/packages/rivetkit-core/tests/registry_http.rs
@@ -6,16 +6,20 @@ mod moved_tests {
 
 	use super::{
 		HttpResponseEncoding, authorization_bearer_token, authorization_bearer_token_map,
-		framework_action_error_response, framework_anyhow_error_response_with_actor,
-		is_actor_request_path, message_boundary_error_response,
+		build_envoy_response, framework_action_error_response,
+		framework_anyhow_error_response_with_actor, is_actor_request_path,
+		message_boundary_error_response,
 		message_boundary_error_response_with_actor, normalize_actor_request_path, request_encoding,
-		workflow_dispatch_result,
+		prepare_user_request, workflow_dispatch_result,
 	};
 	use crate::actor::action::ActionDispatchError;
+	use crate::actor::messages::{ActorHttpResponse, Request, Response, StreamingResponse};
 	use crate::error::ActorLifecycle as ActorLifecycleError;
 	use http::StatusCode;
+	use rivet_envoy_client::config::ResponseChunk;
 	use rivet_error::{ActorSpecifier, MacroMarker, RivetError, RivetErrorSchema};
 	use serde_json::json;
+	use tokio::sync::mpsc;
 	use vbare::OwnedVersionedData;
 
 	#[derive(RivetError)]
@@ -55,6 +59,107 @@ mod moved_tests {
 		let error = rivet_error::RivetError::extract(&error);
 		assert_eq!(error.group(), "actor");
 		assert_eq!(error.code(), "destroying");
+	}
+
+	#[tokio::test]
+	async fn build_envoy_response_preserves_stream_body() {
+		let (tx, rx) = mpsc::channel(1);
+		let stream = StreamingResponse::from_parts(
+			StatusCode::OK.as_u16(),
+			HashMap::from([("content-type".to_owned(), "text/event-stream".to_owned())]),
+			rx,
+		)
+		.expect("streaming response should build");
+
+		let mut response =
+			build_envoy_response(ActorHttpResponse::Stream(stream), &http::Method::GET)
+				.expect("envoy response should build");
+
+		assert_eq!(response.status, StatusCode::OK.as_u16());
+		assert_eq!(response.body, None);
+		assert!(response.body_stream.is_some());
+
+		tx.send(ResponseChunk::Data {
+			data: b"data: ok\n\n".to_vec(),
+			finish: true,
+		})
+		.await
+		.expect("send response chunk");
+		let chunk = response
+			.body_stream
+			.as_mut()
+			.expect("body stream should exist")
+			.recv()
+			.await
+			.expect("stream chunk should arrive");
+		match chunk {
+			ResponseChunk::Data { data, finish } => {
+				assert_eq!(data, b"data: ok\n\n");
+				assert!(finish);
+			}
+			ResponseChunk::Error(error) => panic!("unexpected response chunk error: {error}"),
+		}
+	}
+
+	#[tokio::test]
+	async fn non_streaming_factory_request_is_buffered_before_dispatch() {
+		let (body_tx, body_rx) = mpsc::channel(1);
+		let (abort_tx, abort_rx) = tokio::sync::watch::channel::<
+			Option<rivet_envoy_client::config::HttpRequestBodyError>,
+		>(None);
+		body_tx
+			.send(b"-stream".to_vec())
+			.await
+			.expect("send body chunk");
+		drop(body_tx);
+		drop(abort_tx);
+		let request = Request::from_parts_with_stream(
+			"POST",
+			"/",
+			HashMap::new(),
+			b"prefix".to_vec(),
+			Some(rivet_envoy_client::config::HttpRequestBodyStream::new(
+				body_rx, abort_rx,
+			)),
+		)
+		.expect("build streaming request");
+
+		let request = prepare_user_request(request, false)
+			.await
+			.expect("buffer request");
+
+		assert!(!request.has_body_stream());
+		assert_eq!(request.into_body(), b"prefix-stream");
+	}
+
+	#[test]
+	fn build_envoy_response_drops_stream_for_body_forbidden_status() {
+		let (_tx, rx) = mpsc::channel(1);
+		let stream =
+			StreamingResponse::from_parts(StatusCode::NO_CONTENT.as_u16(), HashMap::new(), rx)
+				.expect("streaming response should build");
+
+		let response = build_envoy_response(ActorHttpResponse::Stream(stream), &http::Method::GET)
+			.expect("envoy response should build");
+
+		assert_eq!(response.status, StatusCode::NO_CONTENT.as_u16());
+		assert_eq!(response.body, Some(Vec::new()));
+		assert!(response.body_stream.is_none());
+	}
+
+	#[test]
+	fn build_envoy_response_drops_buffered_body_for_head() {
+		let response =
+			Response::from_parts(StatusCode::OK.as_u16(), HashMap::new(), b"body".to_vec())
+				.expect("buffered response should build");
+
+		let response =
+			build_envoy_response(ActorHttpResponse::Buffered(response), &http::Method::HEAD)
+				.expect("envoy response should build");
+
+		assert_eq!(response.status, StatusCode::OK.as_u16());
+		assert_eq!(response.body, Some(Vec::new()));
+		assert!(response.body_stream.is_none());
 	}
 
 	#[test]

--- a/rivetkit-rust/packages/rivetkit/src/event.rs
+++ b/rivetkit-rust/packages/rivetkit/src/event.rs
@@ -6,8 +6,8 @@ use rivetkit_core::actor::ShutdownKind;
 use rivetkit_core::actor::schedule::ScheduledFireInfo;
 use rivetkit_core::error::ActorRuntime;
 use rivetkit_core::{
-	ActorEvent, QueueSendResult, QueueSendStatus, Reply, Request, Response, SerializeStateReason,
-	StateDelta, WebSocket,
+	ActorEvent, ActorHttpResponse, QueueSendResult, QueueSendStatus, Reply, Request, Response,
+	SerializeStateReason, StateDelta, WebSocket,
 };
 use serde::{
 	Serialize,
@@ -964,7 +964,7 @@ impl de::Expected for Expected {
 #[must_use = "reply to the HTTP call or dropping it sends actor/dropped_reply"]
 pub struct HttpCall {
 	pub(crate) request: Option<Request>,
-	pub(crate) reply: Option<Reply<Response>>,
+	pub(crate) reply: Option<Reply<ActorHttpResponse>>,
 }
 
 impl Drop for HttpCall {
@@ -983,7 +983,7 @@ impl Drop for HttpCall {
 #[derive(Debug)]
 #[must_use = "reply to the deferred HTTP call or dropping it sends actor/dropped_reply"]
 pub struct HttpReply {
-	reply: Option<Reply<Response>>,
+	reply: Option<Reply<ActorHttpResponse>>,
 }
 
 impl Drop for HttpReply {
@@ -997,7 +997,7 @@ impl Drop for HttpReply {
 impl HttpReply {
 	pub fn reply(mut self, response: Response) {
 		if let Some(reply) = self.reply.take() {
-			reply.send(Ok(response));
+			reply.send(Ok(ActorHttpResponse::Buffered(response)));
 		}
 	}
 
@@ -1042,7 +1042,7 @@ impl HttpCall {
 
 	pub fn reply(mut self, response: Response) {
 		if let Some(reply) = self.reply.take() {
-			reply.send(Ok(response));
+			reply.send(Ok(ActorHttpResponse::Buffered(response)));
 		}
 	}
 
@@ -1908,6 +1908,9 @@ mod tests {
 			.block_on(reply_rx)
 			.expect("receive http reply")
 			.expect("http reply_status should succeed");
+		let ActorHttpResponse::Buffered(response) = response else {
+			panic!("http reply_status should return buffered response");
+		};
 		assert_eq!(response.status().as_u16(), 404);
 		assert!(response.body().is_empty());
 	}

--- a/rivetkit-rust/packages/rivetkit/src/start.rs
+++ b/rivetkit-rust/packages/rivetkit/src/start.rs
@@ -311,7 +311,12 @@ async fn handle_actor_event<A: Actor>(
 			}
 		}
 		ActorEvent::HttpRequest { request, reply } => {
-			reply.send(actor.on_fetch(ctx, request).await);
+			reply.send(
+				actor
+					.on_fetch(ctx, request)
+					.await
+					.map(rivetkit_core::ActorHttpResponse::Buffered),
+			);
 		}
 		ActorEvent::QueueSend {
 			name,
@@ -927,6 +932,9 @@ mod tests {
 		.expect("send http event");
 
 		let response = reply_rx.await.expect("http reply").expect("http response");
+		let rivetkit_core::ActorHttpResponse::Buffered(response) = response else {
+			panic!("default fetch should return buffered response");
+		};
 		assert_eq!(response.status().as_u16(), 404);
 
 		request_sleep(&tx).await;

--- a/rivetkit-typescript/packages/rivetkit-napi/index.d.ts
+++ b/rivetkit-typescript/packages/rivetkit-napi/index.d.ts
@@ -48,6 +48,7 @@ export interface JsHttpResponse {
   status?: number
   headers?: Record<string, string>
   body?: Buffer
+  stream?: boolean
 }
 export interface JsQueueSendResult {
   status: string
@@ -330,6 +331,16 @@ export declare class ActorContext {
   registerTask(promise: Promise<any>): void
   runtimeState(): object
   clearRuntimeState(): void
+}
+export declare class HttpResponseBodyStream {
+  cancelled(): Promise<void>
+  write(chunk: Buffer): Promise<void>
+  end(): Promise<void>
+  error(message: string): Promise<void>
+}
+export declare class HttpRequestBodyStream {
+  read(): Promise<Buffer | null>
+  cancel(): Promise<void>
 }
 export declare class NapiActorFactory {
   constructor(callbacks: object, config?: JsActorConfig | undefined | null)

--- a/rivetkit-typescript/packages/rivetkit-napi/index.js
+++ b/rivetkit-typescript/packages/rivetkit-napi/index.js
@@ -310,11 +310,13 @@ if (!nativeBinding) {
   throw new Error(`Failed to load native binding`)
 }
 
-const { ActorContext, decodeInspectorRequest, encodeInspectorResponse, NapiActorFactory, CancellationToken, ConnHandle, JsNativeDatabase, JsSqliteTransaction, Kv, Queue, QueueMessage, CoreRegistry, Schedule, WebSocket } = nativeBinding
+const { ActorContext, decodeInspectorRequest, encodeInspectorResponse, HttpResponseBodyStream, HttpRequestBodyStream, NapiActorFactory, CancellationToken, ConnHandle, JsNativeDatabase, JsSqliteTransaction, Kv, Queue, QueueMessage, CoreRegistry, Schedule, WebSocket } = nativeBinding
 
 module.exports.ActorContext = ActorContext
 module.exports.decodeInspectorRequest = decodeInspectorRequest
 module.exports.encodeInspectorResponse = encodeInspectorResponse
+module.exports.HttpResponseBodyStream = HttpResponseBodyStream
+module.exports.HttpRequestBodyStream = HttpRequestBodyStream
 module.exports.NapiActorFactory = NapiActorFactory
 module.exports.CancellationToken = CancellationToken
 module.exports.ConnHandle = ConnHandle

--- a/rivetkit-typescript/packages/rivetkit-napi/src/actor_factory.rs
+++ b/rivetkit-typescript/packages/rivetkit-napi/src/actor_factory.rs
@@ -11,9 +11,11 @@ use rivet_error::{ActorSpecifier, RivetError, RivetErrorKind};
 use rivetkit_core::inspector::InspectorTabEntry;
 use rivetkit_core::{
 	ActionDefinition, ActorConfig, ActorConfigInput, ActorContext as CoreActorContext,
-	ActorFactory as CoreActorFactory, ConnHandle as CoreConnHandle, Request, Response,
-	WebSocket as CoreWebSocket,
+	ActorFactory as CoreActorFactory, ActorHttpResponse, ConnHandle as CoreConnHandle,
+	HTTP_BODY_STREAM_CHANNEL_CAPACITY, HttpRequestBodyStream as CoreHttpRequestBodyStream, Request,
+	Response, ResponseChunk, StreamingResponse, WebSocket as CoreWebSocket,
 };
+use tokio::sync::{Mutex as TokioMutex, mpsc};
 
 use crate::actor_context::{ActorContext, StateDeltaPayload};
 use crate::cancellation_token::CancellationToken;
@@ -45,6 +47,131 @@ pub struct JsHttpResponse {
 	pub status: Option<u16>,
 	pub headers: Option<HashMap<String, String>>,
 	pub body: Option<Buffer>,
+	pub stream: Option<bool>,
+}
+
+#[napi]
+#[derive(Clone)]
+pub struct HttpResponseBodyStream {
+	tx: Arc<TokioMutex<Option<mpsc::Sender<ResponseChunk>>>>,
+	closed_tx: mpsc::Sender<ResponseChunk>,
+}
+
+impl HttpResponseBodyStream {
+	fn new(tx: mpsc::Sender<ResponseChunk>) -> Self {
+		Self {
+			tx: Arc::new(TokioMutex::new(Some(tx.clone()))),
+			closed_tx: tx,
+		}
+	}
+
+	async fn take_sender(&self) -> napi::Result<mpsc::Sender<ResponseChunk>> {
+		self.tx
+			.lock()
+			.await
+			.take()
+			.ok_or_else(|| napi::Error::from_reason("http response body stream is already closed"))
+	}
+}
+
+#[napi]
+impl HttpResponseBodyStream {
+	#[napi]
+	pub async fn cancelled(&self) {
+		self.closed_tx.closed().await;
+	}
+
+	#[napi]
+	pub async fn write(&self, chunk: Buffer) -> napi::Result<()> {
+		let tx = self.tx.lock().await.clone().ok_or_else(|| {
+			napi::Error::from_reason("http response body stream is already closed")
+		})?;
+		tx.send(ResponseChunk::Data {
+			data: chunk.to_vec(),
+			finish: false,
+		})
+		.await
+		.map_err(|_| napi::Error::from_reason("http response body stream receiver dropped"))
+	}
+
+	#[napi]
+	pub async fn end(&self) -> napi::Result<()> {
+		let tx = self.take_sender().await?;
+		tx.send(ResponseChunk::Data {
+			data: Vec::new(),
+			finish: true,
+		})
+		.await
+		.map_err(|_| napi::Error::from_reason("http response body stream receiver dropped"))
+	}
+
+	#[napi]
+	pub async fn error(&self, message: String) -> napi::Result<()> {
+		let tx = self.take_sender().await?;
+		tx.send(ResponseChunk::Error(message))
+			.await
+			.map_err(|_| napi::Error::from_reason("http response body stream receiver dropped"))
+	}
+}
+
+#[napi]
+pub struct HttpRequestBodyStream {
+	initial_body: Arc<TokioMutex<Option<Vec<u8>>>>,
+	rx: Arc<TokioMutex<Option<CoreHttpRequestBodyStream>>>,
+	cancel: tokio_util::sync::CancellationToken,
+}
+
+impl HttpRequestBodyStream {
+	fn new(initial_body: Vec<u8>, rx: CoreHttpRequestBodyStream) -> Self {
+		Self {
+			initial_body: Arc::new(TokioMutex::new(Some(initial_body))),
+			rx: Arc::new(TokioMutex::new(Some(rx))),
+			cancel: tokio_util::sync::CancellationToken::new(),
+		}
+	}
+}
+
+#[napi]
+impl HttpRequestBodyStream {
+	#[napi]
+	pub async fn read(&self) -> napi::Result<Option<Buffer>> {
+		if self.cancel.is_cancelled() {
+			return Ok(None);
+		}
+
+		if let Some(initial_body) = self.initial_body.lock().await.take() {
+			if self.cancel.is_cancelled() {
+				return Ok(None);
+			}
+			if !initial_body.is_empty() {
+				return Ok(Some(Buffer::from(initial_body)));
+			}
+		}
+
+		let mut rx = self.rx.lock().await;
+		let Some(rx) = rx.as_mut() else {
+			return Ok(None);
+		};
+		tokio::select! {
+			biased;
+			_ = self.cancel.cancelled() => Ok(None),
+			chunk = rx.recv() => match chunk {
+				Ok(Some(chunk)) => Ok(Some(Buffer::from(chunk))),
+				Ok(None) => Ok(None),
+				Err(error) => Err(napi::Error::from_reason(format!(
+					"streaming request body aborted: {error}"
+				))),
+			},
+		}
+	}
+
+	#[napi]
+	pub async fn cancel(&self) -> napi::Result<()> {
+		self.cancel.cancel();
+		self.initial_body.lock().await.take();
+		self.rx.lock().await.take();
+		Ok(())
+	}
 }
 
 #[napi(object)]
@@ -144,6 +271,7 @@ pub(crate) struct HttpRequestPayload {
 	pub(crate) ctx: CoreActorContext,
 	pub(crate) request: Request,
 	pub(crate) cancel_token: Option<tokio_util::sync::CancellationToken>,
+	pub(crate) response_stream: Option<HttpResponseBodyStream>,
 }
 
 #[derive(Clone)]
@@ -329,14 +457,14 @@ impl NapiActorFactory {
 		// Reject malformed config (empty ids/labels, duplicate ids, custom
 		// tabs colliding with built-in ids, etc.) before the actor starts.
 		actor_config.validate().map_err(napi_anyhow_error)?;
-		let inner = Arc::new(CoreActorFactory::new_with_manual_startup_ready(
-			actor_config,
-			move |start| {
+		let inner = Arc::new(
+			CoreActorFactory::new_with_manual_startup_ready(actor_config, move |start| {
 				let bindings = Arc::clone(&adapter_bindings);
 				let config = Arc::clone(&loop_config);
 				Box::pin(async move { run_adapter_loop(bindings, config, start).await })
-			},
-		));
+			})
+			.with_streaming_request_body(),
+		);
 
 		Ok(Self {
 			_bindings: bindings,
@@ -553,8 +681,11 @@ where
 pub(crate) async fn call_request(
 	callback_name: &str,
 	callback: &CallbackTsfn<HttpRequestPayload>,
-	payload: HttpRequestPayload,
-) -> Result<Response> {
+	mut payload: HttpRequestPayload,
+) -> Result<ActorHttpResponse> {
+	let (body_tx, body_rx) = mpsc::channel(HTTP_BODY_STREAM_CHANNEL_CAPACITY);
+	payload.response_stream = Some(HttpResponseBodyStream::new(body_tx));
+
 	log_tsfn_invocation(callback_name, &payload);
 	let promise = callback
 		.call_async::<Promise<JsHttpResponse>>(Ok(payload))
@@ -563,14 +694,21 @@ pub(crate) async fn call_request(
 	let response = promise
 		.await
 		.map_err(|error| callback_error(callback_name, error))?;
-	Response::from_parts(
-		response.status.unwrap_or(200),
-		response.headers.unwrap_or_default(),
-		response
-			.body
-			.unwrap_or_else(|| Buffer::from(Vec::new()))
-			.to_vec(),
-	)
+	let status = response.status.unwrap_or(200);
+	let headers = response.headers.unwrap_or_default();
+	if response.stream.unwrap_or(false) {
+		StreamingResponse::from_parts(status, headers, body_rx).map(ActorHttpResponse::Stream)
+	} else {
+		Response::from_parts(
+			status,
+			headers,
+			response
+				.body
+				.unwrap_or_else(|| Buffer::from(Vec::new()))
+				.to_vec(),
+		)
+		.map(ActorHttpResponse::Buffered)
+	}
 }
 
 #[allow(dead_code)]
@@ -824,6 +962,10 @@ fn build_http_request_payload(
 	let mut object = env.create_object()?;
 	object.set("ctx", ActorContext::new(payload.ctx))?;
 	object.set("request", build_request_object(env, payload.request)?)?;
+	match payload.response_stream {
+		Some(response_stream) => object.set("responseBodyStream", response_stream)?,
+		None => object.set("responseBodyStream", env.get_undefined()?)?,
+	}
 	match payload.cancel_token {
 		Some(cancel_token) => object.set("cancelToken", CancellationToken::new(cancel_token))?,
 		None => object.set("cancelToken", env.get_undefined()?)?,
@@ -973,11 +1115,18 @@ fn build_serialize_state_payload(
 
 fn build_request_object(env: &Env, request: Request) -> napi::Result<JsObject> {
 	let (method, uri, headers, body) = request.to_parts();
+	let body_stream = request.take_body_stream();
 	let mut request_object = env.create_object()?;
 	request_object.set("method", method)?;
 	request_object.set("uri", uri)?;
 	request_object.set("headers", headers)?;
-	request_object.set("body", Buffer::from(body))?;
+	if let Some(body_stream) = body_stream {
+		request_object.set("body", env.get_undefined()?)?;
+		request_object.set("bodyStream", HttpRequestBodyStream::new(body, body_stream))?;
+	} else {
+		request_object.set("body", Buffer::from(body))?;
+		request_object.set("bodyStream", env.get_undefined()?)?;
+	}
 	Ok(request_object)
 }
 

--- a/rivetkit-typescript/packages/rivetkit-napi/src/napi_actor_events.rs
+++ b/rivetkit-typescript/packages/rivetkit-napi/src/napi_actor_events.rs
@@ -1151,7 +1151,23 @@ async fn call_http_request(
 	ctx: &ActorContext,
 	request: rivetkit_core::Request,
 	cancel_token: Option<CancellationToken>,
-) -> Result<rivetkit_core::Response> {
+) -> Result<rivetkit_core::ActorHttpResponse> {
+	let request_cancel_token = request.cancellation_token();
+	let cancel_token = match cancel_token {
+		Some(dispatch_cancel_token) => {
+			let combined_cancel_token = CancellationToken::new();
+			let combined_cancel_token_task = combined_cancel_token.clone();
+			tokio::spawn(async move {
+				tokio::select! {
+					_ = request_cancel_token.cancelled() => {}
+					_ = dispatch_cancel_token.cancelled() => {}
+				}
+				combined_cancel_token_task.cancel();
+			});
+			Some(combined_cancel_token)
+		}
+		None => Some(request_cancel_token),
+	};
 	call_request(
 		"onRequest",
 		callback,
@@ -1159,6 +1175,7 @@ async fn call_http_request(
 			ctx: ctx.inner().clone(),
 			request,
 			cancel_token,
+			response_stream: None,
 		},
 	)
 	.await

--- a/rivetkit-typescript/packages/rivetkit-napi/tests/actor_factory.rs
+++ b/rivetkit-typescript/packages/rivetkit-napi/tests/actor_factory.rs
@@ -7,10 +7,12 @@ mod moved_tests {
 
 	use parking_lot::Mutex;
 	use rivet_error::{MacroMarker, RivetError, RivetErrorSchema};
+	use rivetkit_core::HttpRequestBodyStream as CoreHttpRequestBodyStream;
+	use tokio::sync::{mpsc, watch};
 	use tracing::Level;
 	use tracing_subscriber::fmt::MakeWriter;
 
-	use super::{BRIDGE_RIVET_ERROR_PREFIX, parse_bridge_rivet_error};
+	use super::{BRIDGE_RIVET_ERROR_PREFIX, HttpRequestBodyStream, parse_bridge_rivet_error};
 
 	static AUTH_FORBIDDEN_SCHEMA: RivetErrorSchema = RivetErrorSchema {
 		group: "auth",
@@ -123,5 +125,26 @@ mod moved_tests {
 		let logs = capture.output();
 		assert!(logs.contains("malformed BridgeRivetErrorPayload"));
 		assert!(logs.contains("parse_err"));
+	}
+
+	#[tokio::test]
+	async fn cancelling_http_request_body_drops_core_receiver() {
+		let (body_tx, body_rx) = mpsc::channel(1);
+		let (_abort_tx, abort_rx) = watch::channel(None);
+		let stream = HttpRequestBodyStream::new(
+			Vec::new(),
+			CoreHttpRequestBodyStream::new(body_rx, abort_rx),
+		);
+
+		stream.cancel().await.expect("cancel request body stream");
+
+		assert!(body_tx.is_closed());
+		assert!(
+			stream
+				.read()
+				.await
+				.expect("read cancelled request body")
+				.is_none()
+		);
 	}
 }

--- a/rivetkit-typescript/packages/rivetkit-wasm/src/lib.rs
+++ b/rivetkit-typescript/packages/rivetkit-wasm/src/lib.rs
@@ -811,6 +811,13 @@ async fn dispatch_event(callbacks: &WasmCallbacks, ctx: &WasmActorContext, event
 						.ok_or_else(|| anyhow!("wasm onRequest callback is not implemented"))?;
 					let payload = object();
 					set_anyhow(&payload, "ctx", JsValue::from(ctx.clone()))?;
+					set_anyhow(
+						&payload,
+						"cancelToken",
+						JsValue::from(WasmCancellationToken {
+							inner: request.cancellation_token(),
+						}),
+					)?;
 					set_anyhow(&payload, "request", request_to_js(request)?)?;
 					let value = call_callback(callback, &payload.into()).await?;
 					response_from_js(value)

--- a/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/raw-http.ts
+++ b/rivetkit-typescript/packages/rivetkit/fixtures/driver-test-suite/raw-http.ts
@@ -1,11 +1,25 @@
 import { Hono } from "hono";
 import { actor, type RequestContext } from "rivetkit";
 
+type RawHttpConnParams = { streamLifecycle?: boolean } | undefined;
+
 export const rawHttpActor = actor({
 	state: {
 		requestCount: 0,
+		requestAbortStarted: false,
+		requestAbortObserved: false,
+		responseAbortStarted: false,
+		responseAbortObserved: false,
+		streamResponseFinished: false,
+		streamDisconnectedBeforeFinish: false,
 	},
-	onRequest(
+	onBeforeConnect: (_c, _params: RawHttpConnParams) => {},
+	onDisconnect: (c, conn) => {
+		if (conn.params?.streamLifecycle && !c.state.streamResponseFinished) {
+			c.state.streamDisconnectedBeforeFinish = true;
+		}
+	},
+	async onRequest(
 		ctx: RequestContext<any, any, any, any, any, any>,
 		request: Request,
 	) {
@@ -31,9 +45,153 @@ export const rawHttpActor = actor({
 			});
 		}
 
+		if (url.pathname === "/api/stream") {
+			const encoder = new TextEncoder();
+			return new Response(
+				new ReadableStream<Uint8Array>({
+					async start(controller) {
+						controller.enqueue(encoder.encode("data: first\n\n"));
+						await new Promise((resolve) =>
+							setTimeout(resolve, 150),
+						);
+						controller.enqueue(encoder.encode("data: second\n\n"));
+						controller.close();
+					},
+				}),
+				{
+					headers: { "Content-Type": "text/event-stream" },
+				},
+			);
+		}
+
+		if (url.pathname === "/api/stream-lifecycle") {
+			const encoder = new TextEncoder();
+			ctx.state.streamResponseFinished = false;
+			ctx.state.streamDisconnectedBeforeFinish = false;
+			return new Response(
+				new ReadableStream<Uint8Array>({
+					async start(controller) {
+						controller.enqueue(encoder.encode("data: first\n\n"));
+						await new Promise((resolve) =>
+							setTimeout(resolve, 150),
+						);
+						ctx.state.streamResponseFinished = true;
+						controller.close();
+					},
+				}),
+				{
+					headers: { "Content-Type": "text/event-stream" },
+				},
+			);
+		}
+
+		if (url.pathname === "/api/wait-for-response-abort") {
+			const encoder = new TextEncoder();
+			ctx.state.responseAbortStarted = true;
+			ctx.state.responseAbortObserved = false;
+			return new Response(
+				new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.enqueue(encoder.encode("data: ready\n\n"));
+						const observeAbort = () => {
+							ctx.state.responseAbortObserved = true;
+						};
+						if (request.signal.aborted) {
+							observeAbort();
+						} else {
+							request.signal.addEventListener(
+								"abort",
+								observeAbort,
+								{ once: true },
+							);
+						}
+					},
+				}),
+				{
+					headers: { "Content-Type": "text/event-stream" },
+				},
+			);
+		}
+
+		if (url.pathname === "/api/sse-proxy") {
+			const target = url.searchParams.get("target");
+			if (!target) {
+				return new Response("Missing target", { status: 400 });
+			}
+
+			const upstreamHeaders = new Headers();
+			for (const name of ["accept", "cache-control", "last-event-id"]) {
+				const value = request.headers.get(name);
+				if (value) {
+					upstreamHeaders.set(name, value);
+				}
+			}
+
+			const upstream = await fetch(target, {
+				headers: upstreamHeaders,
+				signal: request.signal,
+			});
+			return new Response(upstream.body, {
+				status: upstream.status,
+				headers: upstream.headers,
+			});
+		}
+
+		if (url.pathname === "/api/upload-stream" && method === "POST") {
+			const reader = request.body?.getReader();
+			const sizes: number[] = [];
+			let totalBytes = 0;
+			if (reader) {
+				for (;;) {
+					const next = await reader.read();
+					if (next.done) break;
+					sizes.push(next.value.byteLength);
+					totalBytes += next.value.byteLength;
+				}
+			}
+			return new Response(
+				JSON.stringify({
+					chunkCount: sizes.length,
+					contentLength: request.headers.get("content-length"),
+					sizes,
+					totalBytes,
+				}),
+				{
+					headers: { "Content-Type": "application/json" },
+				},
+			);
+		}
+
+		if (url.pathname === "/api/cancel-upload" && method === "POST") {
+			await request.body?.cancel();
+			return new Response("upload cancelled");
+		}
+
+		if (url.pathname === "/api/wait-for-request-abort") {
+			ctx.state.requestAbortStarted = true;
+			await new Promise<void>((resolve) => {
+				if (request.signal.aborted) {
+					resolve();
+				} else {
+					request.signal.addEventListener("abort", () => resolve(), {
+						once: true,
+					});
+				}
+			});
+			ctx.state.requestAbortObserved = true;
+			return new Response("aborted");
+		}
+
 		if (url.pathname === "/api/state") {
 			return new Response(
 				JSON.stringify({
+					requestAbortStarted: ctx.state.requestAbortStarted,
+					requestAbortObserved: ctx.state.requestAbortObserved,
+					responseAbortStarted: ctx.state.responseAbortStarted,
+					responseAbortObserved: ctx.state.responseAbortObserved,
+					streamResponseFinished: ctx.state.streamResponseFinished,
+					streamDisconnectedBeforeFinish:
+						ctx.state.streamDisconnectedBeforeFinish,
 					requestCount: ctx.state.requestCount,
 				}),
 				{

--- a/rivetkit-typescript/packages/rivetkit/src/engine-client/actor-http-client.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/engine-client/actor-http-client.ts
@@ -17,8 +17,7 @@ export async function sendHttpRequestToGateway(
 	actorRequest: Request,
 	options: HttpGatewayRequestOptions = {},
 ): Promise<Response> {
-	// Handle body properly based on method and presence
-	let bodyToSend: ArrayBuffer | null = null;
+	let bodyToSend: ReadableStream<Uint8Array> | null = null;
 	const guardHeaders = buildGuardHeaders(runConfig, actorRequest, options);
 
 	if (actorRequest.method !== "GET" && actorRequest.method !== "HEAD") {
@@ -26,28 +25,22 @@ export async function sendHttpRequestToGateway(
 			throw new Error("Request body has already been consumed");
 		}
 
-		// TODO: This buffers the entire request in memory every time. We
-		// need to properly implement streaming bodies.
-		const reqBody = await actorRequest.arrayBuffer();
-
-		if (reqBody.byteLength !== 0) {
-			bodyToSend = reqBody;
-
-			// If this is a streaming request, we need to convert the headers
-			// for the basic array buffer.
+		if (actorRequest.body) {
+			bodyToSend = actorRequest.body;
 			guardHeaders.delete("transfer-encoding");
 			guardHeaders.delete("content-length");
 		}
 	}
 
-	const guardRequest = new Request(gatewayUrl, {
-		method: actorRequest.method,
-		headers: guardHeaders,
-		body: bodyToSend,
-		signal: actorRequest.signal,
-	});
-
-	return mutableResponse(await fetch(guardRequest));
+	return mutableResponse(
+		await fetch(gatewayUrl, {
+			method: actorRequest.method,
+			headers: guardHeaders,
+			body: bodyToSend,
+			signal: actorRequest.signal,
+			...(bodyToSend ? { duplex: "half" } : {}),
+		} as RequestInit),
+	);
 }
 
 function mutableResponse(fetchRes: Response): Response {

--- a/rivetkit-typescript/packages/rivetkit/src/registry/native.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/native.ts
@@ -105,6 +105,19 @@ import { createWriteThroughProxy } from "./write-through-proxy";
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
+const HTTP_BODY_CHUNK_SIZE = 64 * 1024;
+
+interface NativeHttpResponseBodyStream {
+	cancelled(): Promise<void>;
+	write(chunk: Uint8Array): Promise<void>;
+	end(): Promise<void>;
+	error(message: string): Promise<void>;
+}
+
+interface NativeHttpRequestBodyStream {
+	read(): Promise<Uint8Array | null | undefined>;
+	cancel(): Promise<void>;
+}
 
 type ResolvedRuntimeKind = Exclude<RuntimeKind, "auto">;
 type RuntimeHostKind = "node-like" | "edge-like";
@@ -1168,32 +1181,166 @@ function buildRequest(init: {
 	uri: string;
 	headers?: Record<string, string>;
 	body?: RuntimeBytes;
+	bodyStream?: NativeHttpRequestBodyStream;
+	signal?: AbortSignal;
+	abortController?: AbortController;
 }): Request {
 	const url = init.uri.startsWith("http")
 		? init.uri
 		: new URL(init.uri, "http://127.0.0.1").toString();
-	const body =
-		init.body && init.body.length > 0
-			? runtimeBytesToArrayBuffer(init.body)
-			: undefined;
+	const method = init.method.toUpperCase();
+	const bodyForbidden = method === "GET" || method === "HEAD";
+	const body = bodyForbidden
+		? undefined
+		: init.bodyStream
+			? new ReadableStream<Uint8Array>({
+					async pull(controller) {
+						try {
+							if (init.body && init.body.length > 0) {
+								controller.enqueue(new Uint8Array(init.body));
+								init.body = undefined;
+								return;
+							}
+							const chunk = await init.bodyStream?.read();
+							if (!chunk) {
+								controller.close();
+							} else {
+								controller.enqueue(new Uint8Array(chunk));
+							}
+						} catch (error) {
+							init.abortController?.abort(error);
+							controller.error(error);
+						}
+					},
+					async cancel() {
+						await init.bodyStream?.cancel();
+					},
+				})
+			: init.body && init.body.length > 0
+				? runtimeBytesToArrayBuffer(init.body)
+				: undefined;
+	const streamInit =
+		init.bodyStream && !bodyForbidden ? { duplex: "half" } : {};
 	return new Request(url, {
-		method: init.method,
+		method,
 		headers: init.headers,
 		body,
-	});
+		signal: init.abortController?.signal ?? init.signal,
+		...streamInit,
+	} as RequestInit);
 }
 
-async function toRuntimeHttpResponse(
+async function writeHttpResponseChunk(
+	stream: NativeHttpResponseBodyStream,
+	chunk: Uint8Array,
+) {
+	for (
+		let offset = 0;
+		offset < chunk.byteLength;
+		offset += HTTP_BODY_CHUNK_SIZE
+	) {
+		await stream.write(
+			chunk.subarray(offset, offset + HTTP_BODY_CHUNK_SIZE),
+		);
+	}
+}
+
+async function pumpRuntimeHttpResponseBody(
+	reader: ReadableStreamDefaultReader<Uint8Array>,
+	stream: NativeHttpResponseBodyStream,
+) {
+	const cancelled = stream
+		.cancelled()
+		.then(() => ({ cancelled: true }) as const);
+	try {
+		for (;;) {
+			const read = reader
+				.read()
+				.then((next) => ({ cancelled: false, next }) as const);
+			const result = await Promise.race([read, cancelled]);
+			if (result.cancelled) {
+				await reader.cancel(
+					new Error("native http response stream receiver dropped"),
+				);
+				return;
+			}
+			const { next } = result;
+			if (next.done) {
+				await stream.end();
+				return;
+			}
+			if (next.value?.byteLength) {
+				await writeHttpResponseChunk(stream, next.value);
+			}
+		}
+	} catch (error) {
+		try {
+			await stream.error(stringifyError(error));
+		} catch (streamError) {
+			logger().debug({
+				msg: "failed to report native http response stream error",
+				error: streamError,
+			});
+		}
+		try {
+			await reader.cancel(error);
+		} catch {
+			// Reader may already be closed after a native-side disconnect.
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+interface RuntimeHttpResponseConversion {
+	response: RuntimeHttpResponse;
+	bodyCompletion?: Promise<void>;
+}
+
+async function convertRuntimeHttpResponse(
 	response: ResponseLike,
-): Promise<RuntimeHttpResponse> {
+	responseBodyStream?: NativeHttpResponseBodyStream,
+): Promise<RuntimeHttpResponseConversion> {
 	const headers = Object.fromEntries(response.headers.entries());
-	const body = new Uint8Array(await response.arrayBuffer());
+	if (!response.body) {
+		return {
+			response: {
+				status: response.status,
+				headers,
+				body: new Uint8Array(),
+			},
+		};
+	}
+
+	if (responseBodyStream) {
+		const reader = response.body.getReader();
+		const bodyCompletion = pumpRuntimeHttpResponseBody(
+			reader,
+			responseBodyStream,
+		);
+		return {
+			response: {
+				status: response.status,
+				headers,
+				stream: true,
+			},
+			bodyCompletion,
+		};
+	}
+
 	return {
-		status: response.status,
-		headers,
-		body,
+		response: {
+			status: response.status,
+			headers,
+			body: new Uint8Array(await response.arrayBuffer()),
+		},
 	};
 }
+
+export const nativeRegistryTestInternals = {
+	buildRequest,
+	convertRuntimeHttpResponse,
+};
 
 function toActorKey(
 	segments: Array<{
@@ -3716,19 +3863,22 @@ export function buildNativeFactory(
 		);
 	const maybeHandleNativeInspectorRequest = async (
 		ctx: ActorContextHandle,
-		_rawRequest: {
+		rawRequest: {
 			method: string;
 			uri: string;
 			headers?: Record<string, string>;
 			body?: RuntimeBytes;
 		},
-		jsRequest: Request,
 	): Promise<Response | undefined> => {
-		const url = new URL(jsRequest.url);
+		const rawUrl = rawRequest.uri.startsWith("http")
+			? rawRequest.uri
+			: new URL(rawRequest.uri, "http://127.0.0.1").toString();
+		const url = new URL(rawUrl);
 		if (!url.pathname.startsWith("/inspector/")) {
 			return undefined;
 		}
 
+		const jsRequest = buildRequest(rawRequest);
 		const jsonResponse = (body: unknown, init?: ResponseInit) =>
 			new Response(JSON.stringify(body), {
 				status: init?.status ?? 200,
@@ -4662,38 +4812,61 @@ export function buildNativeFactory(
 						uri: string;
 						headers?: Record<string, string>;
 						body?: RuntimeBytes;
+						bodyStream?: NativeHttpRequestBodyStream;
 					};
 					cancelToken?: CancellationTokenHandle;
+					responseBodyStream?: NativeHttpResponseBodyStream;
 				},
 			) => {
 				try {
-					const { ctx, request, cancelToken } = unwrapTsfnPayload(
-						error,
-						payload,
-					);
-					const jsRequest = buildRequest(request);
+					const { ctx, request, cancelToken, responseBodyStream } =
+						unwrapTsfnPayload(error, payload);
 					const inspectorResponse =
-						await maybeHandleNativeInspectorRequest(
-							ctx,
-							request,
-							jsRequest,
-						);
+						await maybeHandleNativeInspectorRequest(ctx, request);
 					if (inspectorResponse) {
-						return await toRuntimeHttpResponse(inspectorResponse);
+						return (
+							await convertRuntimeHttpResponse(
+								inspectorResponse,
+								responseBodyStream,
+							)
+						).response;
 					}
 
 					if (typeof config.onRequest !== "function") {
-						return await toRuntimeHttpResponse(
-							new Response(null, { status: 404 }),
-						);
+						return (
+							await convertRuntimeHttpResponse(
+								new Response(null, { status: 404 }),
+								responseBodyStream,
+							)
+						).response;
 					}
 
+					const requestAbortController = new AbortController();
+					const handlerRequest = buildRequest({
+						...request,
+						abortController: requestAbortController,
+					});
 					const rawConnParams =
-						jsRequest.headers.get(HEADER_CONN_PARAMS);
+						handlerRequest.headers.get(HEADER_CONN_PARAMS);
 					let requestCtx:
 						| ReturnType<typeof withConnContext>
 						| undefined;
 					let conn: ConnHandle | undefined;
+					let removeRequestAbortListener: (() => void) | undefined;
+					let cleanupDeferredToBody = false;
+					let cleanedUp = false;
+					const cleanupRequest = async () => {
+						if (cleanedUp) return;
+						cleanedUp = true;
+						removeRequestAbortListener?.();
+						try {
+							await requestCtx?.dispose();
+						} finally {
+							if (conn) {
+								await runtime.connDisconnect(conn);
+							}
+						}
+					};
 					try {
 						const connParams = validateConnParams(
 							schemaConfig.connParamsSchema,
@@ -4711,23 +4884,54 @@ export function buildNativeFactory(
 						requestCtx = makeConnCtx(
 							ctx,
 							conn,
-							jsRequest,
+							handlerRequest,
 							cancelToken,
 						);
+						const ctxAbortSignal = requestCtx.abortSignal;
+						const abortRequest = () =>
+							requestAbortController.abort(ctxAbortSignal.reason);
+						if (ctxAbortSignal.aborted) {
+							abortRequest();
+						} else {
+							ctxAbortSignal.addEventListener(
+								"abort",
+								abortRequest,
+								{ once: true },
+							);
+							removeRequestAbortListener = () =>
+								ctxAbortSignal.removeEventListener(
+									"abort",
+									abortRequest,
+								);
+						}
 						const response = await config.onRequest(
 							requestCtx,
-							jsRequest,
+							handlerRequest,
 						);
 						if (!isResponseLike(response)) {
 							throw new Error(
 								"onRequest handler must return a Response",
 							);
 						}
-						return await toRuntimeHttpResponse(response);
+						const conversion = await convertRuntimeHttpResponse(
+							response,
+							responseBodyStream,
+						);
+						if (conversion.bodyCompletion) {
+							cleanupDeferredToBody = true;
+							void conversion.bodyCompletion
+								.then(cleanupRequest)
+								.catch((cleanupError) => {
+									logger().error({
+										msg: "failed to clean up native streaming http request",
+										error: cleanupError,
+									});
+								});
+						}
+						return conversion.response;
 					} finally {
-						await requestCtx?.dispose();
-						if (conn) {
-							await runtime.connDisconnect(conn);
+						if (!cleanupDeferredToBody) {
+							await cleanupRequest();
 						}
 					}
 				} catch (error) {

--- a/rivetkit-typescript/packages/rivetkit/src/registry/runtime.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/runtime.ts
@@ -36,6 +36,7 @@ export interface RuntimeHttpResponse {
 	status?: number;
 	headers?: Record<string, string>;
 	body?: RuntimeBytes;
+	stream?: boolean;
 }
 
 export interface RuntimeStateDeltaPayload {

--- a/rivetkit-typescript/packages/rivetkit/tests/driver/sse-contract-harness.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/driver/sse-contract-harness.ts
@@ -1,0 +1,728 @@
+import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+	chmod,
+	mkdir,
+	readFile,
+	rename,
+	rm,
+	writeFile,
+} from "node:fs/promises";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import getPort from "get-port";
+
+const HARNESS_VERSION = "2.31.0";
+const RELEASE_URL =
+	"https://github.com/launchdarkly/sse-contract-tests/releases/download";
+const HARNESS_TIMEOUT_MS = 330_000;
+const HARNESS_KILL_GRACE_MS = 5_000;
+const HARNESS_ACQUIRE_TIMEOUT_MS = 60_000;
+
+interface HarnessAsset {
+	archive: string;
+	binary: string;
+	sha256: string;
+	binarySha256: string;
+}
+
+const HARNESS_ASSETS: Record<string, HarnessAsset> = {
+	"darwin-arm64": {
+		archive: "sse-contract-tests_Darwin_arm64.tar.gz",
+		binary: "sse-contract-tests",
+		sha256: "65084d8e2c28ddce72a7770e25c90d9fb774ac4bfe1e62caf9c2c4061418176d",
+		binarySha256:
+			"955d1baac0b7f56019818c280761933b3c74b17dfb1018808b26cb5de5c86efd",
+	},
+	"darwin-x64": {
+		archive: "sse-contract-tests_Darwin_x86_64.tar.gz",
+		binary: "sse-contract-tests",
+		sha256: "ddcb50140943552da75cceba531e73fcc63dd9f3eeda2a9fdd69e544af1f6c08",
+		binarySha256:
+			"e88a77ff3193c969b8a358bafc496776ebd5ec00a9f4def7425a131e86e2c3a6",
+	},
+	"linux-arm64": {
+		archive: "sse-contract-tests_Linux_arm64.tar.gz",
+		binary: "sse-contract-tests",
+		sha256: "abe663905d0944bc37f7f2b7f8df4871b50f6e907c76bc3aeded73401b42f175",
+		binarySha256:
+			"c957df214133990f63b92950ab29e9eb004b30f671817d32c58891841643bf52",
+	},
+	"linux-x64": {
+		archive: "sse-contract-tests_Linux_x86_64.tar.gz",
+		binary: "sse-contract-tests",
+		sha256: "b8963f94dffc34a41a9cf192b3c59d5a16c94e4ba722dca945eed288ff88ec1d",
+		binarySha256:
+			"7035444fe54def899eb390ea05d35eefefc6913d5fc57f0cea64a47349131612",
+	},
+};
+
+interface ActorFetch {
+	fetch(input: string | URL | Request, init?: RequestInit): Promise<Response>;
+}
+
+interface StreamParams {
+	callbackUrl: string;
+	initialDelayMs?: number | null;
+	lastEventId?: string | null;
+	streamUrl: string;
+}
+
+interface StreamClient {
+	abortController: AbortController;
+	callbacks: Promise<void>;
+	done: Promise<void>;
+	nextCallback: number;
+}
+
+function sha256(data: Uint8Array): string {
+	return createHash("sha256").update(data).digest("hex");
+}
+
+function debugAdapter(message: string): void {
+	if (process.env.SSE_CONTRACT_DEBUG === "1") {
+		process.stderr.write(`[sse-contract-adapter] ${message}\n`);
+	}
+}
+
+async function ensureHarnessBinary(): Promise<string> {
+	const asset = HARNESS_ASSETS[`${process.platform}-${process.arch}`];
+	if (!asset) {
+		throw new Error(
+			`SSE contract tests do not support ${process.platform}-${process.arch}`,
+		);
+	}
+
+	const cacheDir = join(
+		tmpdir(),
+		"rivetkit-sse-contract-tests",
+		`v${HARNESS_VERSION}`,
+		`${process.platform}-${process.arch}`,
+	);
+	const archivePath = join(cacheDir, asset.archive);
+	const installDir = join(cacheDir, asset.sha256);
+	const binaryPath = join(installDir, asset.binary);
+	await mkdir(cacheDir, { recursive: true });
+
+	let archive: Uint8Array | undefined;
+	try {
+		const cached = await readFile(archivePath);
+		if (sha256(cached) === asset.sha256) {
+			archive = cached;
+		}
+	} catch {
+		// Download below.
+	}
+
+	if (!archive) {
+		const response = await fetch(
+			`${RELEASE_URL}/v${HARNESS_VERSION}/${asset.archive}`,
+			{ signal: AbortSignal.timeout(HARNESS_ACQUIRE_TIMEOUT_MS) },
+		);
+		if (!response.ok) {
+			throw new Error(
+				`failed to download SSE contract harness: ${response.status} ${response.statusText}`,
+			);
+		}
+
+		archive = new Uint8Array(await response.arrayBuffer());
+		const actualSha256 = sha256(archive);
+		if (actualSha256 !== asset.sha256) {
+			throw new Error(
+				`SSE contract harness checksum mismatch: expected ${asset.sha256}, received ${actualSha256}`,
+			);
+		}
+
+		const temporaryPath = `${archivePath}.${process.pid}.tmp`;
+		await writeFile(temporaryPath, archive);
+		await rename(temporaryPath, archivePath);
+	}
+
+	try {
+		const binary = await readFile(binaryPath);
+		if (sha256(binary) === asset.binarySha256) {
+			await chmod(binaryPath, 0o755);
+			return binaryPath;
+		}
+	} catch {
+		// Replace the installation below.
+	}
+	await rm(installDir, { recursive: true, force: true });
+
+	const temporaryInstallDir = join(
+		cacheDir,
+		`.extract-${process.pid}-${randomUUID()}`,
+	);
+	await mkdir(temporaryInstallDir);
+	try {
+		await extractArchive(archivePath, temporaryInstallDir);
+		const temporaryBinaryPath = join(temporaryInstallDir, asset.binary);
+		const binary = await readFile(temporaryBinaryPath);
+		const actualBinarySha256 = sha256(binary);
+		if (actualBinarySha256 !== asset.binarySha256) {
+			throw new Error(
+				`SSE contract harness binary checksum mismatch: expected ${asset.binarySha256}, received ${actualBinarySha256}`,
+			);
+		}
+		await chmod(temporaryBinaryPath, 0o755);
+	} catch (error) {
+		await rm(temporaryInstallDir, { recursive: true, force: true });
+		throw error;
+	}
+	try {
+		await rename(temporaryInstallDir, installDir);
+	} catch (error) {
+		await rm(temporaryInstallDir, { recursive: true, force: true });
+		try {
+			const binary = await readFile(binaryPath);
+			if (sha256(binary) !== asset.binarySha256) {
+				throw error;
+			}
+			await chmod(binaryPath, 0o755);
+		} catch {
+			throw error;
+		}
+	}
+	await chmod(binaryPath, 0o755);
+	return binaryPath;
+}
+
+async function extractArchive(
+	archivePath: string,
+	installDir: string,
+): Promise<void> {
+	await new Promise<void>((resolve, reject) => {
+		const child = spawn("tar", ["-xzf", archivePath, "-C", installDir], {
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stderr = "";
+		let timedOut = false;
+		let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+		const timeoutTimer = setTimeout(() => {
+			timedOut = true;
+			child.kill("SIGTERM");
+			forceKillTimer = setTimeout(() => {
+				child.kill("SIGKILL");
+			}, HARNESS_KILL_GRACE_MS);
+		}, HARNESS_ACQUIRE_TIMEOUT_MS);
+		const clearTimers = () => {
+			clearTimeout(timeoutTimer);
+			if (forceKillTimer) clearTimeout(forceKillTimer);
+		};
+		child.stderr.on("data", (chunk) => {
+			stderr += chunk.toString();
+		});
+		child.once("error", (error) => {
+			clearTimers();
+			reject(error);
+		});
+		child.once("exit", (code) => {
+			clearTimers();
+			if (timedOut) {
+				reject(
+					new Error(
+						`timed out extracting SSE contract harness after ${HARNESS_ACQUIRE_TIMEOUT_MS}ms`,
+					),
+				);
+				return;
+			}
+			if (code === 0) {
+				resolve();
+			} else {
+				reject(
+					new Error(
+						`failed to extract SSE contract harness (exit ${code}): ${stderr}`,
+					),
+				);
+			}
+		});
+	});
+}
+
+async function readJson(request: IncomingMessage): Promise<unknown> {
+	const chunks: Buffer[] = [];
+	for await (const chunk of request) {
+		chunks.push(Buffer.from(chunk));
+	}
+	return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function listen(server: Server, port: number): Promise<void> {
+	return new Promise((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(port, "127.0.0.1", () => {
+			server.off("error", reject);
+			resolve();
+		});
+	});
+}
+
+function close(server: Server): Promise<void> {
+	return new Promise((resolve, reject) => {
+		server.close((error) => {
+			if (error) reject(error);
+			else resolve();
+		});
+	});
+}
+
+function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+	return new Promise((resolve) => {
+		const timeout = setTimeout(resolve, ms);
+		signal.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(timeout);
+				resolve();
+			},
+			{ once: true },
+		);
+	});
+}
+
+interface ParsedEvent {
+	data: string;
+	id: string;
+	type: string;
+}
+
+export async function parseEventStream(
+	body: ReadableStream<Uint8Array>,
+	initialLastEventId: string,
+	onEvent: (event: ParsedEvent) => void,
+	onRetry: (delayMs: number) => void,
+	signal?: AbortSignal,
+): Promise<string> {
+	const decoder = new TextDecoder("utf-8", { ignoreBOM: true });
+	const reader = body.getReader();
+	let data: string[] = [];
+	let eventType = "";
+	let lastEventId = initialLastEventId;
+	let pendingLastEventId: string | undefined;
+	let lineParts: string[] = [];
+	let skipLeadingLf = false;
+	let firstCharacter = true;
+	const abortReader = () => {
+		void reader.cancel(signal?.reason).catch(() => {
+			// The body may already be closed by the HTTP client.
+		});
+	};
+	if (signal?.aborted) {
+		abortReader();
+	} else {
+		signal?.addEventListener("abort", abortReader, { once: true });
+	}
+
+	const finishLine = (line: string) => {
+		if (line === "") {
+			if (pendingLastEventId !== undefined) {
+				lastEventId = pendingLastEventId;
+			}
+			if (data.length > 0) {
+				onEvent({
+					data: data.join("\n"),
+					id: lastEventId,
+					type: eventType || "message",
+				});
+			}
+			data = [];
+			eventType = "";
+			pendingLastEventId = undefined;
+			return;
+		}
+
+		if (line.startsWith(":")) {
+			return;
+		}
+
+		const colon = line.indexOf(":");
+		const field = colon === -1 ? line : line.slice(0, colon);
+		let value = colon === -1 ? "" : line.slice(colon + 1);
+		if (value.startsWith(" ")) {
+			value = value.slice(1);
+		}
+
+		switch (field) {
+			case "data":
+				data.push(value);
+				break;
+			case "event":
+				eventType = value;
+				break;
+			case "id":
+				if (!value.includes("\0")) {
+					pendingLastEventId = value;
+				}
+				break;
+			case "retry":
+				if (/^\d+$/.test(value)) {
+					onRetry(Number(value));
+				}
+				break;
+		}
+	};
+
+	const processText = (decoded: string) => {
+		let offset = 0;
+		if (firstCharacter && decoded.length > 0) {
+			firstCharacter = false;
+			if (decoded[0] === "\uFEFF") {
+				offset = 1;
+			}
+		}
+		if (skipLeadingLf && offset < decoded.length) {
+			skipLeadingLf = false;
+			if (decoded[offset] === "\n") {
+				offset++;
+			}
+		}
+
+		while (offset < decoded.length) {
+			const cr = decoded.indexOf("\r", offset);
+			const lf = decoded.indexOf("\n", offset);
+			const lineEnd = cr === -1 ? lf : lf === -1 ? cr : Math.min(cr, lf);
+			if (lineEnd === -1) {
+				lineParts.push(decoded.slice(offset));
+				return;
+			}
+
+			lineParts.push(decoded.slice(offset, lineEnd));
+			finishLine(lineParts.join(""));
+			lineParts = [];
+			const terminator = decoded[lineEnd];
+			offset = lineEnd + 1;
+			if (terminator === "\r") {
+				if (offset < decoded.length) {
+					if (decoded[offset] === "\n") {
+						offset++;
+					}
+				} else {
+					skipLeadingLf = true;
+				}
+			}
+		}
+	};
+
+	try {
+		for (;;) {
+			const next = await reader.read();
+			if (next.done) {
+				processText(decoder.decode());
+				return lastEventId;
+			}
+			processText(decoder.decode(next.value, { stream: true }));
+		}
+	} finally {
+		signal?.removeEventListener("abort", abortReader);
+		reader.releaseLock();
+	}
+}
+
+async function startTestService(actor: ActorFetch): Promise<{
+	close: () => Promise<void>;
+	url: string;
+}> {
+	const port = await getPort();
+	const streams = new Map<string, StreamClient>();
+	let nextStream = 1;
+
+	const sendCallback = (
+		client: StreamClient,
+		callbackUrl: string,
+		body: unknown,
+	) => {
+		const callbackNumber = client.nextCallback++;
+		client.callbacks = client.callbacks.then(async () => {
+			const callbackBody = JSON.stringify(body);
+			debugAdapter(
+				`posting callback ${callbackNumber} (${callbackBody.length} bytes)`,
+			);
+			const response = await fetch(`${callbackUrl}/${callbackNumber}`, {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: callbackBody,
+			});
+			if (!response.ok) {
+				throw new Error(
+					`SSE contract callback failed: ${response.status} ${await response.text()}`,
+				);
+			}
+			debugAdapter(`posted callback ${callbackNumber}`);
+		});
+	};
+
+	const runStream = async (
+		client: StreamClient,
+		params: StreamParams,
+	): Promise<void> => {
+		let retryDelayMs = params.initialDelayMs ?? 1_000;
+		let lastEventId = params.lastEventId ?? "";
+
+		while (!client.abortController.signal.aborted) {
+			try {
+				const headers = new Headers({
+					accept: "text/event-stream",
+					"cache-control": "no-cache",
+				});
+				if (lastEventId) {
+					headers.set("last-event-id", lastEventId);
+				}
+
+				const response = await actor.fetch(
+					`api/sse-proxy?target=${encodeURIComponent(params.streamUrl)}`,
+					{
+						headers,
+						signal: client.abortController.signal,
+					},
+				);
+				if (response.status === 204) {
+					return;
+				}
+				if (!response.ok || !response.body) {
+					throw new Error(
+						`SSE request failed with ${response.status}`,
+					);
+				}
+				if (
+					!response.headers
+						.get("content-type")
+						?.toLowerCase()
+						.startsWith("text/event-stream")
+				) {
+					throw new Error(
+						`invalid SSE content type: ${response.headers.get("content-type")}`,
+					);
+				}
+				debugAdapter(`connected to ${params.streamUrl}`);
+
+				lastEventId = await parseEventStream(
+					response.body,
+					lastEventId,
+					(event) => {
+						debugAdapter(
+							`parsed event (${event.data.length} bytes)`,
+						);
+						lastEventId = event.id;
+						sendCallback(client, params.callbackUrl, {
+							kind: "event",
+							event: {
+								type: event.type,
+								data: event.data,
+								...(event.id ? { id: event.id } : {}),
+							},
+						});
+					},
+					(delayMs) => {
+						retryDelayMs = delayMs;
+					},
+					client.abortController.signal,
+				);
+				if (!client.abortController.signal.aborted) {
+					sendCallback(client, params.callbackUrl, {
+						kind: "error",
+						comment: "SSE stream disconnected",
+					});
+				}
+			} catch (error) {
+				debugAdapter(
+					`stream failed: ${error instanceof Error ? error.stack : String(error)}`,
+				);
+				if (!client.abortController.signal.aborted) {
+					sendCallback(client, params.callbackUrl, {
+						kind: "error",
+						comment:
+							error instanceof Error
+								? error.message
+								: String(error),
+					});
+				}
+			}
+
+			await abortableDelay(retryDelayMs, client.abortController.signal);
+		}
+	};
+
+	const server = createServer(async (request, response) => {
+		try {
+			const url = new URL(request.url ?? "/", `http://127.0.0.1:${port}`);
+
+			if (request.method === "GET" && url.pathname === "/") {
+				response.writeHead(200, { "content-type": "application/json" });
+				response.end(
+					JSON.stringify({
+						capabilities: [
+							"bom",
+							"last-event-id",
+							"server-directed-shutdown-request",
+						],
+					}),
+				);
+				return;
+			}
+
+			if (request.method === "POST" && url.pathname === "/") {
+				const params = (await readJson(request)) as StreamParams;
+				if (!params.streamUrl || !params.callbackUrl) {
+					response.writeHead(400).end();
+					return;
+				}
+
+				const id = String(nextStream++);
+				const abortController = new AbortController();
+				const client: StreamClient = {
+					abortController,
+					callbacks: Promise.resolve(),
+					done: Promise.resolve(),
+					nextCallback: 1,
+				};
+				client.done = runStream(client, params);
+				streams.set(id, client);
+
+				response.writeHead(201, {
+					location: `http://127.0.0.1:${port}/streams/${id}`,
+				});
+				response.end();
+				return;
+			}
+
+			const streamMatch = /^\/streams\/(\d+)$/.exec(url.pathname);
+			const streamId = streamMatch?.[1];
+			const client = streamId ? streams.get(streamId) : undefined;
+			if (!streamId || !client) {
+				response.writeHead(404).end();
+				return;
+			}
+
+			if (request.method === "POST") {
+				response.writeHead(400).end();
+				return;
+			}
+
+			if (request.method === "DELETE") {
+				debugAdapter(`deleting stream ${streamId}`);
+				client.abortController.abort();
+				await client.done;
+				await client.callbacks;
+				debugAdapter(`deleted stream ${streamId}`);
+				streams.delete(streamId);
+				response.writeHead(204).end();
+				return;
+			}
+
+			response.writeHead(405).end();
+		} catch (error) {
+			response.writeHead(500, { "content-type": "text/plain" });
+			response.end(error instanceof Error ? error.stack : String(error));
+		}
+	});
+
+	await listen(server, port);
+	return {
+		url: `http://127.0.0.1:${port}`,
+		close: async () => {
+			for (const client of streams.values()) {
+				client.abortController.abort();
+			}
+			await Promise.allSettled(
+				[...streams.values()].flatMap((client) => [
+					client.done,
+					client.callbacks,
+				]),
+			);
+			await close(server);
+		},
+	};
+}
+
+export async function runSseContractTests(actor: ActorFetch): Promise<string> {
+	const [binary, callbackPort] = await Promise.all([
+		ensureHarnessBinary(),
+		getPort(),
+	]);
+	const service = await startTestService(actor);
+
+	try {
+		return await new Promise<string>((resolve, reject) => {
+			const child = spawn(
+				binary,
+				[
+					"--url",
+					service.url,
+					"--host",
+					"127.0.0.1",
+					"--port",
+					String(callbackPort),
+					...(process.env.SSE_CONTRACT_RUN
+						? ["--run", process.env.SSE_CONTRACT_RUN]
+						: []),
+					...(process.env.SSE_CONTRACT_DEBUG === "1"
+						? ["--debug-all"]
+						: []),
+				],
+				{ stdio: ["ignore", "pipe", "pipe"] },
+			);
+			let stdout = "";
+			let stderr = "";
+			let timedOut = false;
+			let settled = false;
+			let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+			const timeoutTimer = setTimeout(() => {
+				timedOut = true;
+				child.kill("SIGTERM");
+				forceKillTimer = setTimeout(() => {
+					child.kill("SIGKILL");
+				}, HARNESS_KILL_GRACE_MS);
+			}, HARNESS_TIMEOUT_MS);
+			const settle = (result: { output: string } | { error: Error }) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timeoutTimer);
+				if (forceKillTimer) clearTimeout(forceKillTimer);
+				if ("output" in result) {
+					resolve(result.output);
+				} else {
+					reject(result.error);
+				}
+			};
+			child.stdout.on("data", (chunk) => {
+				const text = chunk.toString();
+				stdout += text;
+				if (process.env.SSE_CONTRACT_DEBUG === "1") {
+					process.stdout.write(text);
+				}
+			});
+			child.stderr.on("data", (chunk) => {
+				const text = chunk.toString();
+				stderr += text;
+				if (process.env.SSE_CONTRACT_DEBUG === "1") {
+					process.stderr.write(text);
+				}
+			});
+			child.once("error", (error) => {
+				settle({ error });
+			});
+			child.once("exit", (code, signal) => {
+				if (timedOut) {
+					settle({
+						error: new Error(
+							`SSE contract tests timed out after ${HARNESS_TIMEOUT_MS}ms (signal ${signal ?? "none"})\n${stdout}\n${stderr}`,
+						),
+					});
+					return;
+				}
+				if (code === 0) {
+					settle({ output: stdout });
+				} else {
+					settle({
+						error: new Error(
+							`SSE contract tests failed (exit ${code})\n${stdout}\n${stderr}`,
+						),
+					});
+				}
+			});
+		});
+	} finally {
+		await service.close();
+	}
+}

--- a/rivetkit-typescript/packages/rivetkit/tests/driver/streaming-http.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/driver/streaming-http.test.ts
@@ -1,0 +1,283 @@
+import { createServer } from "node:http";
+import { describe, expect, test } from "vitest";
+import { describeDriverMatrix } from "./shared-matrix";
+import { setupDriverTest } from "./shared-utils";
+import { parseEventStream, runSseContractTests } from "./sse-contract-harness";
+
+function delay(ms: number): Promise<"timeout"> {
+	return new Promise((resolve) => setTimeout(() => resolve("timeout"), ms));
+}
+
+describeDriverMatrix(
+	"Streaming Http",
+	(driverTestConfig) => {
+		describe("streaming http", () => {
+			test("streams response chunks before the body completes", async (c) => {
+				const { client } = await setupDriverTest(c, driverTestConfig);
+				const actor = client.rawHttpActor.getOrCreate([
+					"stream-response",
+				]);
+
+				const response = await actor.fetch("api/stream");
+				expect(response.ok).toBe(true);
+				expect(response.headers.get("content-type")).toContain(
+					"text/event-stream",
+				);
+
+				const reader = response.body?.getReader();
+				expect(reader).toBeDefined();
+				if (!reader) throw new Error("response body is missing");
+				const decoder = new TextDecoder();
+				const first = await reader.read();
+				expect(first.done).toBe(false);
+				expect(decoder.decode(first.value)).toBe("data: first\n\n");
+
+				const secondRead = reader.read();
+				const earlySecond = await Promise.race([secondRead, delay(50)]);
+				expect(earlySecond).toBe("timeout");
+
+				const second = await secondRead;
+				expect(second.done).toBe(false);
+				expect(decoder.decode(second.value)).toBe("data: second\n\n");
+				expect(await reader.read()).toEqual({
+					done: true,
+					value: undefined,
+				});
+			});
+
+			test("keeps the request connection alive through the response stream", async (c) => {
+				const { client } = await setupDriverTest(c, driverTestConfig);
+				const actorKey = ["stream-response-lifecycle"];
+				const actor = client.rawHttpActor.getOrCreate(actorKey, {
+					params: { streamLifecycle: true },
+				});
+				const observer = client.rawHttpActor.getOrCreate(actorKey);
+
+				const response = await actor.fetch("api/stream-lifecycle");
+				const reader = response.body?.getReader();
+				expect(reader).toBeDefined();
+				if (!reader) throw new Error("response body is missing");
+				expect((await reader.read()).done).toBe(false);
+
+				const activeState = (await (
+					await observer.fetch("api/state")
+				).json()) as {
+					streamDisconnectedBeforeFinish: boolean;
+					streamResponseFinished: boolean;
+				};
+				expect(activeState.streamResponseFinished).toBe(false);
+				expect(activeState.streamDisconnectedBeforeFinish).toBe(false);
+
+				expect(await reader.read()).toEqual({
+					done: true,
+					value: undefined,
+				});
+				const finishedState = (await (
+					await observer.fetch("api/state")
+				).json()) as {
+					streamDisconnectedBeforeFinish: boolean;
+					streamResponseFinished: boolean;
+				};
+				expect(finishedState.streamResponseFinished).toBe(true);
+				expect(finishedState.streamDisconnectedBeforeFinish).toBe(
+					false,
+				);
+			});
+
+			test("aborts Request.signal when the client drops a started response stream", async (c) => {
+				const { client } = await setupDriverTest(c, driverTestConfig);
+				const actor = client.rawHttpActor.getOrCreate([
+					"response-stream-request-abort",
+				]);
+
+				const response = await actor.fetch(
+					"api/wait-for-response-abort",
+				);
+				const reader = response.body?.getReader();
+				expect(reader).toBeDefined();
+				if (!reader) throw new Error("response body is missing");
+				expect((await reader.read()).done).toBe(false);
+
+				await reader.cancel();
+
+				const deadline = Date.now() + 2_000;
+				for (;;) {
+					const state = (await (
+						await actor.fetch("api/state")
+					).json()) as {
+						responseAbortObserved: boolean;
+						responseAbortStarted: boolean;
+					};
+					expect(state.responseAbortStarted).toBe(true);
+					if (state.responseAbortObserved) break;
+					if (Date.now() >= deadline) {
+						throw new Error(
+							"actor did not abort Request.signal after the response client disconnected",
+						);
+					}
+					await delay(25);
+				}
+			});
+
+			test("exposes gateway-chunked request bodies as Request streams", async (c) => {
+				const { client } = await setupDriverTest(c, driverTestConfig);
+				const actor = client.rawHttpActor.getOrCreate([
+					"stream-upload",
+				]);
+				const requestBody = new Uint8Array(80 * 1024);
+				requestBody.fill(1, 0, 40 * 1024);
+				requestBody.fill(2, 40 * 1024);
+
+				const response = await actor.fetch("api/upload-stream", {
+					method: "POST",
+					body: Buffer.from(requestBody),
+				});
+
+				expect(response.ok).toBe(true);
+				const body = (await response.json()) as {
+					chunkCount: number;
+					contentLength: string | null;
+					sizes: number[];
+					totalBytes: number;
+				};
+				expect(body.totalBytes, JSON.stringify(body)).toBe(
+					requestBody.byteLength,
+				);
+				expect(body.chunkCount).toBeGreaterThanOrEqual(2);
+				expect(Math.max(...body.sizes)).toBeLessThanOrEqual(64 * 1024);
+			});
+
+			test("allows handlers to cancel unread streamed uploads", async (c) => {
+				const { client } = await setupDriverTest(c, driverTestConfig);
+				const actor = client.rawHttpActor.getOrCreate([
+					"cancel-stream-upload",
+				]);
+				const requestBody = new Uint8Array(2 * 1024 * 1024);
+
+				const response = await actor.fetch("api/cancel-upload", {
+					method: "POST",
+					body: Buffer.from(requestBody),
+				});
+
+				expect(response.ok).toBe(true);
+				expect(await response.text()).toBe("upload cancelled");
+			});
+
+			test("streams a large proxied SSE event", async (c) => {
+				const eventData = "x".repeat(7 * 1024 * 1024);
+				const upstream = createServer((_request, response) => {
+					response.writeHead(200, {
+						"content-type": "text/event-stream",
+					});
+					response.end(`data: ${eventData}\n\n`);
+				});
+				await new Promise<void>((resolve, reject) => {
+					upstream.once("error", reject);
+					upstream.listen(0, "127.0.0.1", resolve);
+				});
+
+				try {
+					const address = upstream.address();
+					if (!address || typeof address === "string") {
+						throw new Error("upstream did not bind a TCP port");
+					}
+					const { client } = await setupDriverTest(
+						c,
+						driverTestConfig,
+					);
+					const actor = client.rawHttpActor.getOrCreate([
+						"large-sse-response",
+					]);
+					const target = encodeURIComponent(
+						`http://127.0.0.1:${address.port}`,
+					);
+
+					const response = await actor.fetch(
+						`api/sse-proxy?target=${target}`,
+					);
+					if (!response.body) {
+						throw new Error("proxied response has no body");
+					}
+					let parsedLength = 0;
+					await parseEventStream(
+						response.body,
+						"",
+						(event) => {
+							parsedLength = event.data.length;
+						},
+						() => {},
+					);
+
+					expect(parsedLength).toBe(eventData.length);
+				} finally {
+					await new Promise<void>((resolve, reject) => {
+						upstream.close((error) => {
+							if (error) reject(error);
+							else resolve();
+						});
+					});
+				}
+			}, 30_000);
+
+			test("aborts Request.signal even when the handler does not read the body", async (c) => {
+				const { client } = await setupDriverTest(c, driverTestConfig);
+				const actor = client.rawHttpActor.getOrCreate([
+					"request-cancellation",
+				]);
+				const abortController = new AbortController();
+				const request = actor.fetch("api/wait-for-request-abort", {
+					method: "POST",
+					body: Buffer.from("ignored"),
+					signal: abortController.signal,
+				});
+
+				const startDeadline = Date.now() + 2_000;
+				for (;;) {
+					const state = (await (
+						await actor.fetch("api/state")
+					).json()) as {
+						requestAbortStarted: boolean;
+					};
+					if (state.requestAbortStarted) break;
+					if (Date.now() >= startDeadline) {
+						throw new Error(
+							"actor did not start the abortable request",
+						);
+					}
+					await delay(25);
+				}
+				abortController.abort();
+				await expect(request).rejects.toThrow();
+
+				const deadline = Date.now() + 2_000;
+				for (;;) {
+					const state = (await (
+						await actor.fetch("api/state")
+					).json()) as {
+						requestAbortObserved: boolean;
+					};
+					if (state.requestAbortObserved) break;
+					if (Date.now() >= deadline) {
+						throw new Error(
+							"actor did not observe the aborted Request.signal",
+						);
+					}
+					await delay(25);
+				}
+			});
+
+			test("passes the LaunchDarkly SSE contract suite", async (c) => {
+				const { client } = await setupDriverTest(c, driverTestConfig);
+				const actor = client.rawHttpActor.getOrCreate(["sse-contract"]);
+
+				const output = await runSseContractTests(actor);
+				expect(output).toContain("All tests passed");
+			}, 360_000);
+		});
+	},
+	{
+		runtimes: ["native"],
+		encodings: ["bare"],
+		sqliteBackends: ["remote"],
+	},
+);

--- a/rivetkit-typescript/packages/rivetkit/tests/native-http-streaming.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/native-http-streaming.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, test } from "vitest";
+import { nativeRegistryTestInternals } from "../src/registry/native";
+
+describe("native http response streaming", () => {
+	test("constructs requests with streaming bodies and abort signals", async () => {
+		const chunks = [new Uint8Array([1]), new Uint8Array([2])];
+		const controller = new AbortController();
+		const request = nativeRegistryTestInternals.buildRequest({
+			method: "POST",
+			uri: "/upload",
+			body: chunks.shift(),
+			bodyStream: {
+				async read() {
+					return chunks.shift() ?? null;
+				},
+				async cancel() {},
+			},
+			signal: controller.signal,
+		});
+
+		controller.abort();
+
+		expect(request.signal.aborted).toBe(true);
+		expect(new Uint8Array(await request.arrayBuffer())).toEqual(
+			new Uint8Array([1, 2]),
+		);
+	});
+
+	test("preserves native request stream chunks through Request bodies", async () => {
+		const chunkSizes = [13_093, 16_384, 32_768, 19_675];
+		const chunks = chunkSizes.map((size, index) => {
+			const chunk = new Uint8Array(size);
+			chunk.fill(index + 1);
+			return chunk;
+		});
+		const request = nativeRegistryTestInternals.buildRequest({
+			method: "POST",
+			uri: "/upload",
+			bodyStream: {
+				async read() {
+					return chunks.shift() ?? null;
+				},
+				async cancel() {},
+			},
+		});
+
+		const reader = request.body?.getReader();
+		expect(reader).toBeDefined();
+		if (!reader) throw new Error("request body is missing");
+
+		const sizes: number[] = [];
+		let totalBytes = 0;
+		for (;;) {
+			const next = await reader.read();
+			if (next.done) break;
+			sizes.push(next.value.byteLength);
+			totalBytes += next.value.byteLength;
+		}
+
+		expect(sizes).toEqual(chunkSizes);
+		expect(totalBytes).toBe(80 * 1024);
+	});
+
+	test("rejects and aborts the Request when the native body stream aborts", async () => {
+		const abortController = new AbortController();
+		const request = nativeRegistryTestInternals.buildRequest({
+			method: "POST",
+			uri: "/upload",
+			bodyStream: {
+				async read() {
+					throw new Error("ClientDisconnect: upload closed");
+				},
+				async cancel() {},
+			},
+			abortController,
+		});
+
+		await expect(request.arrayBuffer()).rejects.toThrow(
+			"ClientDisconnect: upload closed",
+		);
+		expect(request.signal.aborted).toBe(true);
+	});
+
+	test("streams multi-chunk responses through the native body stream", async () => {
+		const writes: Uint8Array[] = [];
+		let finish!: () => void;
+		const finished = new Promise<void>((resolve) => {
+			finish = resolve;
+		});
+
+		const responseBodyStream = {
+			async cancelled() {
+				return new Promise<void>(() => {});
+			},
+			async write(chunk: Uint8Array) {
+				writes.push(new Uint8Array(chunk));
+			},
+			async end() {
+				finish();
+			},
+			async error(message: string) {
+				throw new Error(message);
+			},
+		};
+		const largeChunk = new Uint8Array(64 * 1024 + 1);
+		largeChunk.fill(7);
+		const response = new Response(
+			new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.enqueue(new Uint8Array([1]));
+					controller.enqueue(largeChunk);
+					controller.close();
+				},
+			}),
+			{
+				status: 202,
+				headers: {
+					"x-streamed": "yes",
+				},
+			},
+		);
+
+		const { response: runtimeResponse } =
+			await nativeRegistryTestInternals.convertRuntimeHttpResponse(
+				response,
+				responseBodyStream,
+			);
+		await finished;
+
+		expect(runtimeResponse).toEqual({
+			status: 202,
+			headers: {
+				"x-streamed": "yes",
+			},
+			stream: true,
+		});
+		expect(writes.map((chunk) => chunk.byteLength)).toEqual([
+			1,
+			64 * 1024,
+			1,
+		]);
+		expect(writes[0]).toEqual(new Uint8Array([1]));
+		expect(writes[1][0]).toBe(7);
+		expect(writes[2][0]).toBe(7);
+	});
+
+	test("returns streamed response headers before the first body chunk", async () => {
+		let bodyController!: ReadableStreamDefaultController<Uint8Array>;
+		let finish!: () => void;
+		const finished = new Promise<void>((resolve) => {
+			finish = resolve;
+		});
+		const responseBodyStream = {
+			async cancelled() {
+				return new Promise<void>(() => {});
+			},
+			async write() {},
+			async end() {
+				finish();
+			},
+			async error(message: string) {
+				throw new Error(message);
+			},
+		};
+		const response = new Response(
+			new ReadableStream<Uint8Array>({
+				start(controller) {
+					bodyController = controller;
+				},
+			}),
+			{
+				status: 200,
+				headers: {
+					"content-type": "text/event-stream",
+				},
+			},
+		);
+
+		const runtimeResponsePromise = nativeRegistryTestInternals
+			.convertRuntimeHttpResponse(response, responseBodyStream)
+			.then(({ response }) => response);
+		const headersReturnedBeforeBody = await Promise.race([
+			runtimeResponsePromise.then(() => true),
+			new Promise<false>((resolve) =>
+				setTimeout(() => resolve(false), 10),
+			),
+		]);
+
+		bodyController.enqueue(new TextEncoder().encode("data: ready\n\n"));
+		bodyController.close();
+		const runtimeResponse = await runtimeResponsePromise;
+		await finished;
+
+		expect(headersReturnedBeforeBody).toBe(true);
+		expect(runtimeResponse).toEqual({
+			status: 200,
+			headers: {
+				"content-type": "text/event-stream",
+			},
+			stream: true,
+		});
+	});
+
+	test("keeps streaming response lifecycle open until the body finishes", async () => {
+		let bodyController!: ReadableStreamDefaultController<Uint8Array>;
+		const responseBodyStream = {
+			async cancelled() {
+				return new Promise<void>(() => {});
+			},
+			async write() {},
+			async end() {},
+			async error(message: string) {
+				throw new Error(message);
+			},
+		};
+		const response = new Response(
+			new ReadableStream<Uint8Array>({
+				start(controller) {
+					bodyController = controller;
+				},
+			}),
+		);
+
+		const conversion =
+			await nativeRegistryTestInternals.convertRuntimeHttpResponse(
+				response,
+				responseBodyStream,
+			);
+		expect(conversion.response.stream).toBe(true);
+		expect(conversion.bodyCompletion).toBeDefined();
+
+		let bodySettled = false;
+		void conversion.bodyCompletion?.then(() => {
+			bodySettled = true;
+		});
+		await Promise.resolve();
+		expect(bodySettled).toBe(false);
+
+		bodyController.close();
+		await conversion.bodyCompletion;
+		expect(bodySettled).toBe(true);
+	});
+
+	test("cancels an idle streamed response when the native receiver drops", async () => {
+		let cancelNative!: () => void;
+		const nativeCancelled = new Promise<void>((resolve) => {
+			cancelNative = resolve;
+		});
+		let cancelBody!: (reason?: unknown) => void;
+		const bodyCancelled = new Promise<unknown>((resolve) => {
+			cancelBody = resolve;
+		});
+		const responseBodyStream = {
+			cancelled: () => nativeCancelled,
+			async write() {},
+			async end() {},
+			async error() {},
+		};
+		const response = new Response(
+			new ReadableStream<Uint8Array>({
+				cancel: cancelBody,
+			}),
+			{
+				headers: {
+					"content-type": "text/event-stream",
+				},
+			},
+		);
+
+		const conversion =
+			await nativeRegistryTestInternals.convertRuntimeHttpResponse(
+				response,
+				responseBodyStream,
+			);
+		cancelNative();
+		const reason = await bodyCancelled;
+		await conversion.bodyCompletion;
+
+		expect(conversion.response.stream).toBe(true);
+		expect(reason).toBeInstanceOf(Error);
+		expect((reason as Error).message).toContain("receiver dropped");
+	});
+});

--- a/rivetkit-typescript/packages/rivetkit/tests/sse-contract-harness.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/sse-contract-harness.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "vitest";
+import { parseEventStream } from "./driver/sse-contract-harness";
+
+test("the SSE parser strips exactly one leading BOM", async () => {
+	const events: string[] = [];
+	const bytes = new TextEncoder().encode("\uFEFF\uFEFFdata: hidden\n\n");
+	const body = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(bytes);
+			controller.close();
+		},
+	});
+
+	await parseEventStream(
+		body,
+		"",
+		(event) => events.push(event.data),
+		() => {},
+	);
+
+	expect(events).toEqual([]);
+});
+
+test("the SSE parser retains IDs from blocks without data", async () => {
+	const events: Array<{ data: string; id: string }> = [];
+	const bytes = new TextEncoder().encode("id: retained\n\n");
+	const body = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(bytes);
+			controller.close();
+		},
+	});
+
+	const lastEventId = await parseEventStream(
+		body,
+		"",
+		(event) => events.push({ data: event.data, id: event.id }),
+		() => {},
+	);
+
+	expect(lastEventId).toBe("retained");
+	expect(events).toEqual([]);
+});
+
+test("the SSE parser handles a large event split across many chunks", async () => {
+	const dataLength = 5 * 1024 * 1024;
+	const bytes = new TextEncoder().encode(
+		`data: ${"x".repeat(dataLength)}\n\n`,
+	);
+	const body = new ReadableStream<Uint8Array>({
+		start(controller) {
+			for (
+				let offset = 0;
+				offset < bytes.byteLength;
+				offset += 16 * 1024
+			) {
+				controller.enqueue(bytes.subarray(offset, offset + 16 * 1024));
+			}
+			controller.close();
+		},
+	});
+	let parsedLength = 0;
+
+	await parseEventStream(
+		body,
+		"",
+		(event) => {
+			parsedLength = event.data.length;
+		},
+		() => {},
+	);
+
+	expect(parsedLength).toBe(dataLength);
+}, 10_000);

--- a/website/src/content/docs/actors/limits.mdx
+++ b/website/src/content/docs/actors/limits.mdx
@@ -50,7 +50,7 @@ These limits affect actions that do not use `.connect()` and [low-level HTTP req
 | Name | Soft Limit | Hard Limit | Description |
 |------|------------|------------|-------------|
 | Max request body size | — | 20 MiB | Maximum size of HTTP request bodies. |
-| Max response body size | — | 20 MiB | Maximum size of HTTP response bodies. |
+| Max buffered response body size | — | 20 MiB | Maximum size of non-streaming HTTP response bodies. Streaming responses, including SSE, do not have a total-size limit. Per-request gateway buffering is capped at 20 MiB, but slow downstream consumers can still create pressure in shared actor transport queues. |
 | Request timeout | 60 seconds | — | Maximum time for an `onRequest` handler to complete. Defaults to `actionTimeout`; configure with `actionTimeout`. |
 
 ### Networking

--- a/website/src/content/docs/actors/request-handler.mdx
+++ b/website/src/content/docs/actors/request-handler.mdx
@@ -86,7 +86,6 @@ The `onRequest` handler is WinterTC compliant and will work with existing librar
 
 ## Limitations
 
-- Does not support streaming responses & server-sent events at the moment. See the [tracking issue](https://github.com/rivet-dev/rivet/issues/3529).
 - `OPTIONS` requests currently are handled by Rivet and are not passed to `onRequest`
 
 ## Advanced


### PR DESCRIPTION
Streams HTTP request/response bodies through rivetkit instead of buffering them, so actors can serve and proxy long-lived/streaming responses (SSE, chunked, long-poll) without materializing the whole body.

## Changes
- **protocol:** add v6 HTTP abort reasons
- **http:** shared streaming body primitives
- **gateway:** stream HTTP bodies over the envoy tunnel
- **core:** stream HTTP bodies through rivetkit core; surface streaming request bodies
- **napi:** stream HTTP bodies through the TypeScript runtime
- **envoy-client:** finalize HTTP stream safety
- **test:** cover streaming requests and responses

## Why
Consumers forwarding fetch Request/Response through an actor (e.g. the Flue Rivet target) currently must serialize the entire body to JSON, which breaks SSE/streaming (buffers until the stream closes) and mishandles null-body responses. End-to-end body streaming removes that limitation.