### PR TITLE
feat(frontend): redirect to production namespace onboarding after project creation

### DIFF
--- a/frontend/src/app/dialogs/create-project-frame.tsx
+++ b/frontend/src/app/dialogs/create-project-frame.tsx
@@ -19,6 +19,12 @@ const useDefaultOrg = () => {
 export type CreateProjectSuccessVars = {
 	displayName: string;
 	organization: string;
+	/**
+	 * Name of the namespace to land on after creation. The backend auto-creates
+	 * a "Production" namespace on project create, and landing on it triggers the
+	 * onboarding flow. Undefined if no namespace could be resolved.
+	 */
+	namespace: string | undefined;
 };
 
 export default function CreateProjectFrameContent({
@@ -43,6 +49,25 @@ export default function CreateProjectFrameContent({
 		...provider.createProjectMutationOptions(),
 	});
 
+	// Resolve the auto-created "Production" namespace so we can land on it and
+	// trigger the onboarding flow right after the project is created.
+	const resolveOnboardingNamespace = async (
+		organization: string,
+		project: string,
+	) => {
+		const data = await queryClient.fetchInfiniteQuery(
+			provider.orgProjectNamespacesQueryOptions({
+				organization,
+				project,
+			}),
+		);
+		const namespaces = data.pages.flatMap((page) => page.namespaces);
+		const production = namespaces.find(
+			(ns) => ns.displayName === "Production",
+		);
+		return (production ?? namespaces[0])?.name;
+	};
+
 	return (
 		<CreateProjectForm.Form
 			onSubmit={async (values) => {
@@ -55,13 +80,31 @@ export default function CreateProjectFrameContent({
 					provider.currentOrgProjectsQueryOptions(),
 				);
 
+				const namespace = await resolveOnboardingNamespace(
+					values.organization,
+					result.project.name,
+				);
+
 				const successVars: CreateProjectSuccessVars = {
 					displayName: values.name,
 					organization: values.organization,
+					namespace,
 				};
 
 				if (onSuccess) {
 					onSuccess(result, successVars);
+					return;
+				}
+
+				if (namespace) {
+					await navigate({
+						to: "/orgs/$organization/projects/$project/ns/$namespace",
+						params: {
+							organization: values.organization,
+							project: result.project.name,
+							namespace,
+						},
+					});
 					return;
 				}
 

--- a/frontend/src/routes/_context/orgs.$organization/new/index.tsx
+++ b/frontend/src/routes/_context/orgs.$organization/new/index.tsx
@@ -34,6 +34,20 @@ function RouteComponent() {
 						<CreateProjectFrameContent
 							organization={params.organization}
 							onSuccess={(data, vars) => {
+								if (vars.namespace) {
+									return navigate({
+										to: "/orgs/$organization/projects/$project/ns/$namespace",
+										params: {
+											organization: vars.organization,
+											project: data.project.name,
+											namespace: vars.namespace,
+										},
+										search: {
+											flow: search.flow,
+										},
+									});
+								}
+
 								return navigate({
 									to: "/orgs/$organization/projects/$project",
 									params: {


### PR DESCRIPTION
## Summary

After creating a fresh project, the user now lands directly on the auto-created **Production** namespace page, which triggers the onboarding flow (`GettingStarted`) instead of dropping them on the namespaces grid. Same applies to the **new org → new project** flow.

## Changes

- **`frontend/src/app/dialogs/create-project-frame.tsx`**
  - Added `resolveOnboardingNamespace()` which fetches the project's namespaces after creation and picks the one with `displayName === "Production"` (falling back to the first namespace).
  - Default post-create navigation now goes to `/orgs/$organization/projects/$project/ns/$namespace`, falling back to the project page only if no namespace resolves.
  - Added `namespace` to `CreateProjectSuccessVars` so callers overriding `onSuccess` can route there too.
- **`frontend/src/routes/_context/orgs.$organization/new/index.tsx`**
  - The onboarding `onSuccess` now navigates to the namespace page when `vars.namespace` is present, preserving the `flow` search param.

## Why resolve instead of hardcode

The auto-created namespace name is suffixed (e.g. `production-l53g`), not literally `production`, so hardcoding the slug would 404. Resolution is keyed on `displayName === "Production"`, matching the onboarding trigger in `ns.$namespace.tsx`.

## Testing

Verified end-to-end against the local dashboard with agent-browser:
1. Create Project → submit → redirected to `/orgs/.../projects/onboard-test-qmoo/ns/production-l53g`.
2. Onboarding flow ("Step 1 of 2 · Local setup → Run locally") rendered immediately.

`tsc --noEmit` passes. Cloud/platform-only flow (projects don't exist in OSS).