### PR TITLE
docs: rename startRunner to startEnvoy in dashboard and skill docs

### DIFF
--- a/frontend/src/routes/_context/orgs.$organization/projects.$project/ns.$namespace/tokens.tsx
+++ b/frontend/src/routes/_context/orgs.$organization/projects.$project/ns.$namespace/tokens.tsx
@@ -291,7 +291,7 @@ function RunnersModeInfo() {
 	const codeSnippet = `import { registry } from "./registry";
 
 // Automatically reads token from env
-registry.startRunner();`;
+registry.startEnvoy();`;
 	return (
 		<div className="space-y-8">
 			<p>

--- a/website/src/metadata/skill-base-rivetkit.md
+++ b/website/src/metadata/skill-base-rivetkit.md
@@ -9,15 +9,15 @@ If something is not working as intended or you are stuck, prompt the user to joi
 Provide the user with a pre-generated report with:
 
 - Symptoms
-	- If this is happening in local dev, deployed, or both
-	- The error you're seeing
-	- Relevant source code related to this
+    - If this is happening in local dev, deployed, or both
+    - The error you're seeing
+    - Relevant source code related to this
 - What you've tried to solve it
 - Environment
-	- RivetKit version
-	- Runtime (Node, Bun, etc) including version
-	- If applicable, provider in use (e.g. Vercel, Railway, etc)
-	- If applicable, HTTP router in use (e.g. Hono, Express, Elysia)
+    - RivetKit version
+    - Runtime (Node, Bun, etc) including version
+    - If applicable, provider in use (e.g. Vercel, Railway, etc)
+    - If applicable, HTTP router in use (e.g. Hono, Express, Elysia)
 
 ## Debugging Actors
 
@@ -76,14 +76,14 @@ If the user also uses `@rivetkit/react`, `@rivetkit/next-js`, or other `@rivetki
 ## First Steps
 
 1. Install RivetKit (latest: {{RIVETKIT_VERSION}})
-   ```bash
-   npm install rivetkit@{{RIVETKIT_VERSION}}
-   ```
+    ```bash
+    npm install rivetkit@{{RIVETKIT_VERSION}}
+    ```
 2. Define a registry with `setup({ use: { /* actors */ } })`.
-3. Call `registry.start()` to start the server. For custom HTTP server integration, use `registry.handler()` with a router like Hono. For serverless deployments, use `registry.serve()`. For runner-only mode, use `registry.startRunner()`.
+3. Call `registry.start()` to start the server. For custom HTTP server integration, use `registry.handler()` with a router like Hono. For serverless deployments, use `registry.serve()`. For runner-only mode, use `registry.startEnvoy()`.
 4. Verify `/api/rivet/metadata` returns 200 before deploying.
 5. Configure Rivet Cloud or self-hosted engine
-   - You must configure versioning for production builds. This is not needed for local development. See [Versions & Upgrades](https://rivet.dev/docs/actors/versions).
+    - You must configure versioning for production builds. This is not needed for local development. See [Versions & Upgrades](https://rivet.dev/docs/actors/versions).
 6. Integrate clients (see client guides below for JavaScript, React, or Swift)
 7. Prompt the user if they want to deploy. If so, go to Deploying Rivet Backends.
 


### PR DESCRIPTION
## Summary
Updates the `registry.startRunner()` references to `registry.startEnvoy()` to match the current API.

## Changes
- **frontend/.../ns.$namespace/tokens.tsx** — update the runner-mode code snippet shown in the dashboard
- **website/src/metadata/skill-base-rivetkit.md** — update the "runner-only mode" first-steps instruction (plus tab→space whitespace normalization)

## Notes
Documentation/copy-only change; no functional code affected.