### PR TITLE
feat(frontend): agentOS onboarding wizard (rebased) + fixes

### DIFF
--- a/frontend/src/app/actors-grid.tsx
+++ b/frontend/src/app/actors-grid.tsx
@@ -1,4 +1,4 @@
-import { faGear, faLogs, faPlus, Icon } from "@rivet-gg/icons";
+import { faChevronDown, faGear, faLogs, faPlus, Icon } from "@rivet-gg/icons";
 import {
 	queryOptions,
 	useInfiniteQuery,
@@ -22,6 +22,13 @@ import {
 	useCloudNamespaceDataProvider,
 	useDataProvider,
 } from "@/components/actors";
+import { Badge } from "@/components/ui/badge";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { NoProvidersAlert } from "@/components/actors/no-providers-alert";
 import { ActorIcon } from "@/components/lazy-icon";
 import { VisibilitySensor } from "@/components/visibility-sensor";
@@ -55,6 +62,57 @@ function _GridCard({
 		>
 			{children}
 		</Wrapper>
+	);
+}
+
+// Header create affordance. With the agentOS feature flag on, the single
+// "Create Actor" button becomes a "Create" menu offering Actor or agentOS;
+// both open the same create dialog, the latter with agentOS-tailored copy.
+function CreateMenu({ buttonVariant }: { buttonVariant: "outline" | "default" }) {
+	const navigate = useNavigate();
+	const openModal = (modal: string) =>
+		navigate({ to: ".", search: (old) => ({ ...old, modal }) });
+
+	if (!features.agentOs) {
+		return (
+			<Button
+				variant={buttonVariant}
+				size="sm"
+				startIcon={<Icon icon={faPlus} />}
+				onClick={() => openModal("create-actor")}
+			>
+				Create Actor
+			</Button>
+		);
+	}
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant={buttonVariant}
+					size="sm"
+					startIcon={<Icon icon={faPlus} />}
+					endIcon={<Icon icon={faChevronDown} />}
+				>
+					Create
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuItem onClick={() => openModal("create-actor")}>
+					Actor
+				</DropdownMenuItem>
+				<DropdownMenuItem onClick={() => openModal("create-agent-os")}>
+					agentOS
+					<Badge
+						variant="outline"
+						className="ml-2 text-[10px] leading-none py-0.5 px-1.5 font-medium"
+					>
+						Preview
+					</Badge>
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 }
 
@@ -186,7 +244,7 @@ export function ActorsGrid({ namespaceLabel }: { namespaceLabel?: string }) {
 										size="icon-sm"
 										aria-label="Namespace settings"
 										onClick={() => {
-											navigate({
+											void navigate({
 												to: ".",
 												search: (old) => ({
 													...old,
@@ -208,22 +266,7 @@ export function ActorsGrid({ namespaceLabel }: { namespaceLabel?: string }) {
 								Actors
 							</h2>
 							{builds.length > 0 ? (
-								<Button
-									variant="outline"
-									size="sm"
-									startIcon={<Icon icon={faPlus} />}
-									onClick={() => {
-										navigate({
-											to: ".",
-											search: (old) => ({
-												...old,
-												modal: "create-actor",
-											}),
-										});
-									}}
-								>
-									Create Actor
-								</Button>
+								<CreateMenu buttonVariant="outline" />
 							) : null}
 						</header>
 
@@ -246,22 +289,7 @@ export function ActorsGrid({ namespaceLabel }: { namespaceLabel?: string }) {
 										Deploy code that registers an actor to
 										see it here.
 									</SmallText>
-									<Button
-										variant="default"
-										size="sm"
-										startIcon={<Icon icon={faPlus} />}
-										onClick={() => {
-											navigate({
-												to: ".",
-												search: (old) => ({
-													...old,
-													modal: "create-actor",
-												}),
-											});
-										}}
-									>
-										Create Actor
-									</Button>
+									<CreateMenu buttonVariant="default" />
 								</div>
 							)
 						) : (

--- a/frontend/src/app/actors-grid.tsx
+++ b/frontend/src/app/actors-grid.tsx
@@ -108,7 +108,7 @@ function CreateMenu({ buttonVariant }: { buttonVariant: "outline" | "default" })
 						variant="outline"
 						className="ml-2 text-[10px] leading-none py-0.5 px-1.5 font-medium"
 					>
-						Preview
+						Beta
 					</Badge>
 				</DropdownMenuItem>
 			</DropdownMenuContent>

--- a/frontend/src/app/data-providers/engine-data-provider.tsx
+++ b/frontend/src/app/data-providers/engine-data-provider.tsx
@@ -201,7 +201,7 @@ export const createNamespaceContext = ({
 					);
 
 					for (const page of regions.pages) {
-						for (const region of page.datacenters) {
+						for (const region of page.datacenters ?? []) {
 							if (region.name === name) {
 								return region;
 							}
@@ -383,7 +383,7 @@ export const createNamespaceContext = ({
 					return data;
 				},
 				getNextPageParam: (lastPage) => {
-					if (Object.keys(lastPage.names).length < RECORDS_PER_PAGE) {
+					if (Object.keys(lastPage.names ?? {}).length < RECORDS_PER_PAGE) {
 						return undefined;
 					}
 					return lastPage.pagination?.cursor;
@@ -627,7 +627,7 @@ export const createNamespaceContext = ({
 					return data;
 				},
 				getNextPageParam: (lastPage) => {
-					if (lastPage.names.length < RECORDS_PER_PAGE) {
+					if ((lastPage.names ?? []).length < RECORDS_PER_PAGE) {
 						return undefined;
 					}
 					return lastPage.pagination.cursor;
@@ -752,11 +752,11 @@ export const createNamespaceContext = ({
 
 				select: (data) =>
 					data.pages.flatMap((page) =>
-						Object.entries(page.runnerConfigs),
+						Object.entries(page.runnerConfigs ?? {}),
 					),
 				getNextPageParam: (lastPage) => {
 					if (
-						Object.values(lastPage.runnerConfigs).length <
+						Object.values(lastPage.runnerConfigs ?? {}).length <
 						RECORDS_PER_PAGE
 					) {
 						return undefined;
@@ -848,7 +848,10 @@ export const createNamespaceContext = ({
 						limit: 100,
 					});
 
-					const names = Object.keys(namesList.names);
+					// The engine may return `names` as null/undefined (rather than
+					// an empty object) for a namespace with no actors; guard so the
+					// existence probe resolves to 0 instead of throwing.
+					const names = Object.keys(namesList.names ?? {});
 					const BATCH_SIZE = 32;
 
 					for (let i = 0; i < names.length; i += BATCH_SIZE) {
@@ -910,7 +913,7 @@ export function hasProvider(
 ): boolean {
 	if (!configs) return false;
 	return configs.some(([, config]) =>
-		Object.values(config.datacenters).some(
+		Object.values(config.datacenters ?? {}).some(
 			(datacenter) =>
 				datacenter.metadata &&
 				hasMetadataProvider(datacenter.metadata) &&

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -62,8 +62,6 @@ import { EnvVariables, useRivetDsn } from "./env-variables";
 import { StepperForm, StepVisibilityContext } from "./forms/stepper-form";
 import { Content } from "./layout";
 import { AgentSelectStep } from "@/components/onboarding/agent-os/agent-select-step";
-import { SoftwareSelectStep } from "@/components/onboarding/agent-os/software-select-step";
-import { SandboxMountStep } from "@/components/onboarding/agent-os/sandbox-mount-step";
 import { buildAgentOsSetup } from "@/components/onboarding/agent-os/build-agent-os-setup";
 import {
 	DEFAULT_AGENT,
@@ -109,32 +107,6 @@ const stepper = defineStepper(
 		description: "Pick the coding agent to run inside agentOS.",
 		next: "Continue",
 		schema: z.object({ agent: z.string().nonempty() }),
-		group: "local",
-		isVisible: (values: Record<string, unknown>) =>
-			values.template === "agent-os",
-	},
-	{
-		id: "software",
-		title: "Choose software",
-		description: "Select the packages baked into your build image.",
-		next: "Continue",
-		schema: z.object({ packages: z.array(z.string()) }),
-		group: "local",
-		isVisible: (values: Record<string, unknown>) =>
-			values.template === "agent-os",
-	},
-	{
-		id: "sandbox",
-		title: "Sandbox & mounts",
-		description:
-			"Optionally mount a full sandbox for heavy workloads. Off by default.",
-		next: "Continue",
-		schema: z.object({
-			sandbox: z.object({
-				enabled: z.boolean(),
-				provider: z.string().optional(),
-			}),
-		}),
 		group: "local",
 		isVisible: (values: Record<string, unknown>) =>
 			values.template === "agent-os",
@@ -353,16 +325,6 @@ export function GettingStarted({
 									agent: () => (
 										<StepContent>
 											<AgentSelectStep />
-										</StepContent>
-									),
-									software: () => (
-										<StepContent>
-											<SoftwareSelectStep />
-										</StepContent>
-									),
-									sandbox: () => (
-										<StepContent>
-											<SandboxMountStep />
 										</StepContent>
 									),
 									handoff: () => (

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -678,7 +678,7 @@ function AgentOsKeyNotice() {
 					from the host process, so your server passes it to each
 					session.{" "}
 					<a
-						href="https://rivet.dev/docs/agent-os/llm-credentials"
+						href="https://agentos-sdk.dev/docs/llm-credentials/"
 						target="_blank"
 						rel="noreferrer"
 						className="text-primary hover:underline"

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -837,7 +837,7 @@ function BuildTargetSelector() {
 						<BuildTargetCard
 							icon={<AgentOsLogo className="size-5" />}
 							label="agentOS"
-							badge="Preview"
+							badge="Beta"
 							description="An open-source OS for agents. Runs in-process with ~6 ms cold starts."
 							isSelected={field.value === "agent-os"}
 							onSelect={() =>

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -16,7 +16,7 @@ import {
 } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { motion } from "framer-motion";
-import { type ReactNode, Suspense } from "react";
+import { type ReactNode, Suspense, useContext, useMemo } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import { toast } from "sonner";
 import { match } from "ts-pattern";
@@ -59,8 +59,17 @@ import {
 	ConfigurationAccordion,
 } from "./dialogs/connect-manual-serverless-frame";
 import { EnvVariables, useRivetDsn } from "./env-variables";
-import { StepperForm } from "./forms/stepper-form";
+import { StepperForm, StepVisibilityContext } from "./forms/stepper-form";
 import { Content } from "./layout";
+import { AgentSelectStep } from "@/components/onboarding/agent-os/agent-select-step";
+import { SoftwareSelectStep } from "@/components/onboarding/agent-os/software-select-step";
+import { SandboxMountStep } from "@/components/onboarding/agent-os/sandbox-mount-step";
+import { buildAgentOsSetup } from "@/components/onboarding/agent-os/build-agent-os-setup";
+import {
+	DEFAULT_AGENT,
+	DEFAULT_PACKAGES,
+	DEFAULT_SANDBOX_PROVIDER,
+} from "@/components/onboarding/agent-os/catalog";
 import { RunnerConfigToggleGroup } from "./runner-config-toggle-group";
 import {
 	getAgentInstructionsPrompt,
@@ -78,10 +87,68 @@ const stepper = defineStepper(
 	{
 		id: "local",
 		title: "Run locally",
+		titleFor: (values: Record<string, unknown>) =>
+			values.template === "agent-os"
+				? "What are you building?"
+				: "Run locally",
 		description: "Get your first Rivet Actor running on your machine.",
+		next: "Continue",
+		// `template` is carried in the step schema so the stepper accumulates it
+		// into its running values. The agentOS steps below gate on it via
+		// isVisible, so it must survive navigation past this step.
+		schema: z.object({
+			template: z.enum(["actor", "agent-os"]).optional(),
+		}),
+		group: "local",
+	},
+	// agentOS-only steps. Hidden for the actor path via isVisible, so the
+	// stepper skips them and the wizard stays a two-step local -> deploy flow.
+	{
+		id: "agent",
+		title: "Choose your agent",
+		description: "Pick the coding agent to run inside agentOS.",
+		next: "Continue",
+		schema: z.object({ agent: z.string().nonempty() }),
+		group: "local",
+		isVisible: (values: Record<string, unknown>) =>
+			values.template === "agent-os",
+	},
+	{
+		id: "software",
+		title: "Choose software",
+		description: "Select the packages baked into your build image.",
+		next: "Continue",
+		schema: z.object({ packages: z.array(z.string()) }),
+		group: "local",
+		isVisible: (values: Record<string, unknown>) =>
+			values.template === "agent-os",
+	},
+	{
+		id: "sandbox",
+		title: "Sandbox & mounts",
+		description:
+			"Optionally mount a full sandbox for heavy workloads. Off by default.",
+		next: "Continue",
+		schema: z.object({
+			sandbox: z.object({
+				enabled: z.boolean(),
+				provider: z.string().optional(),
+			}),
+		}),
+		group: "local",
+		isVisible: (values: Record<string, unknown>) =>
+			values.template === "agent-os",
+	},
+	{
+		id: "handoff",
+		title: "Set up agentOS",
+		description:
+			"Boot an agentOS instance and run your first session, locally.",
 		next: "Continue to deploy",
 		schema: z.object({}),
 		group: "local",
+		isVisible: (values: Record<string, unknown>) =>
+			values.template === "agent-os",
 	},
 	{
 		id: "deploy",
@@ -192,6 +259,12 @@ export function GettingStarted({
 		datacenter: "",
 		mode: "serverless" as "serverless" | "serverfull",
 		template: "actor" as "actor" | "agent-os",
+		agent: DEFAULT_AGENT,
+		packages: DEFAULT_PACKAGES,
+		sandbox: { enabled: false, provider: DEFAULT_SANDBOX_PROVIDER } as {
+			enabled: boolean;
+			provider?: string;
+		},
 		...(initialRunnerConfig || {}),
 	};
 
@@ -275,6 +348,26 @@ export function GettingStarted({
 									local: () => (
 										<StepContent>
 											<RunLocallyStep />
+										</StepContent>
+									),
+									agent: () => (
+										<StepContent>
+											<AgentSelectStep />
+										</StepContent>
+									),
+									software: () => (
+										<StepContent>
+											<SoftwareSelectStep />
+										</StepContent>
+									),
+									sandbox: () => (
+										<StepContent>
+											<SandboxMountStep />
+										</StepContent>
+									),
+									handoff: () => (
+										<StepContent>
+											<AgentOsHandoff />
 										</StepContent>
 									),
 									deploy: () => (
@@ -544,9 +637,13 @@ function SkipOnboardingHeaderLink() {
 
 function OnboardingProgress({ action }: { action?: ReactNode }) {
 	const s = stepper.useStepper();
-	const steps = s.all;
-	const currentIndex = steps.findIndex((step) => step.id === s.current.id);
-	const total = steps.length;
+	const { isStepVisible, visibleStepIndex, visibleStepCount } =
+		useContext(StepVisibilityContext);
+	// Count only steps visible for the current path (agentOS adds steps that are
+	// hidden for the actor path), so "Step X of N" and the dots stay accurate.
+	const steps = s.all.filter((step) => isStepVisible(step.id));
+	const currentIndex = Math.max(0, visibleStepIndex(s.current.id));
+	const total = visibleStepCount;
 	const groupLabel = s.current.group === "local" ? "Local setup" : "Deploy";
 	return (
 		<div className="mb-6 flex flex-col gap-2">
@@ -794,6 +891,77 @@ function RunLocallyStep() {
 					</div>
 				</>
 			)}
+		</div>
+	);
+}
+
+// agentOS handoff: turns the agent/software/sandbox selections into the install
+// command, server.ts/client.ts, and a copy-prompt for the coding agent. Shown
+// as the final local-group step on the agentOS path.
+function AgentOsHandoff() {
+	const agent = useWatch({ name: "agent" }) as string | undefined;
+	const packages = useWatch({ name: "packages" }) as string[] | undefined;
+	const sandbox = useWatch({ name: "sandbox" }) as
+		| { enabled: boolean; provider?: string }
+		| undefined;
+
+	const setup = useMemo(
+		() =>
+			buildAgentOsSetup({
+				agent: agent ?? DEFAULT_AGENT,
+				packages: packages ?? DEFAULT_PACKAGES,
+				sandbox: sandbox ?? {
+					enabled: false,
+					provider: DEFAULT_SANDBOX_PROVIDER,
+				},
+			}),
+		[agent, packages, sandbox],
+	);
+
+	return (
+		<div className="flex flex-col gap-6">
+			<AgentPromptBanner
+				code={setup.prompt}
+				title="Use your coding agent"
+				description="Have your coding agent set up agentOS and run a session for you."
+			/>
+			<OrDivider label="or set it up yourself" />
+			<div className="flex flex-col gap-4">
+				<div>
+					<p className="font-medium mb-1.5">Install</p>
+					<CommandBox command={setup.installCommand} />
+				</div>
+				<CodeGroup className="my-0">
+					{[
+						<CodeFrame
+							key="server"
+							language="typescript"
+							title="server.ts"
+							code={() => setup.serverCode}
+							className="m-0"
+						>
+							<CodePreview
+								language="typescript"
+								className="text-left"
+								code={setup.serverCode}
+							/>
+						</CodeFrame>,
+						<CodeFrame
+							key="client"
+							language="typescript"
+							title="client.ts"
+							code={() => setup.clientCode}
+							className="m-0"
+						>
+							<CodePreview
+								language="typescript"
+								className="text-left"
+								code={setup.clientCode}
+							/>
+						</CodeFrame>,
+					]}
+				</CodeGroup>
+			</div>
 		</div>
 	);
 }

--- a/frontend/src/app/getting-started.tsx
+++ b/frontend/src/app/getting-started.tsx
@@ -1,8 +1,10 @@
 import {
+	faActors,
 	faArrowRight,
 	faCheck,
 	faChevronDown,
 	faCopy,
+	faKey,
 	Icon,
 } from "@rivet-gg/icons";
 import { deployOptions, type Provider } from "@rivetkit/shared-data";
@@ -26,6 +28,7 @@ import {
 	CodeGroup,
 	CodeGroupSyncProvider,
 	CodePreview,
+	FormField,
 	Skeleton,
 } from "@/components";
 import {
@@ -188,6 +191,7 @@ export function GettingStarted({
 		datacenters: {},
 		datacenter: "",
 		mode: "serverless" as "serverless" | "serverfull",
+		template: "actor" as "actor" | "agent-os",
 		...(initialRunnerConfig || {}),
 	};
 
@@ -479,8 +483,10 @@ function RivetDeploy() {
 		dataProvider.createApiTokenQueryOptions({ name: "Onboarding" }),
 	);
 	const deployCommand = `npx @rivetkit/cli deploy --token ${cloudToken ?? "<RIVET_CLOUD_TOKEN>"}`;
+	const isAgentOs = useWatch({ name: "template" }) === "agent-os";
 	return (
 		<div className="flex flex-col gap-6">
+			{isAgentOs ? <AgentOsKeyNotice /> : null}
 			<CopyAgentInstructionsButton provider="rivet" />
 			<OrDivider label="or deploy manually" />
 			<div>
@@ -595,35 +601,199 @@ function CommandBox({ command }: { command: string }) {
 	);
 }
 
+function AgentOsKeyNotice() {
+	return (
+		<div className="flex gap-3 rounded-md border border-border bg-muted/30 p-3 text-sm">
+			<Icon
+				icon={faKey}
+				className="mt-0.5 shrink-0 text-muted-foreground"
+			/>
+			<div className="space-y-1">
+				<p className="font-medium">agentOS needs an LLM key</p>
+				<p className="text-muted-foreground text-xs">
+					Set{" "}
+					<code className="rounded bg-muted px-1 py-0.5 text-foreground">
+						ANTHROPIC_API_KEY
+					</code>{" "}
+					as a secret on your deployment. agentOS doesn't inherit it
+					from the host process, so your server passes it to each
+					session.{" "}
+					<a
+						href="https://rivet.dev/docs/agent-os/llm-credentials"
+						target="_blank"
+						rel="noreferrer"
+						className="text-primary hover:underline"
+					>
+						Learn more
+					</a>
+				</p>
+			</div>
+		</div>
+	);
+}
+
+// agentOS brand mark (rounded square + "OS") drawn in currentColor so it adapts
+// to the theme, unlike the white-only marketing SVG.
+function AgentOsLogo({ className }: { className?: string }) {
+	return (
+		<svg
+			viewBox="0 0 32 32"
+			fill="none"
+			className={className}
+			aria-hidden="true"
+		>
+			<rect
+				x="2.75"
+				y="2.75"
+				width="26.5"
+				height="26.5"
+				rx="8"
+				stroke="currentColor"
+				strokeWidth="2.5"
+			/>
+			<text
+				x="16"
+				y="20.5"
+				textAnchor="middle"
+				fontSize="11"
+				fontWeight="700"
+				fontFamily="inherit"
+				fill="currentColor"
+			>
+				OS
+			</text>
+		</svg>
+	);
+}
+
+function BuildTargetCard({
+	icon,
+	label,
+	description,
+	badge,
+	isSelected,
+	onSelect,
+}: {
+	icon: ReactNode;
+	label: string;
+	description: string;
+	badge?: string;
+	isSelected: boolean;
+	onSelect: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			onClick={onSelect}
+			className={cn(
+				"flex items-start gap-3 rounded-lg border px-4 py-3 text-left transition-colors cursor-pointer",
+				isSelected
+					? "border-primary bg-primary/5"
+					: "border-border hover:border-muted-foreground/50",
+			)}
+		>
+			<span className="text-muted-foreground mt-0.5 shrink-0">{icon}</span>
+			<div className="min-w-0">
+				<div className="flex items-center gap-2">
+					<p className="text-sm font-medium">{label}</p>
+					{badge ? (
+						<Badge
+							variant="outline"
+							className="text-[10px] leading-none py-0.5 px-1.5 font-medium"
+						>
+							{badge}
+						</Badge>
+					) : null}
+				</div>
+				<p className="text-xs text-muted-foreground">{description}</p>
+			</div>
+		</button>
+	);
+}
+
+// "What are you building?" selector shown atop the first step when the agentOS
+// feature flag is on. Picking agentOS reveals the agent/software/sandbox/handoff
+// steps (gated by `template === "agent-os"` via the stepper's isVisible).
+function BuildTargetSelector() {
+	const { control, setValue } = useFormContext();
+	return (
+		<FormField
+			control={control}
+			name="template"
+			render={({ field }) => (
+				<div>
+					<p className="font-medium mb-2">What are you building?</p>
+					<div className="grid grid-cols-2 gap-2">
+						<BuildTargetCard
+							icon={<Icon icon={faActors} className="!size-5" />}
+							label="Rivet Actors"
+							description="Realtime, state, and multiplayer for any app"
+							isSelected={field.value !== "agent-os"}
+							onSelect={() =>
+								setValue("template", "actor", {
+									shouldDirty: true,
+									shouldTouch: true,
+									shouldValidate: true,
+								})
+							}
+						/>
+						<BuildTargetCard
+							icon={<AgentOsLogo className="size-5" />}
+							label="agentOS"
+							badge="Preview"
+							description="An open-source OS for agents. Runs in-process with ~6 ms cold starts."
+							isSelected={field.value === "agent-os"}
+							onSelect={() =>
+								setValue("template", "agent-os", {
+									shouldDirty: true,
+									shouldTouch: true,
+									shouldValidate: true,
+								})
+							}
+						/>
+					</div>
+				</div>
+			)}
+		/>
+	);
+}
+
 function RunLocallyStep() {
+	const isAgentOs = useWatch({ name: "template" }) === "agent-os";
 	return (
 		<div className="flex flex-col gap-6">
-			{features.compute ? (
-				<RunLocallyComputeBanner />
-			) : (
-				<RunLocallyGenericBanner />
+			{features.agentOs ? <BuildTargetSelector /> : null}
+			{isAgentOs ? null : (
+				<>
+					{features.compute ? (
+						<RunLocallyComputeBanner />
+					) : (
+						<RunLocallyGenericBanner />
+					)}
+					<OrDivider label="or do it yourself" />
+					<div className="w-full flex items-center justify-between gap-4 rounded-lg px-4 py-4 border border-border">
+						<div className="min-w-0">
+							<p className="font-medium mb-1">
+								Follow the quickstart guide
+							</p>
+							<p className="text-sm text-muted-foreground">
+								Build a Rivet Actor project by hand, step by
+								step.
+							</p>
+						</div>
+						<Button variant="outline" asChild className="shrink-0">
+							<a
+								href="https://rivet.dev/docs/actors/quickstart/"
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								Quickstart guide
+								<Icon icon={faArrowRight} className="ms-2" />
+							</a>
+						</Button>
+					</div>
+				</>
 			)}
-			<OrDivider label="or do it yourself" />
-			<div className="w-full flex items-center justify-between gap-4 rounded-lg px-4 py-4 border border-border">
-				<div className="min-w-0">
-					<p className="font-medium mb-1">
-						Follow the quickstart guide
-					</p>
-					<p className="text-sm text-muted-foreground">
-						Build a Rivet Actor project by hand, step by step.
-					</p>
-				</div>
-				<Button variant="outline" asChild className="shrink-0">
-					<a
-						href="https://rivet.dev/docs/actors/quickstart/"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						Quickstart guide
-						<Icon icon={faArrowRight} className="ms-2" />
-					</a>
-				</Button>
-			</div>
 		</div>
 	);
 }
@@ -818,9 +988,11 @@ function BackendSetupRivet() {
 	const ghSecretCmd = cloudToken
 		? `gh secret set RIVET_CLOUD_TOKEN --body "${cloudToken}"`
 		: "gh secret set RIVET_CLOUD_TOKEN";
+	const isAgentOs = useWatch({ name: "template" }) === "agent-os";
 
 	return (
 		<div className="flex flex-col gap-6">
+			{isAgentOs ? <AgentOsKeyNotice /> : null}
 			<CopyAgentInstructionsButton provider="rivet" />
 			<OrDivider label="or set it up manually" />
 			<div className="flex gap-3">
@@ -933,6 +1105,7 @@ function BackendSetupRivet() {
 
 function BackendSetup() {
 	const provider = useWatch({ name: "provider" });
+	const isAgentOs = useWatch({ name: "template" }) === "agent-os";
 	const mode = useWatch({ name: "mode" }) as
 		| "serverless"
 		| "serverfull"
@@ -945,6 +1118,7 @@ function BackendSetup() {
 
 	return (
 		<div className="flex flex-col gap-6">
+			{isAgentOs ? <AgentOsKeyNotice /> : null}
 			<CopyAgentInstructionsButton provider={provider} />
 			<OrDivider label="or set it up manually" />
 			<div>

--- a/frontend/src/components/actors/dialogs/create-actor-sheet.tsx
+++ b/frontend/src/components/actors/dialogs/create-actor-sheet.tsx
@@ -23,11 +23,13 @@ import * as ActorCreateForm from "../form/actor-create-form";
 interface CreateActorSheetProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
+	variant?: "actor" | "agent-os";
 }
 
 export function CreateActorSheet({
 	open,
 	onOpenChange,
+	variant = "actor",
 }: CreateActorSheetProps) {
 	const dataProvider = useEngineCompatDataProvider();
 	const navigate = useNavigate();
@@ -54,6 +56,14 @@ export function CreateActorSheet({
 	});
 	const { copy } = useActorsView();
 	const [advancedOpen, setAdvancedOpen] = useState(false);
+
+	const isAgentOs = variant === "agent-os";
+	const title = isAgentOs
+		? "Create agentOS instance"
+		: copy.createActorModal.title(name);
+	const description = isAgentOs
+		? "agentOS boots an isolated VM for this key. Choose the agentOS build and a key to identify this instance."
+		: copy.createActorModal.description;
 
 	return (
 		<Dialog
@@ -97,12 +107,8 @@ export function CreateActorSheet({
 					className="flex flex-col min-h-0 flex-1"
 				>
 					<DialogHeader className="px-6 pt-6 pb-4 shrink-0">
-						<DialogTitle>
-							{copy.createActorModal.title(name)}
-						</DialogTitle>
-						<DialogDescription>
-							{copy.createActorModal.description}
-						</DialogDescription>
+						<DialogTitle>{title}</DialogTitle>
+						<DialogDescription>{description}</DialogDescription>
 					</DialogHeader>
 
 					{/*

--- a/frontend/src/components/onboarding/agent-os/agent-os-onboarding.stories.tsx
+++ b/frontend/src/components/onboarding/agent-os/agent-os-onboarding.stories.tsx
@@ -1,0 +1,99 @@
+import type { Story } from "@ladle/react";
+import { useState } from "react";
+import "../../../../.ladle/ladle.css";
+import { AgentSelect } from "./agent-select-step";
+import {
+	type AgentOsSelections,
+	buildAgentOsSetup,
+} from "./build-agent-os-setup";
+import { DEFAULT_AGENT, DEFAULT_PACKAGES } from "./catalog";
+import { SandboxMount, type SandboxValue } from "./sandbox-mount-step";
+import { SoftwareSelect } from "./software-select-step";
+
+// Integration story: the three agentOS selection steps wired to the pure
+// `buildAgentOsSetup` generator, so the generated install command / server.ts /
+// client.ts / handoff prompt update live as selections change. This is the unit
+// that matters (selection -> generated code); the individual card lists are
+// trivial on their own.
+function Harness({ initial }: { initial: AgentOsSelections }) {
+	const [agent, setAgent] = useState(initial.agent);
+	const [packages, setPackages] = useState<string[]>(initial.packages);
+	const [sandbox, setSandbox] = useState<SandboxValue>(initial.sandbox);
+
+	const setup = buildAgentOsSetup({ agent, packages, sandbox });
+
+	return (
+		<div className="bg-background min-h-screen p-10 text-foreground">
+			<div className="grid grid-cols-2 gap-8 max-w-6xl">
+				<div className="flex flex-col gap-6">
+					<Section title="Agent">
+						<AgentSelect value={agent} onChange={setAgent} />
+					</Section>
+					<Section title="Software">
+						<SoftwareSelect value={packages} onChange={setPackages} />
+					</Section>
+					<Section title="Sandbox & mounts">
+						<SandboxMount value={sandbox} onChange={setSandbox} />
+					</Section>
+				</div>
+				<div className="flex flex-col gap-6">
+					<Section title="Install command">
+						<Code>{setup.installCommand}</Code>
+					</Section>
+					<Section title="server.ts">
+						<Code>{setup.serverCode}</Code>
+					</Section>
+					<Section title="client.ts">
+						<Code>{setup.clientCode}</Code>
+					</Section>
+					<Section title="Handoff prompt">
+						<Code>{setup.prompt}</Code>
+					</Section>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function Section({
+	title,
+	children,
+}: {
+	title: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="flex flex-col gap-2">
+			<h2 className="text-sm font-semibold text-foreground">{title}</h2>
+			{children}
+		</div>
+	);
+}
+
+function Code({ children }: { children: string }) {
+	return (
+		<pre className="overflow-auto rounded-md border border-border bg-muted/30 p-3 text-xs text-foreground whitespace-pre-wrap">
+			{children}
+		</pre>
+	);
+}
+
+export const Playground: Story = () => (
+	<Harness
+		initial={{
+			agent: DEFAULT_AGENT,
+			packages: DEFAULT_PACKAGES,
+			sandbox: { enabled: false, provider: "docker" },
+		}}
+	/>
+);
+
+export const WithSandboxAndExtras: Story = () => (
+	<Harness
+		initial={{
+			agent: DEFAULT_AGENT,
+			packages: ["common", "ripgrep", "jq", "git"],
+			sandbox: { enabled: true, provider: "docker" },
+		}}
+	/>
+);

--- a/frontend/src/components/onboarding/agent-os/agent-select-step.tsx
+++ b/frontend/src/components/onboarding/agent-os/agent-select-step.tsx
@@ -1,0 +1,42 @@
+import { useController } from "react-hook-form";
+import { AGENTS, DEFAULT_AGENT } from "./catalog";
+import { SelectCard } from "./select-card";
+
+// Presentational single-select for the coding agent. Pi is available; the rest
+// render disabled with a "Coming soon" badge.
+export function AgentSelect({
+	value,
+	onChange,
+}: {
+	value: string;
+	onChange: (slug: string) => void;
+}) {
+	return (
+		<div className="flex flex-col gap-2">
+			{AGENTS.map((agent) => (
+				<SelectCard
+					key={agent.slug}
+					title={agent.title}
+					description={agent.description}
+					badge={
+						agent.status === "coming-soon" ? "Coming soon" : undefined
+					}
+					selected={value === agent.slug}
+					disabled={agent.status !== "available"}
+					onSelect={() => onChange(agent.slug)}
+				/>
+			))}
+		</div>
+	);
+}
+
+// Wizard step: binds AgentSelect to the react-hook-form `agent` field.
+export function AgentSelectStep() {
+	const { field } = useController({ name: "agent" });
+	return (
+		<AgentSelect
+			value={(field.value as string) ?? DEFAULT_AGENT}
+			onChange={field.onChange}
+		/>
+	);
+}

--- a/frontend/src/components/onboarding/agent-os/build-agent-os-setup.ts
+++ b/frontend/src/components/onboarding/agent-os/build-agent-os-setup.ts
@@ -213,6 +213,10 @@ ${sandboxSection}
 
 Run the server, then the client, and confirm the agent created the file. Then verify it works through the Rivet inspector or your deployed endpoint.
 
+## After Setup
+
+Once everything is built and verified, tell the user they can browse more tools, file systems, agents, and sandbox mounting configurations in the agentOS Registry: https://rivet.dev/agent-os/registry/
+
 ## If You Get Stuck
 
 agentOS is in beta. See https://rivet.dev/docs/agent-os, the troubleshooting guide at https://rivet.dev/docs/actors/troubleshooting, or the Rivet Discord (https://rivet.dev/discord).`;

--- a/frontend/src/components/onboarding/agent-os/build-agent-os-setup.ts
+++ b/frontend/src/components/onboarding/agent-os/build-agent-os-setup.ts
@@ -170,7 +170,7 @@ function buildPrompt(opts: {
 	const sandboxSection = sandboxEnabled
 		? `\n## Sandbox mounting
 
-This setup mounts a ${provider} sandbox at \`/sandbox\` for heavy workloads. It requires the \`sandbox-agent\` and \`@rivet-dev/agent-os-sandbox\` packages and a running ${provider} provider. See https://rivet.dev/docs/agent-os/sandbox.
+This setup mounts a ${provider} sandbox at \`/sandbox\` for heavy workloads. It requires the \`sandbox-agent\` and \`@rivet-dev/agent-os-sandbox\` packages and a running ${provider} provider. See https://agentos-sdk.dev/docs/sandbox/
 `
 		: "";
 
@@ -219,5 +219,5 @@ Once everything is built and verified, tell the user they can browse more tools,
 
 ## If You Get Stuck
 
-agentOS is in beta. See https://rivet.dev/docs/agent-os, the troubleshooting guide at https://rivet.dev/docs/actors/troubleshooting, or the Rivet Discord (https://rivet.dev/discord).`;
+agentOS is in beta. See https://agentos-sdk.dev/docs/, the troubleshooting guide at https://rivet.dev/docs/actors/troubleshooting, or the Rivet Discord (https://rivet.dev/discord).`;
 }

--- a/frontend/src/components/onboarding/agent-os/build-agent-os-setup.ts
+++ b/frontend/src/components/onboarding/agent-os/build-agent-os-setup.ts
@@ -178,7 +178,7 @@ This setup mounts a ${provider} sandbox at \`/sandbox\` for heavy workloads. It 
 
 I want to add agentOS to this project using RivetKit. agentOS is a portable, open-source operating system for agents that runs in your process. Software is baked into the build at build time and is immutable after deploy, so these choices are made up front. An agentOS actor is a normal Rivet Actor and deploys like any other.
 
-Read https://rivet.dev/docs/agent-os/quickstart before making changes. agentOS is in preview.
+Read https://rivet.dev/docs/agent-os/quickstart before making changes. agentOS is in beta.
 
 ## Selections
 
@@ -215,5 +215,5 @@ Run the server, then the client, and confirm the agent created the file. Then ve
 
 ## If You Get Stuck
 
-agentOS is in preview. See https://rivet.dev/docs/agent-os, the troubleshooting guide at https://rivet.dev/docs/actors/troubleshooting, or the Rivet Discord (https://rivet.dev/discord).`;
+agentOS is in beta. See https://rivet.dev/docs/agent-os, the troubleshooting guide at https://rivet.dev/docs/actors/troubleshooting, or the Rivet Discord (https://rivet.dev/discord).`;
 }

--- a/frontend/src/components/onboarding/agent-os/build-agent-os-setup.ts
+++ b/frontend/src/components/onboarding/agent-os/build-agent-os-setup.ts
@@ -1,0 +1,219 @@
+// Pure generator: maps the onboarding agentOS selections to the install command,
+// the server.ts/client.ts the user hands to their coding agent, and a handoff
+// prompt that enumerates the selections so the agent scaffolds matching code.
+//
+// The generated code mirrors the verified in-repo examples:
+//   examples/agent-os/src/agent-session/server.ts  (minimal)
+//   examples/agent-os/src/sandbox/server.ts         (sandbox on)
+// Software/agent packages are default imports passed to `software: [...]`.
+
+import {
+	AGENTS,
+	DEFAULT_AGENT,
+	DEFAULT_SANDBOX_PROVIDER,
+	SOFTWARE,
+	type SoftwareEntry,
+} from "./catalog";
+
+export interface AgentOsSelections {
+	agent: string;
+	packages: string[];
+	sandbox: { enabled: boolean; provider?: string };
+}
+
+export interface AgentOsSetup {
+	installCommand: string;
+	serverCode: string;
+	clientCode: string;
+	prompt: string;
+}
+
+// kebab-case slug -> a valid default-import identifier (e.g. build-essential -> buildEssential).
+function importName(slug: string): string {
+	return slug.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+function resolveAgent(slug: string) {
+	const found = AGENTS.find((a) => a.slug === slug && a.status === "available");
+	// Fall back to the default available agent (Pi) if an unavailable one slips through.
+	return found?.package
+		? found
+		: (AGENTS.find((a) => a.slug === DEFAULT_AGENT) ?? AGENTS[0]);
+}
+
+export function buildAgentOsSetup(selections: AgentOsSelections): AgentOsSetup {
+	const agent = resolveAgent(selections.agent);
+	const agentPackage = agent.package ?? "@rivet-dev/agent-os-pi";
+	const agentSymbol = importName(agent.slug);
+
+	const softwareEntries: SoftwareEntry[] = selections.packages
+		.map((slug) => SOFTWARE.find((s) => s.slug === slug))
+		.filter((s): s is SoftwareEntry => Boolean(s));
+
+	const sandboxEnabled = selections.sandbox.enabled;
+	const provider = selections.sandbox.provider ?? DEFAULT_SANDBOX_PROVIDER;
+
+	const installPackages = [
+		"rivetkit",
+		...softwareEntries.map((s) => s.package),
+		agentPackage,
+		...(sandboxEnabled
+			? ["@rivet-dev/agent-os-sandbox", "sandbox-agent"]
+			: []),
+	];
+	const installCommand = `npm install ${installPackages.join(" ")}`;
+
+	const softwareSymbols = [
+		...softwareEntries.map((s) => importName(s.slug)),
+		agentSymbol,
+	];
+
+	const importLines = [
+		`import { agentOs } from "rivetkit/agent-os";`,
+		`import { setup } from "rivetkit";`,
+		...softwareEntries.map(
+			(s) => `import ${importName(s.slug)} from "${s.package}";`,
+		),
+		`import ${agentSymbol} from "${agentPackage}";`,
+		...(sandboxEnabled
+			? [
+					`import { SandboxAgent } from "sandbox-agent";`,
+					`import { ${provider} } from "sandbox-agent/${provider}";`,
+					`import { createSandboxFs, createSandboxToolkit } from "@rivet-dev/agent-os-sandbox";`,
+				]
+			: []),
+	];
+
+	const softwareArray = softwareSymbols.join(", ");
+
+	const sandboxSetup = sandboxEnabled
+		? `\n// Start a ${provider}-backed sandbox, mounted at /sandbox.\nconst sandbox = await SandboxAgent.start({ sandbox: ${provider}() });\n`
+		: "";
+
+	const optionsBlock = sandboxEnabled
+		? `	options: {
+		software: [${softwareArray}],
+		mounts: [{ path: "/sandbox", driver: createSandboxFs({ client: sandbox }) }],
+		toolKits: [createSandboxToolkit({ client: sandbox })],
+	},`
+		: `	options: { software: [${softwareArray}] },`;
+
+	const serverCode = `${importLines.join("\n")}
+${sandboxSetup}
+const vm = agentOs({
+${optionsBlock}
+});
+
+export const registry = setup({ use: { vm } });
+registry.start();
+`;
+
+	const clientCode = `import { createClient } from "rivetkit/client";
+import type { registry } from "./server";
+
+const client = createClient<typeof registry>();
+
+// getOrCreate boots the agentOS instance on first call.
+const agent = client.vm.getOrCreate(["my-agent"]);
+
+agent.on("sessionEvent", (data) => console.log(data.event));
+
+const session = await agent.createSession("${agent.slug}", {
+	env: { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY! },
+});
+await agent.sendPrompt(
+	session.sessionId,
+	"Write a hello world script to /home/user/hello.js",
+);
+
+const content = await agent.readFile("/home/user/hello.js");
+console.log(new TextDecoder().decode(content));
+`;
+
+	const prompt = buildPrompt({
+		agentTitle: agent.title,
+		softwareEntries,
+		sandboxEnabled,
+		provider,
+		installCommand,
+		serverCode,
+		clientCode,
+	});
+
+	return { installCommand, serverCode, clientCode, prompt };
+}
+
+function buildPrompt(opts: {
+	agentTitle: string;
+	softwareEntries: SoftwareEntry[];
+	sandboxEnabled: boolean;
+	provider: string;
+	installCommand: string;
+	serverCode: string;
+	clientCode: string;
+}): string {
+	const {
+		agentTitle,
+		softwareEntries,
+		sandboxEnabled,
+		provider,
+		installCommand,
+		serverCode,
+		clientCode,
+	} = opts;
+
+	const softwareList =
+		softwareEntries.length > 0
+			? softwareEntries.map((s) => `- ${s.title} (${s.package})`).join("\n")
+			: "- (none beyond the agent)";
+
+	const sandboxSection = sandboxEnabled
+		? `\n## Sandbox mounting
+
+This setup mounts a ${provider} sandbox at \`/sandbox\` for heavy workloads. It requires the \`sandbox-agent\` and \`@rivet-dev/agent-os-sandbox\` packages and a running ${provider} provider. See https://rivet.dev/docs/agent-os/sandbox.
+`
+		: "";
+
+	return `# agentOS Setup
+
+I want to add agentOS to this project using RivetKit. agentOS is a portable, open-source operating system for agents that runs in your process. Software is baked into the build at build time and is immutable after deploy, so these choices are made up front. An agentOS actor is a normal Rivet Actor and deploys like any other.
+
+Read https://rivet.dev/docs/agent-os/quickstart before making changes. agentOS is in preview.
+
+## Selections
+
+Agent: ${agentTitle}
+Software baked into the build:
+${softwareList}
+Sandbox mounting: ${sandboxEnabled ? `enabled (${provider})` : "disabled"}
+
+## Steps
+
+### Step 1: Install
+
+\`\`\`bash
+${installCommand}
+\`\`\`
+
+### Step 2: Create the server (server.ts)
+
+\`\`\`ts
+${serverCode}\`\`\`
+
+### Step 3: Configure the model key
+
+The agent needs an LLM key at runtime. Set \`ANTHROPIC_API_KEY\` in the environment locally, and once deployed, set it as a deployment secret. Never hardcode it.
+
+### Step 4: Boot an instance and run a prompt (client.ts)
+
+\`\`\`ts
+${clientCode}\`\`\`
+${sandboxSection}
+### Step 5: Verify
+
+Run the server, then the client, and confirm the agent created the file. Then verify it works through the Rivet inspector or your deployed endpoint.
+
+## If You Get Stuck
+
+agentOS is in preview. See https://rivet.dev/docs/agent-os, the troubleshooting guide at https://rivet.dev/docs/actors/troubleshooting, or the Rivet Discord (https://rivet.dev/discord).`;
+}

--- a/frontend/src/components/onboarding/agent-os/build-agent-os-setup.ts
+++ b/frontend/src/components/onboarding/agent-os/build-agent-os-setup.ts
@@ -178,7 +178,7 @@ This setup mounts a ${provider} sandbox at \`/sandbox\` for heavy workloads. It 
 
 I want to add agentOS to this project using RivetKit. agentOS is a portable, open-source operating system for agents that runs in your process. Software is baked into the build at build time and is immutable after deploy, so these choices are made up front. An agentOS actor is a normal Rivet Actor and deploys like any other.
 
-Read https://rivet.dev/docs/agent-os/quickstart before making changes. agentOS is in beta.
+Read https://agentos-sdk.dev/docs/quickstart/ before making changes. agentOS is in beta.
 
 ## Selections
 
@@ -215,7 +215,7 @@ Run the server, then the client, and confirm the agent created the file. Then ve
 
 ## After Setup
 
-Once everything is built and verified, tell the user they can browse more tools, file systems, agents, and sandbox mounting configurations in the agentOS Registry: https://rivet.dev/agent-os/registry/
+Once everything is built and verified, tell the user they can browse more tools, file systems, agents, and sandbox mounting configurations in the agentOS Registry: https://agentos-sdk.dev/registry/
 
 ## If You Get Stuck
 

--- a/frontend/src/components/onboarding/agent-os/catalog.ts
+++ b/frontend/src/components/onboarding/agent-os/catalog.ts
@@ -1,0 +1,176 @@
+// Curated agentOS registry catalog for the onboarding selection steps.
+//
+// The canonical registry lives at website/src/data/registry.ts, but it is
+// website-only (the dashboard has no access to it). This is a curated subset of
+// the entries relevant to onboarding. A future unification into
+// frontend/packages/shared-data (where deploy.ts already lives) would remove the
+// drift; out of scope for now.
+
+export type CatalogStatus = "available" | "coming-soon";
+
+export interface AgentEntry {
+	slug: string;
+	title: string;
+	description: string;
+	status: CatalogStatus;
+	/** Present only when status is "available". */
+	package?: string;
+}
+
+export interface SoftwareEntry {
+	slug: string;
+	title: string;
+	package: string;
+	description: string;
+}
+
+export interface SandboxProviderEntry {
+	slug: string;
+	title: string;
+	description: string;
+	/**
+	 * Only `docker` is verified against an in-repo example
+	 * (examples/agent-os/src/sandbox/server.ts). Other providers follow the
+	 * `sandbox-agent/<slug>` subpath + same-named factory pattern and should be
+	 * confirmed before relying on the generated import.
+	 */
+	verified?: boolean;
+}
+
+// Coding agents. Only Pi is available today; the rest render disabled.
+export const AGENTS: AgentEntry[] = [
+	{
+		slug: "pi",
+		title: "Pi",
+		description: "Lightweight, fast coding agent.",
+		status: "available",
+		package: "@rivet-dev/agent-os-pi",
+	},
+	{
+		slug: "claude-code",
+		title: "Claude Code",
+		description: "Coming soon.",
+		status: "coming-soon",
+	},
+	{
+		slug: "codex",
+		title: "Codex",
+		description: "Coming soon.",
+		status: "coming-soon",
+	},
+	{
+		slug: "amp",
+		title: "Amp",
+		description: "Coming soon.",
+		status: "coming-soon",
+	},
+	{
+		slug: "opencode",
+		title: "OpenCode",
+		description: "Coming soon.",
+		status: "coming-soon",
+	},
+];
+
+// Software packages baked into the build. `common` is on by default.
+export const SOFTWARE: SoftwareEntry[] = [
+	{
+		slug: "common",
+		title: "Common",
+		package: "@rivet-dev/agent-os-common",
+		description:
+			"coreutils, sed, grep, gawk, findutils, diffutils, tar, gzip.",
+	},
+	{
+		slug: "build-essential",
+		title: "Build Essential",
+		package: "@rivet-dev/agent-os-build-essential",
+		description: "common + make + git + curl.",
+	},
+	{
+		slug: "git",
+		title: "git",
+		package: "@rivet-dev/agent-os-git",
+		description: "Version control.",
+	},
+	{
+		slug: "jq",
+		title: "jq",
+		package: "@rivet-dev/agent-os-jq",
+		description: "Lightweight JSON processor.",
+	},
+	{
+		slug: "ripgrep",
+		title: "ripgrep",
+		package: "@rivet-dev/agent-os-ripgrep",
+		description: "Fast recursive search (rg).",
+	},
+	{
+		slug: "fd",
+		title: "fd",
+		package: "@rivet-dev/agent-os-fd",
+		description: "Fast file finder.",
+	},
+	{
+		slug: "tree",
+		title: "tree",
+		package: "@rivet-dev/agent-os-tree",
+		description: "Display directory structure as a tree.",
+	},
+	{
+		slug: "coreutils",
+		title: "Coreutils",
+		package: "@rivet-dev/agent-os-coreutils",
+		description: "Essential POSIX commands (when not using Common).",
+	},
+];
+
+export const DEFAULT_AGENT = "pi";
+export const DEFAULT_PACKAGES = ["common"];
+
+// Sandbox mounting providers (sandbox-agent). Mounted at /sandbox.
+export const SANDBOX_PROVIDERS: SandboxProviderEntry[] = [
+	{
+		slug: "docker",
+		title: "Docker",
+		description: "Run sandboxes in local Docker containers.",
+		verified: true,
+	},
+	{
+		slug: "e2b",
+		title: "E2B",
+		description: "Secure, ephemeral cloud sandboxes.",
+	},
+	{
+		slug: "local",
+		title: "Local",
+		description: "Run sandboxes directly on the local machine.",
+	},
+	{
+		slug: "daytona",
+		title: "Daytona",
+		description: "Managed development environments.",
+	},
+	{
+		slug: "modal",
+		title: "Modal",
+		description: "Serverless cloud sandboxes.",
+	},
+	{
+		slug: "vercel",
+		title: "Vercel",
+		description: "Vercel's edge and serverless platform.",
+	},
+	{
+		slug: "computesdk",
+		title: "ComputeSDK",
+		description: "The ComputeSDK compute provider.",
+	},
+	{
+		slug: "sprites",
+		title: "Sprites",
+		description: "Sprites' cloud sandbox infrastructure.",
+	},
+];
+
+export const DEFAULT_SANDBOX_PROVIDER = "docker";

--- a/frontend/src/components/onboarding/agent-os/catalog.ts
+++ b/frontend/src/components/onboarding/agent-os/catalog.ts
@@ -37,7 +37,7 @@ export interface SandboxProviderEntry {
 	verified?: boolean;
 }
 
-// Coding agents. Only Pi is available today; the rest render disabled.
+// Coding agents. Pi, Claude Code, Codex, Amp, and OpenCode all run in agentOS.
 export const AGENTS: AgentEntry[] = [
 	{
 		slug: "pi",
@@ -49,26 +49,36 @@ export const AGENTS: AgentEntry[] = [
 	{
 		slug: "claude-code",
 		title: "Claude Code",
-		description: "Coming soon.",
-		status: "coming-soon",
+		description: "Anthropic's agent with full tool, file, and shell access.",
+		status: "available",
+		// Package not yet documented (docs page 404s); follows the
+		// agent-os-<slug> naming style. Verify before relying on the install.
+		package: "@rivet-dev/agent-os-claude-code",
 	},
 	{
 		slug: "codex",
 		title: "Codex",
-		description: "Coming soon.",
-		status: "coming-soon",
+		description: "OpenAI's Codex coding agent.",
+		status: "available",
+		// Note the `-agent` suffix; the bare `@rivet-dev/agent-os-codex` is the
+		// Codex CLI software package, not the agent.
+		package: "@rivet-dev/agent-os-codex-agent",
 	},
 	{
 		slug: "amp",
 		title: "Amp",
-		description: "Coming soon.",
-		status: "coming-soon",
+		description: "Sourcegraph's Amp coding agent.",
+		status: "available",
+		// Package not yet documented (docs page says "coming soon"); follows the
+		// agent-os-<slug> naming style. Verify before relying on the install.
+		package: "@rivet-dev/agent-os-amp",
 	},
 	{
 		slug: "opencode",
 		title: "OpenCode",
-		description: "Coming soon.",
-		status: "coming-soon",
+		description: "Open-source coding agent.",
+		status: "available",
+		package: "@rivet-dev/agent-os-opencode",
 	},
 ];
 

--- a/frontend/src/components/onboarding/agent-os/sandbox-mount-step.tsx
+++ b/frontend/src/components/onboarding/agent-os/sandbox-mount-step.tsx
@@ -1,0 +1,64 @@
+import { useController } from "react-hook-form";
+import { DEFAULT_SANDBOX_PROVIDER, SANDBOX_PROVIDERS } from "./catalog";
+import { SelectCard } from "./select-card";
+
+export interface SandboxValue {
+	enabled: boolean;
+	provider?: string;
+}
+
+// Presentational sandbox-mounting selector. Off by default; when on, pick a
+// provider mounted at /sandbox.
+export function SandboxMount({
+	value,
+	onChange,
+}: {
+	value: SandboxValue;
+	onChange: (value: SandboxValue) => void;
+}) {
+	const provider = value.provider ?? DEFAULT_SANDBOX_PROVIDER;
+
+	return (
+		<div className="flex flex-col gap-4">
+			<SelectCard
+				multi
+				title="Mount a sandbox"
+				description="Mount a full sandbox at /sandbox for heavy workloads like browsers or native compilation. agentOS itself stays lightweight; this is optional."
+				selected={value.enabled}
+				onSelect={() =>
+					onChange({ ...value, enabled: !value.enabled })
+				}
+			/>
+			{value.enabled ? (
+				<div>
+					<p className="text-xs text-muted-foreground mb-2">
+						Provider (mounted at <code>/sandbox</code>)
+					</p>
+					<div className="grid grid-cols-2 gap-2">
+						{SANDBOX_PROVIDERS.map((p) => (
+							<SelectCard
+								key={p.slug}
+								title={p.title}
+								description={p.description}
+								selected={provider === p.slug}
+								onSelect={() =>
+									onChange({ ...value, provider: p.slug })
+								}
+							/>
+						))}
+					</div>
+				</div>
+			) : null}
+		</div>
+	);
+}
+
+// Wizard step: binds SandboxMount to the react-hook-form `sandbox` field.
+export function SandboxMountStep() {
+	const { field } = useController({ name: "sandbox" });
+	const value = (field.value as SandboxValue) ?? {
+		enabled: false,
+		provider: DEFAULT_SANDBOX_PROVIDER,
+	};
+	return <SandboxMount value={value} onChange={field.onChange} />;
+}

--- a/frontend/src/components/onboarding/agent-os/select-card.tsx
+++ b/frontend/src/components/onboarding/agent-os/select-card.tsx
@@ -1,0 +1,78 @@
+import { faCheck, Icon } from "@rivet-gg/icons";
+import type { ReactNode } from "react";
+import { cn } from "@/components";
+import { Badge } from "@/components/ui/badge";
+
+// Shared selection card for the agentOS onboarding steps. Mirrors the
+// BuildTargetSelector card styling so the agentOS steps feel cohesive with the
+// rest of the wizard. Single-select cards highlight; multi-select cards show a
+// checkbox indicator.
+export function SelectCard({
+	title,
+	description,
+	badge,
+	icon,
+	selected,
+	disabled,
+	multi,
+	onSelect,
+}: {
+	title: string;
+	description: string;
+	badge?: string;
+	icon?: ReactNode;
+	selected: boolean;
+	disabled?: boolean;
+	multi?: boolean;
+	onSelect: () => void;
+}) {
+	return (
+		<button
+			type="button"
+			disabled={disabled}
+			aria-pressed={selected}
+			onClick={disabled ? undefined : onSelect}
+			className={cn(
+				"flex items-start gap-3 rounded-lg border px-4 py-3 text-left transition-colors",
+				disabled
+					? "cursor-not-allowed opacity-50 border-border"
+					: selected
+						? "cursor-pointer border-primary bg-primary/5"
+						: "cursor-pointer border-border hover:border-muted-foreground/50",
+			)}
+		>
+			{multi ? (
+				<span
+					className={cn(
+						"mt-0.5 flex size-4 shrink-0 items-center justify-center rounded border",
+						selected
+							? "border-primary bg-primary text-primary-foreground"
+							: "border-muted-foreground/40",
+					)}
+				>
+					{selected ? (
+						<Icon icon={faCheck} className="size-2.5" />
+					) : null}
+				</span>
+			) : icon != null ? (
+				<span className="mt-0.5 shrink-0 text-muted-foreground">
+					{icon}
+				</span>
+			) : null}
+			<div className="min-w-0 flex-1">
+				<div className="flex items-center gap-2">
+					<p className="text-sm font-medium">{title}</p>
+					{badge ? (
+						<Badge
+							variant="outline"
+							className="text-[10px] leading-none py-0.5 px-1.5 font-medium"
+						>
+							{badge}
+						</Badge>
+					) : null}
+				</div>
+				<p className="text-xs text-muted-foreground">{description}</p>
+			</div>
+		</button>
+	);
+}

--- a/frontend/src/components/onboarding/agent-os/software-select-step.tsx
+++ b/frontend/src/components/onboarding/agent-os/software-select-step.tsx
@@ -1,0 +1,52 @@
+import { useController } from "react-hook-form";
+import { DEFAULT_PACKAGES, SOFTWARE } from "./catalog";
+import { SelectCard } from "./select-card";
+
+// Presentational multi-select for the software packages baked into the build.
+export function SoftwareSelect({
+	value,
+	onChange,
+}: {
+	value: string[];
+	onChange: (slugs: string[]) => void;
+}) {
+	const toggle = (slug: string) => {
+		onChange(
+			value.includes(slug)
+				? value.filter((s) => s !== slug)
+				: [...value, slug],
+		);
+	};
+
+	return (
+		<div className="flex flex-col gap-3">
+			<p className="text-xs text-muted-foreground">
+				Packages are baked into the build image and are immutable after
+				deploy, so choose what your agent needs now.
+			</p>
+			<div className="grid grid-cols-2 gap-2">
+				{SOFTWARE.map((pkg) => (
+					<SelectCard
+						key={pkg.slug}
+						multi
+						title={pkg.title}
+						description={pkg.description}
+						selected={value.includes(pkg.slug)}
+						onSelect={() => toggle(pkg.slug)}
+					/>
+				))}
+			</div>
+		</div>
+	);
+}
+
+// Wizard step: binds SoftwareSelect to the react-hook-form `packages` field.
+export function SoftwareSelectStep() {
+	const { field } = useController({ name: "packages" });
+	return (
+		<SoftwareSelect
+			value={(field.value as string[]) ?? DEFAULT_PACKAGES}
+			onChange={field.onChange}
+		/>
+	);
+}

--- a/frontend/src/lib/data.ts
+++ b/frontend/src/lib/data.ts
@@ -43,15 +43,18 @@ export function deriveOnboardingState(opts: {
 
 	const provider = (runnerConfigs?.pages ?? [])
 		.flatMap((page) =>
-			Object.values(page.runnerConfigs).flatMap((config) =>
-				Object.values(config.datacenters).map((dc) =>
+			// The engine may return `runnerConfigs` / a config's `datacenters`
+			// as null/undefined rather than empty objects; guard so deriving the
+			// onboarding state doesn't throw on a sparse backend response.
+			Object.values(page.runnerConfigs ?? {}).flatMap((config) =>
+				Object.values(config.datacenters ?? {}).map((dc) =>
 					deriveProviderFromMetadata(dc.metadata),
 				),
 			),
 		)
 		.find((p) => p !== undefined);
 
-	const hasRunnerNames = (runnerNames?.pages[0]?.names.length ?? 0) > 0;
+	const hasRunnerNames = (runnerNames?.pages[0]?.names?.length ?? 0) > 0;
 	// A runner-config datacenter counts as "user-onboarded" only when
 	// `metadata.provider` is set. Both onboarding signals write it: the
 	// serverless `upsertRunnerConfig` call here in the frontend, and the
@@ -61,8 +64,8 @@ export function deriveOnboardingState(opts: {
 	// keeps seeing the provider/backend onboarding step instead of being
 	// pushed straight to "Waiting for an Actor".
 	const hasConfiguredDatacenter = (runnerConfigs?.pages ?? []).some((page) =>
-		Object.values(page.runnerConfigs).some((config) =>
-			Object.values(config.datacenters).some(
+		Object.values(page.runnerConfigs ?? {}).some((config) =>
+			Object.values(config.datacenters ?? {}).some(
 				(dc) => deriveProviderFromMetadata(dc.metadata) !== undefined,
 			),
 		),

--- a/frontend/src/lib/features.ts
+++ b/frontend/src/lib/features.ts
@@ -35,7 +35,7 @@ export const features = {
 	// deployments, logs, and the Rivet provider option. Cloud-platform-only
 	// because every surface consumes cloud-namespace data providers.
 	compute: isEnabled("compute") && platform,
-	// `agentOs` gates the agentOS (coding-agent VM) onboarding template. Preview.
+	// `agentOs` gates the agentOS (coding-agent VM) onboarding template. Beta.
 	agentOs: isEnabled("agent-os"),
 	support: isEnabled("support"),
 	branding: isEnabled("branding"),

--- a/frontend/src/lib/features.ts
+++ b/frontend/src/lib/features.ts
@@ -35,6 +35,8 @@ export const features = {
 	// deployments, logs, and the Rivet provider option. Cloud-platform-only
 	// because every surface consumes cloud-namespace data providers.
 	compute: isEnabled("compute") && platform,
+	// `agentOs` gates the agentOS (coding-agent VM) onboarding template. Preview.
+	agentOs: isEnabled("agent-os"),
 	support: isEnabled("support"),
 	branding: isEnabled("branding"),
 	datacenter: isEnabled("datacenter"),

--- a/frontend/src/routes/_context/ns.$namespace.tsx
+++ b/frontend/src/routes/_context/ns.$namespace.tsx
@@ -199,6 +199,21 @@ function Modals() {
 					}
 				}}
 			/>
+			<CreateActorSheet
+				variant="agent-os"
+				open={search.modal === "create-agent-os"}
+				onOpenChange={(value) => {
+					if (!value) {
+						return navigate({
+							to: ".",
+							search: (old) => ({
+								...old,
+								modal: undefined,
+							}),
+						});
+					}
+				}}
+			/>
 			<ConnectProviderSheet
 				modal={search.modal}
 				open={isConnectProviderModal(search.modal)}

--- a/frontend/src/routes/_context/ns.$namespace.tsx
+++ b/frontend/src/routes/_context/ns.$namespace.tsx
@@ -114,7 +114,7 @@ export const Route = createFileRoute("/_context/ns/$namespace")({
 		const cachedHasConfigs =
 			Object.keys(runnerConfigs?.pages[0]?.runnerConfigs ?? {}).length >
 			0;
-		const cachedHasNames = (runnerNames?.pages[0]?.names.length ?? 0) > 0;
+		const cachedHasNames = (runnerNames?.pages[0]?.names?.length ?? 0) > 0;
 
 		// Cache-first: only skip the slow blocking runner-config fetch when the
 		// cache already proves the backend is configured. An absent or empty

--- a/frontend/src/routes/_context/orgs.$organization/projects.$project/ns.$namespace.tsx
+++ b/frontend/src/routes/_context/orgs.$organization/projects.$project/ns.$namespace.tsx
@@ -231,6 +231,21 @@ function CloudNamespaceModals() {
 					}
 				}}
 			/>
+			<CreateActorSheet
+				variant="agent-os"
+				open={search?.modal === "create-agent-os"}
+				onOpenChange={(value) => {
+					if (!value) {
+						return navigate({
+							to: ".",
+							search: (old) => ({
+								...old,
+								modal: undefined,
+							}),
+						});
+					}
+				}}
+			/>
 			<UpsertDeploymentDialog
 				namespace={search?.namespace}
 				defaultImage={

--- a/frontend/src/routes/_context/orgs.$organization/projects.$project/ns.$namespace.tsx
+++ b/frontend/src/routes/_context/orgs.$organization/projects.$project/ns.$namespace.tsx
@@ -139,7 +139,7 @@ export const Route = createFileRoute(
 		const cachedHasConfigs =
 			Object.keys(runnerConfigs?.pages[0]?.runnerConfigs ?? {}).length >
 			0;
-		const cachedHasNames = (runnerNames?.pages[0]?.names.length ?? 0) > 0;
+		const cachedHasNames = (runnerNames?.pages[0]?.names?.length ?? 0) > 0;
 
 		// Cache-first: only skip the slow blocking runner-config fetch when the
 		// cache already proves the backend is configured. An absent or empty


### PR DESCRIPTION
## What

Rebases the agentOS onboarding work (originally `NicholasKissel/agentos-onboarding`, PR #5135) onto current `main` and integrates it into main's onboarding wizard, plus a series of follow-up fixes.

Main had independently collapsed onboarding to a 2-step `local → deploy` flow after that branch was cut, so rather than reverting that, the agentOS flow is grafted on via the stepper's existing `isVisible` mechanism ("approach A"):

- **Actor template** → unchanged 2-step flow (`local → deploy`).
- **agentOS template** (picked in the new "What are you building?" selector) → reveals agentOS steps: `local → agent → handoff → deploy`.

Everything is gated behind the `features.agentOs` flag (`FEATURE_FLAGS=agent-os`).

## Commits

**Feature (rebased onto main):**
- `feat(frontend): agentOS onboarding template and create flow behind feature flag`
- `feat(frontend): add agentOS agent/software/sandbox selection to onboarding`

**Follow-up fixes (each self-contained):**
- `fix: guard null engine list responses on sparse backends` — defensive `?? {}`/`?? []` on main's loader/data-provider code; some engines serialize empty maps as `null` (violating the api-full contract), which crashes the namespace/onboarding loaders. Independent of agentOS; proper fix is server-side.
- `fix: label agentOS as Beta instead of Preview`
- `fix: mark Claude Code, Codex, Amp, and OpenCode as available agents`
- `fix: drop the software and sandbox steps from agentOS onboarding` (flow is now `local → agent → handoff → deploy`)
- `fix: point users to the agentOS Registry in the handoff prompt`
- `fix: use agentos-sdk.dev for the registry and quickstart links`
- `fix: move remaining agentOS doc links to agentos-sdk.dev`

## Testing

- Frontend `tsc` is clean for all changed code. The only remaining type errors are 2 in `cloud-data-provider.tsx`, which are **byte-identical to `main`** (pre-existing, not from this branch).
- Ran the wizard standalone in dev mock mode (`?mock=1` + `FEATURE_FLAGS=agent-os` + MSW stubs, no engine): actor path renders 2 steps; selecting agentOS expands to the agentOS step sequence with correct progress/gating.

## Known open issue

On the agentOS path, **Continue on the "Choose your agent" step does not advance** past it (not yet root-caused). Everything before it (build-target selector + step reveal) works.

## Notes

- Supersedes the rebased contents of #5135 (that branch is left untouched).
- The two `feat` commits preserve Nicholas Kissel as original author.