### PR TITLE
[codex] feat(universaldb): add SlateDB driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "aligned-vec"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +256,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -464,6 +479,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +541,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,6 +586,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -742,6 +786,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,7 +844,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
 ]
 
@@ -929,6 +984,12 @@ checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmsketch"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ee2cfacbd29706479902b06d75ad8f1362900836aa32799eabc7e004bfd854"
 
 [[package]]
 name = "colorchoice"
@@ -1100,12 +1161,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_affinity"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -1145,6 +1236,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-skiplist"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1167,6 +1268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,9 +1293,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1517,9 +1627,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1612,10 +1732,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "duration-str"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f88959de2d447fd3eddcf1909d1f19fe084e27a056a6904203dc5d8b9e771c1e"
+dependencies = [
+ "rust_decimal",
+ "serde",
+ "thiserror 2.0.12",
+ "time",
+ "winnow 0.6.26",
+]
 
 [[package]]
 name = "dyn-clone"
@@ -1841,6 +1980,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fail-parallel"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f4a147ba57fcd64323c54c8f69fd4e045456a99574163010ccf5eea3168aaa"
+dependencies = [
+ "log",
+ "once_cell",
+ "rand 0.9.2",
+ "tokio",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,6 +2008,16 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastant"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e825441bfb2d831c47c97d05821552db8832479f44c571b97fededbf0099c07"
+dependencies = [
+ "small_ctor",
+ "web-time",
+]
 
 [[package]]
 name = "fastrand"
@@ -1880,6 +2041,22 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "toml 0.8.23",
+ "uncased",
+ "version_check",
+]
 
 [[package]]
 name = "filetime"
@@ -1909,6 +2086,16 @@ name = "flagset"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags 2.10.0",
+ "rustc_version",
+]
 
 [[package]]
 name = "flate2"
@@ -1958,6 +2145,120 @@ dependencies = [
 ]
 
 [[package]]
+name = "foyer"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0abc0b87814989efa711f9becd9f26969820e2d3905db27d10969c4bd45890"
+dependencies = [
+ "anyhow",
+ "equivalent",
+ "foyer-common",
+ "foyer-memory",
+ "foyer-storage",
+ "foyer-tokio",
+ "futures-util",
+ "mea",
+ "mixtrics",
+ "pin-project",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "foyer-common"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3db80d5dece93adb7ad709c84578794724a9cba342a7e566c3551c7ec626789"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "bytes",
+ "cfg-if",
+ "foyer-tokio",
+ "mixtrics",
+ "parking_lot",
+ "pin-project",
+ "serde",
+ "twox-hash",
+]
+
+[[package]]
+name = "foyer-intrusive-collections"
+version = "0.10.0-dev"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4fee46bea69e0596130e3210e65d3424e0ac1e6df3bde6636304bdf1ca4a3b"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
+name = "foyer-memory"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db907f40a527ca2aa2f40a5f68b32ea58aa70f050cd233518e9ffd402cfba6ce"
+dependencies = [
+ "anyhow",
+ "bitflags 2.10.0",
+ "cmsketch",
+ "equivalent",
+ "foyer-common",
+ "foyer-intrusive-collections",
+ "foyer-tokio",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "itertools 0.14.0",
+ "mea",
+ "mixtrics",
+ "parking_lot",
+ "paste",
+ "pin-project",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "foyer-storage"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1983f1db3d0710e9c9d5fc116d9202dccd41a2d1e032572224f1aff5520aa958"
+dependencies = [
+ "allocator-api2",
+ "anyhow",
+ "bytes",
+ "core_affinity",
+ "equivalent",
+ "fastant",
+ "foyer-common",
+ "foyer-memory",
+ "foyer-tokio",
+ "fs4",
+ "futures-core",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "io-uring",
+ "itertools 0.14.0",
+ "libc",
+ "lz4",
+ "mea",
+ "parking_lot",
+ "pin-project",
+ "rand 0.9.2",
+ "serde",
+ "tracing",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
+name = "foyer-tokio"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6577b05a7ffad0db555aedf00bfe52af818220fc4c1c3a7a12520896fc38627"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "framehop"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1969,6 +2270,16 @@ dependencies = [
  "gimli 0.33.0",
  "macho-unwind-info",
  "pe-unwind-info",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2108,7 +2419,7 @@ dependencies = [
  "serde_json",
  "statrs",
  "strum",
- "sysinfo",
+ "sysinfo 0.37.2",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
@@ -2207,6 +2518,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2231,6 +2543,18 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "governor"
@@ -2329,6 +2653,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -2402,7 +2731,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2504,6 +2833,15 @@ name = "humantime"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2843,6 +3181,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2902,6 +3246,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -2979,11 +3332,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -3012,9 +3366,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libflate"
@@ -3146,10 +3500,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
 
 [[package]]
 name = "lz4-sys"
@@ -3241,7 +3613,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3249,6 +3631,15 @@ name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
+name = "mea"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2640d335e7273dacdcf51044026139b2e269c3bb0dfc3f8cb3496b85e3f6a42c"
+dependencies = [
+ "slab",
+]
 
 [[package]]
 name = "memchr"
@@ -3263,6 +3654,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -3305,6 +3705,16 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "mixtrics"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c46b5adfb7a3ae4996d327a5bdc90e78fec025806dd312bdbe6f07a755e0ec9"
+dependencies = [
+ "itertools 0.15.0",
+ "parking_lot",
 ]
 
 [[package]]
@@ -3473,6 +3883,18 @@ name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
@@ -3678,6 +4100,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765784b4390c6bcf80316e5a22f4e3661b639c9d8c83246856643c27d8ce9dbe"
+dependencies = [
+ "async-trait",
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "crc-fast",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body-util",
+ "humantime",
+ "hyper 1.6.0",
+ "itertools 0.15.0",
+ "md-5 0.11.0",
+ "nix 0.31.3",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml 0.40.1",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3815,6 +4279,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "papaya"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3914,6 +4402,29 @@ dependencies = [
  "thiserror 2.0.12",
  "zerocopy",
  "zerocopy-derive",
+]
+
+[[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4287,7 +4798,7 @@ checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.38.3",
  "serde",
  "time",
 ]
@@ -4328,7 +4839,7 @@ dependencies = [
  "bytes",
  "fallible-iterator 0.2.0",
  "hmac",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "rand 0.9.2",
  "sha2",
@@ -4420,6 +4931,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -4534,7 +5058,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde_json",
  "smallvec",
- "spin",
+ "spin 0.12.0",
  "symbolic-demangle",
  "tempfile",
  "thiserror 2.0.12",
@@ -4564,6 +5088,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -4675,6 +5209,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4713,6 +5258,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4720,6 +5271,15 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4869,7 +5429,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.2",
 ]
@@ -4885,6 +5445,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -4904,12 +5465,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -5649,6 +6212,7 @@ name = "rivet-pools"
 version = "2.3.2"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clickhouse",
  "divan",
  "futures-util",
@@ -6271,6 +6835,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_decimal"
+version = "1.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
+dependencies = [
+ "arrayvec 0.7.6",
+ "num-traits",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6812,14 +7386,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa 1.0.15",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -6850,6 +7425,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -6925,8 +7509,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6936,8 +7520,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -6982,7 +7566,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -7023,9 +7607,87 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slatedb"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d01d14107ae93175aff71ab4174a09da323cc95c4cddd7ee253ae1649211d3d9"
+dependencies = [
+ "async-channel",
+ "async-trait",
+ "atomic",
+ "backon",
+ "bitflags 2.10.0",
+ "bytes",
+ "chrono",
+ "crc32fast",
+ "crossbeam-skiplist",
+ "dotenvy",
+ "duration-str",
+ "fail-parallel",
+ "figment",
+ "flatbuffers",
+ "foyer",
+ "futures",
+ "log",
+ "lru",
+ "object_store",
+ "ouroboros",
+ "parking_lot",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "siphasher",
+ "slatedb-common",
+ "slatedb-txn-obj",
+ "smallvec",
+ "sysinfo 0.35.2",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "ulid",
+ "url",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
+name = "slatedb-common"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7696aae130a0a617ec44e7c9e731d6f5408f58d949a91ba5082fcab84a896be"
+dependencies = [
+ "chrono",
+ "log",
+ "object_store",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "serde",
+ "thread_local",
+ "tokio",
+]
+
+[[package]]
+name = "slatedb-txn-obj"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5748b15b53b41beac51663a6b05168ac2af1a7abcada92b7720a483beddd30"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "log",
+ "object_store",
+ "parking_lot",
+ "slatedb-common",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "slog"
@@ -7059,6 +7721,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "small_ctor"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88414a5ca1f85d82cc34471e975f0f74f6aa54c40f062efa42c0080e7f763f81"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7083,6 +7751,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spin"
@@ -7117,6 +7791,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "statrs"
@@ -7266,6 +7946,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.35.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -7591,23 +8285,20 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tokio-macros",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7627,9 +8318,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7743,13 +8434,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.15.4",
  "pin-project-lite",
  "tokio",
 ]
@@ -7777,17 +8470,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -7800,13 +8514,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -8070,7 +8804,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]
@@ -8107,12 +8841,15 @@ name = "twox-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
+dependencies = [
+ "rand 0.9.2",
+]
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -8121,12 +8858,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.2",
+ "serde",
+ "web-time",
+]
+
+[[package]]
 name = "uname"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -8191,6 +8948,7 @@ dependencies = [
  "futures-util",
  "hex",
  "lazy_static",
+ "parking_lot",
  "rand 0.8.5",
  "rivet-config",
  "rivet-env",
@@ -8200,7 +8958,11 @@ dependencies = [
  "rivet-test-deps-docker",
  "rivet-tracing-utils",
  "rocksdb",
+ "scc",
  "serde",
+ "serde_bare",
+ "serde_json",
+ "slatedb",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -8210,6 +8972,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "vbare",
 ]
 
 [[package]]
@@ -8511,48 +9274,32 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8560,22 +9307,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
@@ -8616,6 +9363,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8629,9 +9389,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9150,6 +9910,24 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
@@ -9424,6 +10202,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ members = [
   anyhow = "1.0.82"
   pyroscope = "2.0"
   scopeguard = "1.2"
+  slatedb = "0.14.0"
   xxhash-rust = { version = "=0.8.15", features = [ "xxh3" ] }
   async-channel = "2.1.1"
   # Rivet fork of async-nats published as rivet-async-nats. Source: https://github.com/NathanFlurry/nats.rs (branch rivet-async-nats). Carries the SlowConsumer subject enrichment plus subscription backpressure stats; upstream these before returning to the official crate.

--- a/engine/packages/config/src/config/db/mod.rs
+++ b/engine/packages/config/src/config/db/mod.rs
@@ -12,6 +12,7 @@ pub use postgres::{Postgres, PostgresSsl};
 pub enum Database {
 	Postgres(Postgres),
 	FileSystem(FileSystem),
+	SlateDb(SlateDb),
 }
 
 impl Default for Database {
@@ -34,4 +35,26 @@ impl Default for FileSystem {
 
 		Self { path: default_path }
 	}
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SlateDb {
+	/// Object-store URL, e.g. "memory:///", "file:///var/lib/rivet/udb", or "s3://bucket/prefix".
+	pub object_store_url: String,
+	/// Optional database path/prefix inside the object store. Defaults to the path from `object_store_url`.
+	pub path: Option<String>,
+	/// Optional writer lease tuning for multi-node SlateDB.
+	pub lease: Option<SlateDbLease>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct SlateDbLease {
+	/// Lease TTL in milliseconds. Defaults to 15 seconds when omitted by the pool mapping.
+	pub ttl_ms: Option<u64>,
+	/// Heartbeat interval in milliseconds. Defaults to 5 seconds when omitted by the pool mapping.
+	pub heartbeat_ms: Option<u64>,
+	/// Optional NATS subject advertised by the leader.
+	pub nats_subject: Option<String>,
 }

--- a/engine/packages/engine/src/commands/db/mod.rs
+++ b/engine/packages/engine/src/commands/db/mod.rs
@@ -63,6 +63,9 @@ impl SubCommand {
 						println!("Complete");
 						Ok(())
 					}
+					rivet_config::config::Database::SlateDb(_) => {
+						bail!("nuke SlateDB object-store prefixes is not implemented");
+					}
 				}
 			}
 		}

--- a/engine/packages/pools/Cargo.toml
+++ b/engine/packages/pools/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-nats.workspace = true
+async-trait.workspace = true
 clickhouse.workspace = true
 futures-util.workspace = true
 governor.workspace = true

--- a/engine/packages/pools/src/db/udb.rs
+++ b/engine/packages/pools/src/db/udb.rs
@@ -1,7 +1,16 @@
-use std::{ops::Deref, sync::Arc};
+use std::{ops::Deref, sync::Arc, time::Duration};
+use std::result::Result::{Err, Ok};
 
 use anyhow::*;
+use async_trait::async_trait;
 use rivet_config::{Config, config};
+use tokio::task::JoinHandle;
+use universaldb::driver::slatedb::{
+	SlateDbForwardingHandler, SlateDbForwardingServerHandle, SlateDbForwardingTransport,
+};
+use universalpubsub as ups;
+use ups::NextOutput;
+use uuid::Uuid;
 
 #[derive(Clone)]
 pub struct UdbPool {
@@ -16,8 +25,8 @@ impl Deref for UdbPool {
 	}
 }
 
-#[tracing::instrument(skip(config))]
-pub async fn setup(config: &Config) -> Result<Option<UdbPool>> {
+#[tracing::instrument(skip(config, pubsub))]
+pub async fn setup(config: &Config, pubsub: Option<ups::PubSub>, node_id: Uuid) -> Result<Option<UdbPool>> {
 	let db_driver = match config.database() {
 		config::Database::Postgres(pg) => {
 			let postgres_config = universaldb::driver::postgres::PostgresConfig {
@@ -40,6 +49,37 @@ pub async fn setup(config: &Config) -> Result<Option<UdbPool>> {
 			Arc::new(universaldb::driver::RocksDbDatabaseDriver::new(fs.path.clone()).await?)
 				as universaldb::DatabaseDriverHandle
 		}
+		config::Database::SlateDb(cfg) => {
+			let lease = cfg.lease.as_ref().map(|lease| {
+				let mut config = universaldb::driver::slatedb::SlateDbLeaseConfig::default();
+				if let Some(ttl_ms) = lease.ttl_ms {
+					config.ttl_ms = ttl_ms;
+				}
+				if let Some(heartbeat_ms) = lease.heartbeat_ms {
+					config.heartbeat_ms = heartbeat_ms;
+				}
+				config.nats_subject.clone_from(&lease.nats_subject);
+				config
+			});
+			let slatedb_config = universaldb::driver::slatedb::SlateDbConfig {
+				object_store_url: cfg.object_store_url.clone(),
+				path: cfg.path.clone(),
+				lease,
+			};
+			if slatedb_config.lease.is_some() {
+				let pubsub = pubsub.context("SlateDB lease forwarding requires pubsub pool")?;
+				let transport = Arc::new(UpsSlateDbForwardingTransport { pubsub });
+				universaldb::driver::SlateDbDatabaseDriver::new_managed(
+					slatedb_config,
+					transport,
+					node_id,
+				)
+				.await?
+			} else {
+				Arc::new(universaldb::driver::SlateDbDatabaseDriver::new(slatedb_config).await?)
+					as universaldb::DatabaseDriverHandle
+			}
+		}
 	};
 
 	tracing::debug!("udb started");
@@ -47,4 +87,87 @@ pub async fn setup(config: &Config) -> Result<Option<UdbPool>> {
 	Ok(Some(UdbPool {
 		db: universaldb::Database::new(db_driver),
 	}))
+}
+
+struct UpsSlateDbForwardingTransport {
+	pubsub: ups::PubSub,
+}
+
+#[async_trait]
+impl SlateDbForwardingTransport for UpsSlateDbForwardingTransport {
+	async fn request(
+		&self,
+		subject: &str,
+		payload: &[u8],
+		timeout: Duration,
+	) -> Result<Option<Vec<u8>>> {
+		match self
+			.pubsub
+			.request_with_timeout(subject, payload, timeout)
+			.await?
+		{
+			NextOutput::Message(message) => Ok(Some(message.payload)),
+			NextOutput::Unsubscribed | NextOutput::NoResponders => Ok(None),
+		}
+	}
+
+	async fn serve(
+		&self,
+		subject: String,
+		handler: Arc<dyn SlateDbForwardingHandler>,
+	) -> Result<Box<dyn SlateDbForwardingServerHandle>> {
+		let pubsub = self.pubsub.clone();
+		let handle = tokio::spawn(async move {
+			let mut subscriber = match pubsub.subscribe(&subject).await {
+				Ok(subscriber) => subscriber,
+				Err(error) => {
+					tracing::warn!(?error, subject = %subject, "failed to subscribe SlateDB forwarding server");
+					return;
+				}
+			};
+
+			loop {
+				let output = match subscriber.next().await {
+					Ok(output) => output,
+					Err(error) => {
+						tracing::warn!(?error, subject = %subject, "SlateDB forwarding subscriber failed");
+						break;
+					}
+				};
+
+				let message = match output {
+					NextOutput::Message(message) => message,
+					NextOutput::Unsubscribed => break,
+					NextOutput::NoResponders => continue,
+				};
+				let handler = handler.clone();
+				tokio::spawn(async move {
+					match handler.handle(message.payload.clone()).await {
+						Ok(response) => {
+							if let Err(error) = message.reply(&response).await {
+								tracing::debug!(?error, "failed to reply to SlateDB forwarding request");
+							}
+						}
+						Err(error) => {
+							tracing::warn!(?error, "failed to handle SlateDB forwarding request");
+						}
+					}
+				});
+			}
+		});
+
+		Ok(Box::new(UpsSlateDbForwardingServerHandle { handle }))
+	}
+}
+
+struct UpsSlateDbForwardingServerHandle {
+	handle: JoinHandle<()>,
+}
+
+impl SlateDbForwardingServerHandle for UpsSlateDbForwardingServerHandle {}
+
+impl Drop for UpsSlateDbForwardingServerHandle {
+	fn drop(&mut self) {
+		self.handle.abort();
+	}
 }

--- a/engine/packages/pools/src/pools.rs
+++ b/engine/packages/pools/src/pools.rs
@@ -29,10 +29,8 @@ impl Pools {
 
 		install_rustls_provider();
 
-		let (ups, udb) = tokio::try_join!(
-			crate::db::ups::setup(&config, client_name),
-			crate::db::udb::setup(&config),
-		)?;
+		let ups = crate::db::ups::setup(&config, client_name).await?;
+		let udb = crate::db::udb::setup(&config, Some(ups.clone()), node_id.as_uuid()).await?;
 		let clickhouse = crate::db::clickhouse::setup(&config)?;
 
 		let pool = Pools(Arc::new(PoolsInner {
@@ -61,10 +59,8 @@ impl Pools {
 
 		install_rustls_provider();
 
-		let (ups, udb) = tokio::try_join!(
-			crate::db::ups::setup(&config, client_name),
-			crate::db::udb::setup(&config),
-		)?;
+		let ups = crate::db::ups::setup(&config, client_name).await?;
+		let udb = crate::db::udb::setup(&config, Some(ups.clone()), node_id.as_uuid()).await?;
 
 		let pool = Pools(Arc::new(PoolsInner {
 			config,

--- a/engine/packages/test-deps-docker/src/database.rs
+++ b/engine/packages/test-deps-docker/src/database.rs
@@ -8,6 +8,7 @@ use crate::DockerRunConfig;
 pub enum TestDatabase {
 	Postgres,
 	FileSystem,
+	SlateDb,
 }
 
 impl TestDatabase {
@@ -17,6 +18,7 @@ impl TestDatabase {
 			Ok(val) => match val.as_str() {
 				"postgres" => TestDatabase::Postgres,
 				"filesystem" => TestDatabase::FileSystem,
+				"slatedb" => TestDatabase::SlateDb,
 				_ => TestDatabase::FileSystem, // Default
 			},
 			Err(_) => TestDatabase::FileSystem, // Default
@@ -86,6 +88,16 @@ impl TestDatabase {
 
 				Ok((config, None))
 			}
+			TestDatabase::SlateDb => {
+				let config =
+					rivet_config::config::Database::SlateDb(rivet_config::config::db::SlateDb {
+						object_store_url: "memory:///".to_string(),
+						path: Some(format!("rivet-test-slatedb-{}-{}", test_id, dc_label)),
+						lease: None,
+					});
+
+				Ok((config, None))
+			}
 		}
 	}
 
@@ -95,6 +107,7 @@ impl TestDatabase {
 				wait_for_postgres_ready(docker_config.port_mapping.0, 10).await
 			}
 			TestDatabase::FileSystem => Ok(()),
+			TestDatabase::SlateDb => Ok(()),
 		}
 	}
 }

--- a/engine/packages/universaldb/Cargo.toml
+++ b/engine/packages/universaldb/Cargo.toml
@@ -15,11 +15,16 @@ futures-util.workspace = true
 hex.workspace = true
 lazy_static.workspace = true
 rand.workspace = true
+parking_lot.workspace = true
 rivet-metrics.workspace = true
 rivet-postgres-util.workspace = true
 rivet-tracing-utils.workspace = true
 rocksdb.workspace = true
+scc.workspace = true
 serde.workspace = true
+serde_bare.workspace = true
+serde_json.workspace = true
+slatedb.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio-postgres-rustls.workspace = true
@@ -28,6 +33,7 @@ tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
 uuid.workspace = true
+vbare.workspace = true
 
 [dev-dependencies]
 rivet-config.workspace = true

--- a/engine/packages/universaldb/src/driver/mod.rs
+++ b/engine/packages/universaldb/src/driver/mod.rs
@@ -13,9 +13,11 @@ use crate::{
 
 pub mod postgres;
 pub mod rocksdb;
+pub mod slatedb;
 
 pub use postgres::PostgresDatabaseDriver;
 pub use rocksdb::RocksDbDatabaseDriver;
+pub use slatedb::SlateDbDatabaseDriver;
 
 pub type BoxFut<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 pub type Erased = Box<dyn Any + Send>;

--- a/engine/packages/universaldb/src/driver/slatedb/commit.rs
+++ b/engine/packages/universaldb/src/driver/slatedb/commit.rs
@@ -1,0 +1,144 @@
+use std::{
+	collections::BTreeMap,
+	ops::Bound,
+	sync::Arc,
+};
+
+use anyhow::{Context, Result};
+use slatedb::{
+	Db, WriteBatch,
+	config::{DurabilityLevel, ReadOptions, ScanOptions},
+};
+
+use crate::{
+	atomic::apply_atomic_op,
+	options::MutationType,
+	tx_ops::Operation,
+	versionstamp::{generate_versionstamp, substitute_raw_versionstamp},
+};
+
+fn memory_read_options() -> ReadOptions {
+	ReadOptions::new()
+		.with_durability_filter(DurabilityLevel::Memory)
+		.with_dirty(false)
+}
+
+fn memory_scan_options() -> ScanOptions {
+	ScanOptions::new()
+		.with_durability_filter(DurabilityLevel::Memory)
+		.with_dirty(false)
+}
+
+fn range_contains(begin: &[u8], end: &[u8], key: &[u8]) -> bool {
+	begin <= key && key < end
+}
+
+fn overlay_keys_in_range(
+	overlay: &BTreeMap<Vec<u8>, Option<Vec<u8>>>,
+	begin: &[u8],
+	end: &[u8],
+) -> Vec<Vec<u8>> {
+	overlay
+		.range::<[u8], _>((Bound::Included(begin), Bound::Excluded(end)))
+		.map(|(key, _)| key.clone())
+		.collect()
+}
+
+fn cleared_ranges_cover(cleared: &[(Vec<u8>, Vec<u8>)], key: &[u8]) -> bool {
+	cleared
+		.iter()
+		.any(|(begin, end)| range_contains(begin, end, key))
+}
+
+async fn get_live(db: &Db, key: &[u8]) -> Result<Option<Vec<u8>>> {
+	Ok(db
+		.get_with_options(key, &memory_read_options())
+		.await
+		.context("failed to read SlateDB value")?
+		.map(|value| value.to_vec()))
+}
+
+pub async fn build_write_batch(db: Arc<Db>, operations: Vec<Operation>) -> Result<WriteBatch> {
+	let versionstamp = generate_versionstamp(0);
+	let mut overlay: BTreeMap<Vec<u8>, Option<Vec<u8>>> = BTreeMap::new();
+	let mut cleared: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
+
+	for op in operations {
+		match op {
+			Operation::SetValue { key, value } => {
+				overlay.insert(key, Some(value));
+			}
+			Operation::Clear { key } => {
+				overlay.insert(key, None);
+			}
+			Operation::ClearRange { begin, end } => {
+				for key in overlay_keys_in_range(&overlay, &begin, &end) {
+					overlay.insert(key, None);
+				}
+				cleared.push((begin, end));
+			}
+			Operation::AtomicOp {
+				key,
+				param,
+				op_type,
+			} => {
+				if matches!(op_type, MutationType::SetVersionstampedKey) {
+					let key = substitute_raw_versionstamp(key, &versionstamp)
+						.map_err(anyhow::Error::msg)
+						.context("failed substituting versionstamped key")?;
+					overlay.insert(key, Some(param));
+					continue;
+				}
+
+				if matches!(op_type, MutationType::SetVersionstampedValue) {
+					let value = substitute_raw_versionstamp(param, &versionstamp)
+						.map_err(anyhow::Error::msg)
+						.context("failed substituting versionstamped value")?;
+					overlay.insert(key, Some(value));
+					continue;
+				}
+
+				let current = match overlay.get(&key) {
+					Some(value) => value.clone(),
+					None if cleared_ranges_cover(&cleared, &key) => None,
+					None => get_live(&db, &key).await?,
+				};
+				let new_value = apply_atomic_op(current.as_deref(), &param, op_type);
+				overlay.insert(key, new_value);
+			}
+		}
+	}
+
+	for (begin, end) in &cleared {
+		if begin >= end {
+			continue;
+		}
+		let mut iter = db
+			.scan_with_options(begin.clone()..end.clone(), &memory_scan_options())
+			.await
+			.context("failed to scan SlateDB clear range")?;
+		while let Some(kv) = iter
+			.next()
+			.await
+			.context("failed to iterate SlateDB clear range")?
+		{
+			let key = kv.key.to_vec();
+			if !overlay.contains_key(&key) {
+				overlay.insert(key, None);
+			}
+		}
+	}
+
+	let mut batch = WriteBatch::new();
+	for (key, value) in overlay {
+		if key.is_empty() {
+			continue;
+		}
+		match value {
+			Some(value) => batch.put(key, value),
+			None => batch.delete(key),
+		}
+	}
+
+	Ok(batch)
+}

--- a/engine/packages/universaldb/src/driver/slatedb/database.rs
+++ b/engine/packages/universaldb/src/driver/slatedb/database.rs
@@ -1,0 +1,484 @@
+use std::{
+	path::Path,
+	sync::{
+		Arc,
+		atomic::{AtomicBool, AtomicI32, AtomicU64, Ordering},
+	},
+	time::Duration,
+};
+
+use anyhow::{Context, Result};
+use parking_lot::RwLock;
+use slatedb::{
+	Db,
+	object_store::{ObjectStore, parse_url_opts, path::Path as ObjectStorePath},
+};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use url::Url;
+use uuid::Uuid;
+
+use crate::{
+	RetryableTransaction, Transaction,
+	driver::{BoxFut, DatabaseDriver, DatabaseDriverHandle, Erased},
+	error::DatabaseError,
+	transaction::TXN_TIMEOUT,
+	utils::{MaybeCommitted, calculate_tx_retry_backoff},
+};
+
+use super::{
+	forwarding::{
+		SlateDbForwardingClient, SlateDbForwardingDatabaseDriver, SlateDbForwardingServer,
+		SlateDbForwardingTransport,
+	},
+	lease::{LeaseState, SlateDbLease},
+	transaction::SlateDbTransactionDriver,
+	transaction_conflict_tracker::TransactionConflictTracker,
+};
+
+#[derive(Debug, Clone)]
+pub struct SlateDbConfig {
+	pub object_store_url: String,
+	pub path: Option<String>,
+	pub lease: Option<SlateDbLeaseConfig>,
+}
+
+impl SlateDbConfig {
+	pub fn new(object_store_url: String) -> Self {
+		Self {
+			object_store_url,
+			path: None,
+			lease: None,
+		}
+	}
+}
+
+#[derive(Debug, Clone)]
+pub struct SlateDbLeaseConfig {
+	pub ttl_ms: u64,
+	pub heartbeat_ms: u64,
+	pub nats_subject: Option<String>,
+}
+
+impl Default for SlateDbLeaseConfig {
+	fn default() -> Self {
+		Self {
+			ttl_ms: 15_000,
+			heartbeat_ms: 5_000,
+			nats_subject: None,
+		}
+	}
+}
+
+pub struct SlateDbDatabaseDriver {
+	db: Arc<Db>,
+	max_retries: AtomicI32,
+	txn_conflict_tracker: TransactionConflictTracker,
+	commit_mutex: Arc<Mutex<()>>,
+	last_applied_version: Arc<AtomicU64>,
+	active: Option<Arc<AtomicBool>>,
+}
+
+pub(super) fn resolve_object_store(
+	config: &SlateDbConfig,
+) -> Result<(Arc<dyn ObjectStore>, ObjectStorePath)> {
+	let url = Url::parse(&config.object_store_url).context("invalid SlateDB object store URL")?;
+	let (store, parsed_path) =
+		parse_url_opts(&url, std::env::vars()).context("failed to parse object store URL")?;
+	let object_store: Arc<dyn ObjectStore> = Arc::from(store);
+	let db_path = match &config.path {
+		Some(path) => ObjectStorePath::parse(path).context("invalid SlateDB path")?,
+		None => parsed_path,
+	};
+
+	Ok((object_store, db_path))
+}
+
+impl SlateDbDatabaseDriver {
+	pub async fn new(config: SlateDbConfig) -> Result<Self> {
+		tracing::info!(object_store_url=%config.object_store_url, "starting slatedb driver");
+
+		let (object_store, db_path) = resolve_object_store(&config)?;
+		Self::open_resolved(object_store, db_path, None).await
+	}
+
+	async fn open_resolved(
+		object_store: Arc<dyn ObjectStore>,
+		db_path: ObjectStorePath,
+		active: Option<Arc<AtomicBool>>,
+	) -> Result<Self> {
+		let db = Db::open(db_path, object_store)
+			.await
+			.context("failed to open SlateDB")?;
+
+		Ok(SlateDbDatabaseDriver {
+			db: Arc::new(db),
+			max_retries: AtomicI32::new(100),
+			txn_conflict_tracker: TransactionConflictTracker::new(),
+			commit_mutex: Arc::new(Mutex::new(())),
+			last_applied_version: Arc::new(AtomicU64::new(0)),
+			active,
+		})
+	}
+
+	pub async fn new_managed(
+		config: SlateDbConfig,
+		transport: Arc<dyn SlateDbForwardingTransport>,
+		node_id: Uuid,
+	) -> Result<DatabaseDriverHandle> {
+		let (object_store, db_path) = resolve_object_store(&config)?;
+		Self::new_managed_with_object_store(config, object_store, db_path, transport, node_id).await
+	}
+
+	pub async fn new_managed_with_object_store(
+		config: SlateDbConfig,
+		object_store: Arc<dyn ObjectStore>,
+		db_path: ObjectStorePath,
+		transport: Arc<dyn SlateDbForwardingTransport>,
+		node_id: Uuid,
+	) -> Result<DatabaseDriverHandle> {
+		let lease_config = config
+			.lease
+			.clone()
+			.context("managed SlateDB driver requires lease config")?;
+		let subject = forwarding_subject(&lease_config, &db_path);
+		let lease = SlateDbLease::new(object_store.clone(), db_path.clone(), lease_config.clone());
+		let forwarding_client =
+			SlateDbForwardingClient::new(transport.clone(), Some(lease.clone()), subject.clone());
+		let forwarding_driver = Arc::new(SlateDbForwardingDatabaseDriver::new(forwarding_client));
+		let active = Arc::new(AtomicBool::new(false));
+		let local = Arc::new(RwLock::new(None));
+		let heartbeat_ms = lease_config.heartbeat_ms;
+
+		let managed = Arc::new(SlateDbManagedDatabaseDriver {
+			object_store: object_store.clone(),
+			db_path: db_path.clone(),
+			transport: transport.clone(),
+			lease,
+			lease_config,
+			subject,
+			node_id,
+			active: active.clone(),
+			// This is a forced-sync slot because DatabaseDriver::create_txn is synchronous.
+			local: local.clone(),
+			forwarding_driver,
+			lease_task: RwLock::new(None),
+		});
+
+		managed.try_become_leader().await?;
+		let task_driver = Arc::downgrade(&managed);
+		let task = tokio::spawn(async move {
+			let mut interval = tokio::time::interval(Duration::from_millis(heartbeat_ms.max(1)));
+			interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+			loop {
+				interval.tick().await;
+				let Some(driver) = task_driver.upgrade() else {
+					break;
+				};
+				if !driver.active.load(Ordering::Acquire)
+					&& let Err(error) = driver.try_become_leader().await
+				{
+					tracing::warn!(?error, "failed to acquire SlateDB leader lease");
+				}
+			}
+		});
+		*managed.lease_task.write() = Some(task);
+
+		Ok(managed as DatabaseDriverHandle)
+	}
+
+	pub async fn close(&self) -> Result<()> {
+		self.db.close().await.context("failed to close SlateDB")?;
+		Ok(())
+	}
+
+	pub(super) fn is_active(&self) -> bool {
+		self.active
+			.as_ref()
+			.is_none_or(|active| active.load(Ordering::Acquire))
+	}
+}
+
+impl DatabaseDriver for SlateDbDatabaseDriver {
+	fn create_txn(&self) -> Result<Transaction> {
+		if !self.is_active() {
+			return Err(DatabaseError::NotCommitted.into());
+		}
+
+		Ok(Transaction::new(Arc::new(SlateDbTransactionDriver::new(
+			self.db.clone(),
+			self.txn_conflict_tracker.clone(),
+			self.commit_mutex.clone(),
+			self.last_applied_version.clone(),
+			self.active.clone(),
+		))))
+	}
+
+	fn run<'a>(
+		&'a self,
+		closure: Box<dyn Fn(RetryableTransaction) -> BoxFut<'a, Result<Erased>> + Send + Sync + 'a>,
+	) -> BoxFut<'a, Result<Erased>> {
+		Box::pin(async move {
+			let mut maybe_committed = MaybeCommitted(false);
+			let max_retries = self.max_retries.load(Ordering::SeqCst);
+
+			for attempt in 0..max_retries {
+				let tx = self.create_txn()?;
+				let mut retryable = RetryableTransaction::new(tx);
+				retryable.maybe_committed = maybe_committed;
+
+				let error =
+					match tokio::time::timeout(TXN_TIMEOUT, closure(retryable.clone())).await {
+						Ok(Ok(res)) => match retryable.inner.driver.commit_ref().await {
+							Ok(_) => return Ok(res),
+							Err(e) => e,
+						},
+						Ok(Err(e)) => e,
+						Err(_) => anyhow::Error::from(DatabaseError::TransactionTooOld),
+					};
+
+				let chain = error
+					.chain()
+					.find_map(|x| x.downcast_ref::<DatabaseError>());
+
+				if let Some(db_error) = chain {
+					if db_error.is_retryable() {
+						if db_error.is_maybe_committed() {
+							maybe_committed = MaybeCommitted(true);
+						}
+
+						let backoff_ms = calculate_tx_retry_backoff(attempt as usize);
+						tokio::time::sleep(tokio::time::Duration::from_millis(backoff_ms)).await;
+						continue;
+					}
+				}
+
+				return Err(error);
+			}
+
+			Err(DatabaseError::MaxRetriesReached.into())
+		})
+	}
+
+	fn txn_retry_limit(&self, limit: i32) -> Result<()> {
+		self.max_retries.store(limit, Ordering::SeqCst);
+		Ok(())
+	}
+
+	fn checkpoint(&self, _path: &Path) -> Result<()> {
+		anyhow::bail!("checkpoint not supported by SlateDB driver")
+	}
+}
+
+pub struct SlateDbManagedDatabaseDriver {
+	object_store: Arc<dyn ObjectStore>,
+	db_path: ObjectStorePath,
+	transport: Arc<dyn SlateDbForwardingTransport>,
+	lease: SlateDbLease,
+	lease_config: SlateDbLeaseConfig,
+	subject: String,
+	node_id: Uuid,
+	active: Arc<AtomicBool>,
+	local: Arc<RwLock<Option<Arc<SlateDbDatabaseDriver>>>>,
+	forwarding_driver: Arc<SlateDbForwardingDatabaseDriver>,
+	lease_task: RwLock<Option<JoinHandle<()>>>,
+}
+
+impl SlateDbManagedDatabaseDriver {
+	async fn try_become_leader(&self) -> Result<bool> {
+		if self.active.load(Ordering::Acquire) {
+			return Ok(true);
+		}
+
+		let Some(state) = self
+			.lease
+			.try_acquire(
+				self.node_id.to_string(),
+				self.subject.clone(),
+				now_ms(),
+			)
+			.await?
+		else {
+			return Ok(false);
+		};
+
+		self.install_leader(state).await?;
+		Ok(true)
+	}
+
+	async fn install_leader(&self, initial_state: LeaseState) -> Result<()> {
+		let local_active = self.active.clone();
+		let local_driver = Arc::new(
+			SlateDbDatabaseDriver::open_resolved(
+				self.object_store.clone(),
+				self.db_path.clone(),
+				Some(local_active.clone()),
+			)
+			.await?,
+		);
+
+		let server = SlateDbForwardingServer::spawn(
+			self.transport.clone(),
+			self.subject.clone(),
+			local_driver.clone(),
+		)
+		.await?;
+
+		*self.local.write() = Some(local_driver);
+		local_active.store(true, Ordering::Release);
+		let renew_driver = self.clone_for_task();
+		tokio::spawn(async move {
+			renew_driver.renew_loop(initial_state, server).await;
+		});
+
+		tracing::info!(
+			leader_id = %self.node_id,
+			subject = %self.subject,
+			"acquired SlateDB leader lease"
+		);
+
+		Ok(())
+	}
+
+	fn clone_for_task(&self) -> SlateDbManagedTask {
+		SlateDbManagedTask {
+			lease: self.lease.clone(),
+			lease_config: self.lease_config.clone(),
+			active: self.active.clone(),
+			local: self.local.clone(),
+			node_id: self.node_id,
+		}
+	}
+
+}
+
+impl Drop for SlateDbManagedDatabaseDriver {
+	fn drop(&mut self) {
+		if let Some(task) = self.lease_task.write().take() {
+			task.abort();
+		}
+	}
+}
+
+impl DatabaseDriver for SlateDbManagedDatabaseDriver {
+	fn create_txn(&self) -> Result<Transaction> {
+		if self.active.load(Ordering::Acquire)
+			&& let Some(local) = self.local.read().clone()
+		{
+			return local.create_txn();
+		}
+
+		self.forwarding_driver.create_txn()
+	}
+
+	fn run<'a>(
+		&'a self,
+		closure: Box<dyn Fn(RetryableTransaction) -> BoxFut<'a, Result<Erased>> + Send + Sync + 'a>,
+	) -> BoxFut<'a, Result<Erased>> {
+		Box::pin(async move {
+			let mut maybe_committed = MaybeCommitted(false);
+			let max_retries = self.forwarding_driver.max_retries.load(Ordering::SeqCst);
+
+			for attempt in 0..max_retries {
+				let tx = self.create_txn()?;
+				let mut retryable = RetryableTransaction::new(tx);
+				retryable.maybe_committed = maybe_committed;
+
+				let error =
+					match tokio::time::timeout(TXN_TIMEOUT, closure(retryable.clone())).await {
+						Ok(Ok(res)) => match retryable.inner.driver.commit_ref().await {
+							Ok(_) => return Ok(res),
+							Err(e) => e,
+						},
+						Ok(Err(e)) => e,
+						Err(_) => anyhow::Error::from(DatabaseError::TransactionTooOld),
+					};
+
+				let chain = error
+					.chain()
+					.find_map(|x| x.downcast_ref::<DatabaseError>());
+
+				if let Some(db_error) = chain
+					&& db_error.is_retryable()
+				{
+					if db_error.is_maybe_committed() {
+						maybe_committed = MaybeCommitted(true);
+					}
+
+					let backoff_ms = calculate_tx_retry_backoff(attempt as usize);
+					tokio::time::sleep(tokio::time::Duration::from_millis(backoff_ms)).await;
+					continue;
+				}
+
+				return Err(error);
+			}
+
+			Err(DatabaseError::MaxRetriesReached.into())
+		})
+	}
+
+	fn txn_retry_limit(&self, limit: i32) -> Result<()> {
+		self.forwarding_driver.txn_retry_limit(limit)?;
+		if let Some(local) = self.local.read().as_ref() {
+			local.txn_retry_limit(limit)?;
+		}
+		Ok(())
+	}
+
+	fn checkpoint(&self, _path: &Path) -> Result<()> {
+		anyhow::bail!("checkpoint not supported by SlateDB driver")
+	}
+}
+
+struct SlateDbManagedTask {
+	lease: SlateDbLease,
+	lease_config: SlateDbLeaseConfig,
+	active: Arc<AtomicBool>,
+	local: Arc<RwLock<Option<Arc<SlateDbDatabaseDriver>>>>,
+	node_id: Uuid,
+}
+
+impl SlateDbManagedTask {
+	async fn renew_loop(self, mut state: LeaseState, _server: SlateDbForwardingServer) {
+		let mut interval = tokio::time::interval(Duration::from_millis(
+			self.lease_config.heartbeat_ms.max(1),
+		));
+		interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+		loop {
+			interval.tick().await;
+			match self.lease.renew(&state, now_ms()).await {
+				Ok(Some(new_state)) => {
+					state = new_state;
+				}
+				Ok(None) => {
+					tracing::warn!(leader_id = %self.node_id, "lost SlateDB leader lease");
+					self.active.store(false, Ordering::Release);
+					*self.local.write() = None;
+					break;
+				}
+				Err(error) => {
+					tracing::warn!(?error, leader_id = %self.node_id, "failed to renew SlateDB leader lease");
+					self.active.store(false, Ordering::Release);
+					*self.local.write() = None;
+					break;
+				}
+			}
+		}
+	}
+}
+
+fn forwarding_subject(config: &SlateDbLeaseConfig, db_path: &ObjectStorePath) -> String {
+	config.nats_subject.clone().unwrap_or_else(|| {
+		let path = db_path.to_string();
+		format!("udb.slatedb.{}", hex::encode(path.as_bytes()))
+	})
+}
+
+fn now_ms() -> u64 {
+	std::time::SystemTime::now()
+		.duration_since(std::time::UNIX_EPOCH)
+		.map(|duration| duration.as_millis().try_into().unwrap_or(u64::MAX))
+		.unwrap_or(0)
+}

--- a/engine/packages/universaldb/src/driver/slatedb/forwarding.rs
+++ b/engine/packages/universaldb/src/driver/slatedb/forwarding.rs
@@ -1,0 +1,873 @@
+use std::{
+	future::Future,
+	pin::Pin,
+	sync::{
+		Arc,
+		atomic::{AtomicI32, AtomicU64, Ordering},
+	},
+	time::Duration,
+};
+
+use anyhow::{Context, Result, anyhow, bail};
+use async_trait::async_trait;
+use futures_util::{StreamExt, stream};
+use scc::HashMap;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use vbare::OwnedVersionedData;
+
+use crate::{
+	RetryableTransaction, Transaction,
+	driver::{BoxFut, DatabaseDriver, Erased, TransactionDriver},
+	error::DatabaseError,
+	key_selector::KeySelector,
+	options::{ConflictRangeType, MutationType},
+	range_option::RangeOption,
+	tx_ops::{Operation, TransactionOperations},
+	utils::{IsolationLevel, MaybeCommitted, calculate_tx_retry_backoff},
+	value::{KeyValue, Slice, Value, Values},
+};
+
+use super::lease::SlateDbLease;
+
+const PROTOCOL_VERSION: u16 = 1;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[async_trait]
+pub trait SlateDbForwardingTransport: Send + Sync {
+	async fn request(
+		&self,
+		subject: &str,
+		payload: &[u8],
+		timeout: Duration,
+	) -> Result<Option<Vec<u8>>>;
+
+	async fn serve(
+		&self,
+		subject: String,
+		handler: Arc<dyn SlateDbForwardingHandler>,
+	) -> Result<Box<dyn SlateDbForwardingServerHandle>>;
+}
+
+#[async_trait]
+pub trait SlateDbForwardingHandler: Send + Sync {
+	async fn handle(&self, payload: Vec<u8>) -> Result<Vec<u8>>;
+}
+
+pub trait SlateDbForwardingServerHandle: Send + Sync {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WireKeySelector {
+	key: Vec<u8>,
+	or_equal: bool,
+	offset: i32,
+}
+
+impl WireKeySelector {
+	fn from_selector(selector: &KeySelector<'_>) -> Self {
+		Self {
+			key: selector.key().to_vec(),
+			or_equal: selector.or_equal(),
+			offset: selector.offset(),
+		}
+	}
+
+	fn to_selector(&self) -> KeySelector<'static> {
+		KeySelector::new(self.key.clone().into(), self.or_equal, self.offset)
+	}
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WireRangeOption {
+	begin: WireKeySelector,
+	end: WireKeySelector,
+	limit: Option<usize>,
+	target_bytes: usize,
+	mode: crate::options::StreamingMode,
+	reverse: bool,
+}
+
+impl WireRangeOption {
+	fn from_range(opt: &RangeOption<'_>) -> Self {
+		Self {
+			begin: WireKeySelector::from_selector(&opt.begin),
+			end: WireKeySelector::from_selector(&opt.end),
+			limit: opt.limit,
+			target_bytes: opt.target_bytes,
+			mode: opt.mode,
+			reverse: opt.reverse,
+		}
+	}
+
+	fn to_range(&self) -> RangeOption<'static> {
+		RangeOption {
+			begin: self.begin.to_selector(),
+			end: self.end.to_selector(),
+			limit: self.limit,
+			target_bytes: self.target_bytes,
+			mode: self.mode,
+			reverse: self.reverse,
+			__non_exhaustive: std::marker::PhantomData,
+		}
+	}
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum WireOperation {
+	SetValue {
+		key: Vec<u8>,
+		value: Vec<u8>,
+	},
+	Clear {
+		key: Vec<u8>,
+	},
+	ClearRange {
+		begin: Vec<u8>,
+		end: Vec<u8>,
+	},
+	AtomicOp {
+		key: Vec<u8>,
+		param: Vec<u8>,
+		op_type: MutationType,
+	},
+}
+
+impl From<Operation> for WireOperation {
+	fn from(value: Operation) -> Self {
+		match value {
+			Operation::SetValue { key, value } => Self::SetValue { key, value },
+			Operation::Clear { key } => Self::Clear { key },
+			Operation::ClearRange { begin, end } => Self::ClearRange { begin, end },
+			Operation::AtomicOp {
+				key,
+				param,
+				op_type,
+			} => Self::AtomicOp {
+				key,
+				param,
+				op_type,
+			},
+		}
+	}
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WireConflictRange {
+	begin: Vec<u8>,
+	end: Vec<u8>,
+	conflict_type: ConflictRangeType,
+}
+
+impl From<(Vec<u8>, Vec<u8>, ConflictRangeType)> for WireConflictRange {
+	fn from((begin, end, conflict_type): (Vec<u8>, Vec<u8>, ConflictRangeType)) -> Self {
+		Self {
+			begin,
+			end,
+			conflict_type,
+		}
+	}
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WireKeyValue {
+	key: Vec<u8>,
+	value: Vec<u8>,
+}
+
+impl From<KeyValue> for WireKeyValue {
+	fn from(value: KeyValue) -> Self {
+		let (key, value) = value.into_parts();
+		Self { key, value }
+	}
+}
+
+impl From<WireKeyValue> for KeyValue {
+	fn from(value: WireKeyValue) -> Self {
+		KeyValue::new(value.key, value.value)
+	}
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WireValues {
+	values: Vec<WireKeyValue>,
+	more: bool,
+}
+
+impl From<Values> for WireValues {
+	fn from(value: Values) -> Self {
+		Self {
+			more: value.more(),
+			values: value.into_vec().into_iter().map(Into::into).collect(),
+		}
+	}
+}
+
+impl From<WireValues> for Values {
+	fn from(value: WireValues) -> Self {
+		Values::with_more(value.values.into_iter().map(Into::into).collect(), value.more)
+	}
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum WireRequestBody {
+	Get {
+		key: Vec<u8>,
+	},
+	GetKey {
+		selector: WireKeySelector,
+	},
+	GetRange {
+		opt: WireRangeOption,
+		iteration: usize,
+	},
+	GetEstimatedRangeSizeBytes {
+		begin: Vec<u8>,
+		end: Vec<u8>,
+	},
+	Commit {
+		operations: Vec<WireOperation>,
+		conflict_ranges: Vec<WireConflictRange>,
+	},
+	Cancel,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WireRequest {
+	txn_id: [u8; 16],
+	body: WireRequestBody,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum WireError {
+	NotCommitted,
+	TransactionTooOld,
+	MaxRetriesReached,
+	UsedDuringCommit,
+	Other { message: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum WireResponseBody {
+	Value(Option<Vec<u8>>),
+	Key(Vec<u8>),
+	Values(WireValues),
+	EstimatedRangeSizeBytes(i64),
+	Committed,
+	Canceled,
+	Error(WireError),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct WireResponse {
+	body: WireResponseBody,
+}
+
+enum VersionedWireRequest {
+	V1(WireRequest),
+}
+
+impl OwnedVersionedData for VersionedWireRequest {
+	type Latest = WireRequest;
+
+	fn wrap_latest(latest: Self::Latest) -> Self {
+		Self::V1(latest)
+	}
+
+	fn unwrap_latest(self) -> Result<Self::Latest> {
+		match self {
+			Self::V1(data) => Ok(data),
+		}
+	}
+
+	fn deserialize_version(payload: &[u8], version: u16) -> Result<Self> {
+		match version {
+			1 => Ok(Self::V1(serde_bare::from_slice(payload)?)),
+			_ => bail!("invalid SlateDB forwarding request version: {version}"),
+		}
+	}
+
+	fn serialize_version(self, _version: u16) -> Result<Vec<u8>> {
+		match self {
+			Self::V1(data) => serde_bare::to_vec(&data).map_err(Into::into),
+		}
+	}
+}
+
+enum VersionedWireResponse {
+	V1(WireResponse),
+}
+
+impl OwnedVersionedData for VersionedWireResponse {
+	type Latest = WireResponse;
+
+	fn wrap_latest(latest: Self::Latest) -> Self {
+		Self::V1(latest)
+	}
+
+	fn unwrap_latest(self) -> Result<Self::Latest> {
+		match self {
+			Self::V1(data) => Ok(data),
+		}
+	}
+
+	fn deserialize_version(payload: &[u8], version: u16) -> Result<Self> {
+		match version {
+			1 => Ok(Self::V1(serde_bare::from_slice(payload)?)),
+			_ => bail!("invalid SlateDB forwarding response version: {version}"),
+		}
+	}
+
+	fn serialize_version(self, _version: u16) -> Result<Vec<u8>> {
+		match self {
+			Self::V1(data) => serde_bare::to_vec(&data).map_err(Into::into),
+		}
+	}
+}
+
+fn encode_request(request: WireRequest) -> Result<Vec<u8>> {
+	VersionedWireRequest::wrap_latest(request).serialize_with_embedded_version(PROTOCOL_VERSION)
+}
+
+fn decode_request(payload: &[u8]) -> Result<WireRequest> {
+	VersionedWireRequest::deserialize_with_embedded_version(payload)
+}
+
+fn encode_response(response: WireResponse) -> Result<Vec<u8>> {
+	VersionedWireResponse::wrap_latest(response).serialize_with_embedded_version(PROTOCOL_VERSION)
+}
+
+fn decode_response(payload: &[u8]) -> Result<WireResponse> {
+	VersionedWireResponse::deserialize_with_embedded_version(payload)
+}
+
+fn wire_error_from_anyhow(error: &anyhow::Error) -> WireError {
+	match error.chain().find_map(|err| err.downcast_ref::<DatabaseError>()) {
+		Some(DatabaseError::NotCommitted) => WireError::NotCommitted,
+		Some(DatabaseError::TransactionTooOld) => WireError::TransactionTooOld,
+		Some(DatabaseError::MaxRetriesReached) => WireError::MaxRetriesReached,
+		Some(DatabaseError::UsedDuringCommit) => WireError::UsedDuringCommit,
+		None => WireError::Other {
+			message: error.to_string(),
+		},
+	}
+}
+
+fn anyhow_from_wire_error(error: WireError) -> anyhow::Error {
+	match error {
+		WireError::NotCommitted => DatabaseError::NotCommitted.into(),
+		WireError::TransactionTooOld => DatabaseError::TransactionTooOld.into(),
+		WireError::MaxRetriesReached => DatabaseError::MaxRetriesReached.into(),
+		WireError::UsedDuringCommit => DatabaseError::UsedDuringCommit.into(),
+		WireError::Other { message } => anyhow!(message),
+	}
+}
+
+fn now_ms() -> u64 {
+	std::time::SystemTime::now()
+		.duration_since(std::time::UNIX_EPOCH)
+		.map(|duration| duration.as_millis().try_into().unwrap_or(u64::MAX))
+		.unwrap_or(0)
+}
+
+#[derive(Clone)]
+pub struct SlateDbForwardingClient {
+	transport: Arc<dyn SlateDbForwardingTransport>,
+	lease: Option<SlateDbLease>,
+	default_subject: String,
+}
+
+impl SlateDbForwardingClient {
+	pub fn new(
+		transport: Arc<dyn SlateDbForwardingTransport>,
+		lease: Option<SlateDbLease>,
+		default_subject: String,
+	) -> Self {
+		Self {
+			transport,
+			lease,
+			default_subject,
+		}
+	}
+
+	async fn current_subject(&self) -> Result<String> {
+		if let Some(lease) = &self.lease {
+			if let Some(state) = lease
+				.read_current()
+				.await
+				.context("failed to read SlateDB forwarding lease")?
+			{
+				if state.body.expires_at_ms > now_ms() {
+					return Ok(state.body.nats_subject);
+				}
+			}
+		}
+
+		Ok(self.default_subject.clone())
+	}
+
+	async fn request(&self, txn_id: Uuid, body: WireRequestBody) -> Result<WireResponseBody> {
+		let payload = encode_request(WireRequest {
+			txn_id: *txn_id.as_bytes(),
+			body,
+		})?;
+		let subject = self.current_subject().await?;
+
+		let Some(payload) = self
+			.transport
+			.request(&subject, &payload, REQUEST_TIMEOUT)
+			.await
+			.with_context(|| format!("failed to request SlateDB leader on subject {subject}"))?
+		else {
+			return Err(DatabaseError::NotCommitted.into());
+		};
+
+		match decode_response(&payload)?.body {
+			WireResponseBody::Error(error) => Err(anyhow_from_wire_error(error)),
+			body => Ok(body),
+		}
+	}
+}
+
+pub struct SlateDbForwardingDatabaseDriver {
+	client: Arc<SlateDbForwardingClient>,
+	pub(super) max_retries: AtomicI32,
+}
+
+impl SlateDbForwardingDatabaseDriver {
+	pub fn new(client: SlateDbForwardingClient) -> Self {
+		Self {
+			client: Arc::new(client),
+			max_retries: AtomicI32::new(100),
+		}
+	}
+}
+
+impl DatabaseDriver for SlateDbForwardingDatabaseDriver {
+	fn create_txn(&self) -> Result<Transaction> {
+		Ok(Transaction::new(Arc::new(
+			SlateDbForwardingTransactionDriver::new(self.client.clone()),
+		)))
+	}
+
+	fn run<'a>(
+		&'a self,
+		closure: Box<dyn Fn(RetryableTransaction) -> BoxFut<'a, Result<Erased>> + Send + Sync + 'a>,
+	) -> BoxFut<'a, Result<Erased>> {
+		Box::pin(async move {
+			let mut maybe_committed = MaybeCommitted(false);
+			let max_retries = self.max_retries.load(Ordering::SeqCst);
+
+			for attempt in 0..max_retries {
+				let tx = self.create_txn()?;
+				let mut retryable = RetryableTransaction::new(tx);
+				retryable.maybe_committed = maybe_committed;
+
+				let error =
+					match tokio::time::timeout(crate::transaction::TXN_TIMEOUT, closure(retryable.clone()))
+						.await
+					{
+						Ok(Ok(res)) => match retryable.inner.driver.commit_ref().await {
+							Ok(_) => return Ok(res),
+							Err(e) => e,
+						},
+						Ok(Err(e)) => e,
+						Err(_) => anyhow::Error::from(DatabaseError::TransactionTooOld),
+					};
+
+				let chain = error
+					.chain()
+					.find_map(|x| x.downcast_ref::<DatabaseError>());
+
+				if let Some(db_error) = chain
+					&& db_error.is_retryable()
+				{
+					if db_error.is_maybe_committed() {
+						maybe_committed = MaybeCommitted(true);
+					}
+
+					let backoff_ms = calculate_tx_retry_backoff(attempt as usize);
+					tokio::time::sleep(tokio::time::Duration::from_millis(backoff_ms)).await;
+					continue;
+				}
+
+				return Err(error);
+			}
+
+			Err(DatabaseError::MaxRetriesReached.into())
+		})
+	}
+
+	fn txn_retry_limit(&self, limit: i32) -> Result<()> {
+		self.max_retries.store(limit, Ordering::SeqCst);
+		Ok(())
+	}
+}
+
+pub struct SlateDbForwardingTransactionDriver {
+	client: Arc<SlateDbForwardingClient>,
+	txn_id: Uuid,
+	operations: TransactionOperations,
+	committed: AtomicU64,
+}
+
+impl SlateDbForwardingTransactionDriver {
+	fn new(client: Arc<SlateDbForwardingClient>) -> Self {
+		Self {
+			client,
+			txn_id: Uuid::new_v4(),
+			operations: TransactionOperations::default(),
+			committed: AtomicU64::new(0),
+		}
+	}
+
+	async fn remote_get(&self, key: Vec<u8>) -> Result<Option<Slice>> {
+		match self
+			.client
+			.request(self.txn_id, WireRequestBody::Get { key })
+			.await?
+		{
+			WireResponseBody::Value(value) => Ok(value.map(Into::into)),
+			_ => bail!("unexpected SlateDB forwarding get response"),
+		}
+	}
+
+	async fn remote_get_key(&self, selector: WireKeySelector) -> Result<Slice> {
+		match self
+			.client
+			.request(self.txn_id, WireRequestBody::GetKey { selector })
+			.await?
+		{
+			WireResponseBody::Key(key) => Ok(key.into()),
+			_ => bail!("unexpected SlateDB forwarding get_key response"),
+		}
+	}
+
+	async fn remote_get_range(&self, opt: WireRangeOption, iteration: usize) -> Result<Values> {
+		match self
+			.client
+			.request(
+				self.txn_id,
+				WireRequestBody::GetRange {
+					opt,
+					iteration,
+				},
+			)
+			.await?
+		{
+			WireResponseBody::Values(values) => Ok(values.into()),
+			_ => bail!("unexpected SlateDB forwarding get_range response"),
+		}
+	}
+
+	async fn commit_inner(&self) -> Result<()> {
+		if self.committed.swap(1, Ordering::SeqCst) == 1 {
+			return Ok(());
+		}
+
+		let (operations, conflict_ranges) = self.operations.consume();
+		match self
+			.client
+			.request(
+				self.txn_id,
+				WireRequestBody::Commit {
+					operations: operations.into_iter().map(Into::into).collect(),
+					conflict_ranges: conflict_ranges.into_iter().map(Into::into).collect(),
+				},
+			)
+			.await?
+		{
+			WireResponseBody::Committed => Ok(()),
+			_ => bail!("unexpected SlateDB forwarding commit response"),
+		}
+	}
+}
+
+impl TransactionDriver for SlateDbForwardingTransactionDriver {
+	fn atomic_op(&self, key: &[u8], param: &[u8], op_type: MutationType) {
+		self.operations.atomic_op(key, param, op_type);
+	}
+
+	fn get<'a>(
+		&'a self,
+		key: &[u8],
+		isolation_level: IsolationLevel,
+	) -> Pin<Box<dyn Future<Output = Result<Option<Slice>>> + Send + 'a>> {
+		let key = key.to_vec();
+		Box::pin(async move {
+			self.operations
+				.get_with_callback(&key, isolation_level, || async {
+					self.remote_get(key.clone()).await
+				})
+				.await
+		})
+	}
+
+	fn get_key<'a>(
+		&'a self,
+		selector: &KeySelector<'a>,
+		isolation_level: IsolationLevel,
+	) -> Pin<Box<dyn Future<Output = Result<Slice>> + Send + 'a>> {
+		let selector = selector.clone();
+		let wire_selector = WireKeySelector::from_selector(&selector);
+		Box::pin(async move {
+			self.operations
+				.get_key(&selector, isolation_level, || async {
+					self.remote_get_key(wire_selector).await
+				})
+				.await
+		})
+	}
+
+	fn get_range<'a>(
+		&'a self,
+		opt: &RangeOption<'a>,
+		iteration: usize,
+		isolation_level: IsolationLevel,
+	) -> Pin<Box<dyn Future<Output = Result<Values>> + Send + 'a>> {
+		let opt = opt.clone();
+		let wire_opt = WireRangeOption::from_range(&opt);
+		Box::pin(async move {
+			self.operations
+				.get_range(&opt, isolation_level, || async {
+					self.remote_get_range(wire_opt, iteration).await
+				})
+				.await
+		})
+	}
+
+	fn get_ranges_keyvalues<'a>(
+		&'a self,
+		opt: RangeOption<'a>,
+		isolation_level: IsolationLevel,
+	) -> crate::value::Stream<'a, Value> {
+		let fut = async move {
+			match self.get_range(&opt, 1, isolation_level).await {
+				Ok(values) => values
+					.into_iter()
+					.map(|kv| Ok(Value::from_keyvalue(kv)))
+					.collect::<Vec<_>>(),
+				Err(e) => vec![Err(e)],
+			}
+		};
+
+		Box::pin(stream::once(fut).flat_map(stream::iter))
+	}
+
+	fn set(&self, key: &[u8], value: &[u8]) {
+		self.operations.set(key, value);
+	}
+
+	fn clear(&self, key: &[u8]) {
+		self.operations.clear(key);
+	}
+
+	fn clear_range(&self, begin: &[u8], end: &[u8]) {
+		self.operations.clear_range(begin, end);
+	}
+
+	fn commit(self: Box<Self>) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
+		Box::pin(async move { self.commit_inner().await })
+	}
+
+	fn reset(&mut self) {
+		self.operations.clear_all();
+		self.committed.store(0, Ordering::SeqCst);
+		self.txn_id = Uuid::new_v4();
+	}
+
+	fn cancel(&self) {
+		self.operations.clear_all();
+		self.committed.store(1, Ordering::SeqCst);
+		let client = self.client.clone();
+		let txn_id = self.txn_id;
+		tokio::spawn(async move {
+			if let Err(error) = client.request(txn_id, WireRequestBody::Cancel).await {
+				tracing::debug!(?error, "failed to cancel forwarded SlateDB transaction");
+			}
+		});
+	}
+
+	fn add_conflict_range(
+		&self,
+		begin: &[u8],
+		end: &[u8],
+		conflict_type: ConflictRangeType,
+	) -> Result<()> {
+		self.operations
+			.add_conflict_range(begin, end, conflict_type);
+		Ok(())
+	}
+
+	fn get_estimated_range_size_bytes<'a>(
+		&'a self,
+		begin: &'a [u8],
+		end: &'a [u8],
+	) -> Pin<Box<dyn Future<Output = Result<i64>> + Send + 'a>> {
+		let begin = begin.to_vec();
+		let end = end.to_vec();
+		Box::pin(async move {
+			match self
+				.client
+				.request(
+					self.txn_id,
+					WireRequestBody::GetEstimatedRangeSizeBytes { begin, end },
+				)
+				.await?
+			{
+				WireResponseBody::EstimatedRangeSizeBytes(bytes) => Ok(bytes),
+				_ => bail!("unexpected SlateDB forwarding size-estimate response"),
+			}
+		})
+	}
+
+	fn commit_ref(&self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+		Box::pin(async move { self.commit_inner().await })
+	}
+}
+
+pub struct SlateDbForwardingServer {
+	_handle: Box<dyn SlateDbForwardingServerHandle>,
+}
+
+impl SlateDbForwardingServer {
+	pub fn spawn(
+		transport: Arc<dyn SlateDbForwardingTransport>,
+		subject: String,
+		local_driver: Arc<super::database::SlateDbDatabaseDriver>,
+	) -> impl Future<Output = Result<Self>> + Send {
+		let handler = Arc::new(LocalForwardingHandler {
+			sessions: Arc::new(HashMap::new()),
+			local_driver,
+		});
+		async move {
+			let handle = transport.serve(subject, handler).await?;
+			Ok(Self { _handle: handle })
+		}
+	}
+}
+
+struct LocalForwardingHandler {
+	sessions: Arc<HashMap<Uuid, Transaction>>,
+	local_driver: Arc<super::database::SlateDbDatabaseDriver>,
+}
+
+#[async_trait]
+impl SlateDbForwardingHandler for LocalForwardingHandler {
+	async fn handle(&self, payload: Vec<u8>) -> Result<Vec<u8>> {
+		let response =
+			match handle_forwarded_request(&self.sessions, &self.local_driver, &payload).await {
+				Ok(body) => WireResponse { body },
+				Err(error) => WireResponse {
+					body: WireResponseBody::Error(wire_error_from_anyhow(&error)),
+				},
+			};
+
+		encode_response(response)
+	}
+}
+
+async fn get_or_create_session(
+	sessions: &HashMap<Uuid, Transaction>,
+	local_driver: &Arc<super::database::SlateDbDatabaseDriver>,
+	txn_id: Uuid,
+) -> Result<Transaction> {
+	if let Some(entry) = sessions.get_async(&txn_id).await {
+		return Ok(entry.get().clone());
+	}
+
+	let tx = local_driver.create_txn()?;
+	match sessions.entry_async(txn_id).await {
+		scc::hash_map::Entry::Occupied(entry) => Ok(entry.get().clone()),
+		scc::hash_map::Entry::Vacant(entry) => {
+			entry.insert_entry(tx.clone());
+			Ok(tx)
+		}
+	}
+}
+
+async fn handle_forwarded_request(
+	sessions: &HashMap<Uuid, Transaction>,
+	local_driver: &Arc<super::database::SlateDbDatabaseDriver>,
+	payload: &[u8],
+) -> Result<WireResponseBody> {
+	let request = decode_request(payload)?;
+	let txn_id = Uuid::from_bytes(request.txn_id);
+
+	match request.body {
+		WireRequestBody::Get { key } => {
+			let tx = get_or_create_session(sessions, local_driver, txn_id).await?;
+			Ok(WireResponseBody::Value(
+				tx.informal()
+					.get(&key, IsolationLevel::Snapshot)
+					.await?
+					.map(Into::into),
+			))
+		}
+		WireRequestBody::GetKey { selector } => {
+			let tx = get_or_create_session(sessions, local_driver, txn_id).await?;
+			let selector = selector.to_selector();
+			Ok(WireResponseBody::Key(
+				tx.informal()
+					.get_key(&selector, IsolationLevel::Snapshot)
+					.await?
+					.into(),
+			))
+		}
+		WireRequestBody::GetRange { opt, iteration } => {
+			let tx = get_or_create_session(sessions, local_driver, txn_id).await?;
+			let opt = opt.to_range();
+			Ok(WireResponseBody::Values(
+				tx.informal()
+					.get_range(&opt, iteration, IsolationLevel::Snapshot)
+					.await?
+					.into(),
+			))
+		}
+		WireRequestBody::GetEstimatedRangeSizeBytes { begin, end } => {
+			let tx = get_or_create_session(sessions, local_driver, txn_id).await?;
+			Ok(WireResponseBody::EstimatedRangeSizeBytes(
+				tx.informal()
+					.get_estimated_range_size_bytes(&begin, &end)
+					.await?,
+			))
+		}
+		WireRequestBody::Commit {
+			operations,
+			conflict_ranges,
+		} => {
+			let tx = get_or_create_session(sessions, local_driver, txn_id).await?;
+			for operation in operations {
+				apply_forwarded_operation(&tx, operation);
+			}
+			for conflict_range in conflict_ranges {
+				tx.informal().add_conflict_range(
+					&conflict_range.begin,
+					&conflict_range.end,
+					conflict_range.conflict_type,
+				)?;
+			}
+
+			let result = tx.driver.commit_ref().await;
+			let _ = sessions.remove_async(&txn_id).await;
+			result?;
+			Ok(WireResponseBody::Committed)
+		}
+		WireRequestBody::Cancel => {
+			let _ = sessions.remove_async(&txn_id).await;
+			Ok(WireResponseBody::Canceled)
+		}
+	}
+}
+
+fn apply_forwarded_operation(tx: &Transaction, operation: WireOperation) {
+	match operation {
+		WireOperation::SetValue { key, value } => tx.informal().set(&key, &value),
+		WireOperation::Clear { key } => tx.informal().clear(&key),
+		WireOperation::ClearRange { begin, end } => tx.informal().clear_range(&begin, &end),
+		WireOperation::AtomicOp {
+			key,
+			param,
+			op_type,
+		} => tx.informal().atomic_op(&key, &param, op_type),
+	}
+}

--- a/engine/packages/universaldb/src/driver/slatedb/lease.rs
+++ b/engine/packages/universaldb/src/driver/slatedb/lease.rs
@@ -1,0 +1,262 @@
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use slatedb::object_store::{
+	Error as ObjectStoreError, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutResult,
+	UpdateVersion,
+	path::Path as ObjectStorePath,
+};
+
+use super::database::SlateDbLeaseConfig;
+
+const LEASE_OBJECT: &str = "LEADER_LEASE";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LeaseBody {
+	pub leader_id: String,
+	pub epoch: u64,
+	pub expires_at_ms: u64,
+	pub nats_subject: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeaseState {
+	pub body: LeaseBody,
+	version: UpdateVersion,
+}
+
+impl LeaseState {
+	pub fn version(&self) -> &UpdateVersion {
+		&self.version
+	}
+}
+
+#[derive(Clone)]
+pub struct SlateDbLease {
+	object_store: Arc<dyn ObjectStore>,
+	lease_path: ObjectStorePath,
+	config: SlateDbLeaseConfig,
+}
+
+impl SlateDbLease {
+	pub fn new(
+		object_store: Arc<dyn ObjectStore>,
+		db_path: ObjectStorePath,
+		config: SlateDbLeaseConfig,
+		) -> Self {
+		SlateDbLease {
+			object_store,
+			lease_path: db_path.join(LEASE_OBJECT),
+			config,
+		}
+	}
+
+	pub fn lease_path(&self) -> &ObjectStorePath {
+		&self.lease_path
+	}
+
+	pub async fn read_current(&self) -> Result<Option<LeaseState>> {
+		let result = match self.object_store.get(&self.lease_path).await {
+			Ok(result) => result,
+			Err(ObjectStoreError::NotFound { .. }) => return Ok(None),
+			Err(err) => return Err(err).context("failed to read SlateDB leader lease"),
+		};
+		let version = UpdateVersion {
+			e_tag: result.meta.e_tag.clone(),
+			version: result.meta.version.clone(),
+		};
+		let bytes = result
+			.bytes()
+			.await
+			.context("failed to read SlateDB leader lease body")?;
+		let body = serde_json::from_slice(&bytes).context("failed to decode SlateDB leader lease")?;
+
+		Ok(Some(LeaseState { body, version }))
+	}
+
+	pub async fn try_acquire(
+		&self,
+		leader_id: impl Into<String>,
+		nats_subject: impl Into<String>,
+		now_ms: u64,
+	) -> Result<Option<LeaseState>> {
+		let leader_id = leader_id.into();
+		let nats_subject = nats_subject.into();
+		let current = self.read_current().await?;
+
+		let (epoch, mode) = match current {
+			Some(current) if current.body.expires_at_ms > now_ms => return Ok(None),
+			Some(current) => (
+				current.body.epoch.saturating_add(1),
+				PutMode::Update(current.version),
+			),
+			None => (1, PutMode::Create),
+		};
+
+		let body = LeaseBody {
+			leader_id,
+			epoch,
+			expires_at_ms: now_ms.saturating_add(self.config.ttl_ms),
+			nats_subject,
+		};
+		self.write(body, mode).await
+	}
+
+	pub async fn renew(&self, state: &LeaseState, now_ms: u64) -> Result<Option<LeaseState>> {
+		let mut body = state.body.clone();
+		body.expires_at_ms = now_ms.saturating_add(self.config.ttl_ms);
+		self.write(body, PutMode::Update(state.version.clone())).await
+	}
+
+	pub async fn release(&self, state: &LeaseState, now_ms: u64) -> Result<Option<LeaseState>> {
+		let mut body = state.body.clone();
+		body.expires_at_ms = now_ms;
+		self.write(body, PutMode::Update(state.version.clone())).await
+	}
+
+	async fn write(&self, body: LeaseBody, mode: PutMode) -> Result<Option<LeaseState>> {
+		let payload = serde_json::to_vec(&body).context("failed to encode SlateDB leader lease")?;
+		let result = match self
+			.object_store
+			.put_opts(&self.lease_path, payload.into(), PutOptions::from(mode))
+			.await
+		{
+			Ok(result) => result,
+			Err(ObjectStoreError::AlreadyExists { .. } | ObjectStoreError::Precondition { .. }) => {
+				return Ok(None);
+			}
+			Err(err) => return Err(err).context("failed to write SlateDB leader lease"),
+		};
+
+		Ok(Some(LeaseState {
+			body,
+			version: version_from_put(result),
+		}))
+	}
+}
+
+fn version_from_put(result: PutResult) -> UpdateVersion {
+	UpdateVersion {
+		e_tag: result.e_tag,
+		version: result.version,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use slatedb::object_store::{ObjectStore, memory::InMemory, path::Path as ObjectStorePath};
+
+	use super::*;
+
+	fn test_lease() -> SlateDbLease {
+		let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+		SlateDbLease::new(
+			store,
+			ObjectStorePath::from("test-db"),
+			SlateDbLeaseConfig {
+				ttl_ms: 100,
+				heartbeat_ms: 50,
+				nats_subject: None,
+			},
+		)
+	}
+
+	#[tokio::test]
+	async fn acquire_empty_lease_writes_body() {
+		let lease = test_lease();
+
+		let state = lease
+			.try_acquire("leader-a", "udb.leader-a", 1_000)
+			.await
+			.unwrap()
+			.unwrap();
+
+		assert_eq!(state.body.leader_id, "leader-a");
+		assert_eq!(state.body.epoch, 1);
+		assert_eq!(state.body.expires_at_ms, 1_100);
+		assert_eq!(state.body.nats_subject, "udb.leader-a");
+		assert_eq!(lease.read_current().await.unwrap().unwrap().body, state.body);
+	}
+
+	#[tokio::test]
+	async fn acquire_live_lease_loses_without_overwrite() {
+		let lease = test_lease();
+		let state = lease
+			.try_acquire("leader-a", "udb.leader-a", 1_000)
+			.await
+			.unwrap()
+			.unwrap();
+
+		let contender = lease
+			.try_acquire("leader-b", "udb.leader-b", 1_050)
+			.await
+			.unwrap();
+
+		assert!(contender.is_none());
+		assert_eq!(lease.read_current().await.unwrap().unwrap().body, state.body);
+	}
+
+	#[tokio::test]
+	async fn expired_lease_takeover_bumps_epoch() {
+		let lease = test_lease();
+		lease
+			.try_acquire("leader-a", "udb.leader-a", 1_000)
+			.await
+			.unwrap()
+			.unwrap();
+
+		let state = lease
+			.try_acquire("leader-b", "udb.leader-b", 1_101)
+			.await
+			.unwrap()
+			.unwrap();
+
+		assert_eq!(state.body.leader_id, "leader-b");
+		assert_eq!(state.body.epoch, 2);
+		assert_eq!(state.body.expires_at_ms, 1_201);
+	}
+
+	#[tokio::test]
+	async fn stale_renew_fails_after_takeover() {
+		let lease = test_lease();
+		let stale = lease
+			.try_acquire("leader-a", "udb.leader-a", 1_000)
+			.await
+			.unwrap()
+			.unwrap();
+		let current = lease
+			.try_acquire("leader-b", "udb.leader-b", 1_101)
+			.await
+			.unwrap()
+			.unwrap();
+
+		assert!(lease.renew(&stale, 1_120).await.unwrap().is_none());
+		assert_eq!(lease.read_current().await.unwrap().unwrap().body, current.body);
+	}
+
+	#[tokio::test]
+	async fn renew_and_release_use_cas_version() {
+		let lease = test_lease();
+		let state = lease
+			.try_acquire("leader-a", "udb.leader-a", 1_000)
+			.await
+			.unwrap()
+			.unwrap();
+
+		let renewed = lease.renew(&state, 1_050).await.unwrap().unwrap();
+		assert_eq!(renewed.body.epoch, 1);
+		assert_eq!(renewed.body.expires_at_ms, 1_150);
+
+		let released = lease.release(&renewed, 1_060).await.unwrap().unwrap();
+		assert_eq!(released.body.expires_at_ms, 1_060);
+
+		let takeover = lease
+			.try_acquire("leader-b", "udb.leader-b", 1_061)
+			.await
+			.unwrap()
+			.unwrap();
+		assert_eq!(takeover.body.leader_id, "leader-b");
+		assert_eq!(takeover.body.epoch, 2);
+	}
+}

--- a/engine/packages/universaldb/src/driver/slatedb/mod.rs
+++ b/engine/packages/universaldb/src/driver/slatedb/mod.rs
@@ -1,0 +1,13 @@
+mod commit;
+mod database;
+mod forwarding;
+mod lease;
+mod transaction;
+mod transaction_conflict_tracker;
+
+pub use database::{SlateDbConfig, SlateDbDatabaseDriver, SlateDbLeaseConfig};
+pub use forwarding::{
+	SlateDbForwardingClient, SlateDbForwardingDatabaseDriver, SlateDbForwardingHandler,
+	SlateDbForwardingServer, SlateDbForwardingServerHandle, SlateDbForwardingTransport,
+};
+pub use lease::{LeaseBody, LeaseState, SlateDbLease};

--- a/engine/packages/universaldb/src/driver/slatedb/transaction.rs
+++ b/engine/packages/universaldb/src/driver/slatedb/transaction.rs
@@ -1,0 +1,480 @@
+use std::{
+	future::Future,
+	pin::Pin,
+	sync::{
+		Arc,
+		atomic::{AtomicBool, AtomicU64, Ordering},
+	},
+};
+
+use anyhow::{Context, Result, bail};
+use futures_util::{StreamExt, stream};
+use slatedb::{
+	Db, DbSnapshot, IterationOrder,
+	config::{DurabilityLevel, ReadOptions, ScanOptions, WriteOptions},
+};
+use tokio::sync::{Mutex, OnceCell};
+
+use crate::{
+	driver::TransactionDriver,
+	error::DatabaseError,
+	key_selector::KeySelector,
+	options::{ConflictRangeType, MutationType},
+	range_option::RangeOption,
+	tx_ops::TransactionOperations,
+	utils::IsolationLevel,
+	value::{KeyValue, Slice, Value, Values},
+};
+
+use super::{
+	commit::build_write_batch, transaction_conflict_tracker::TransactionConflictTracker,
+};
+
+#[derive(Clone)]
+struct BeginState {
+	read_version: u64,
+	snapshot: Arc<DbSnapshot>,
+}
+
+pub struct SlateDbTransactionDriver {
+	db: Arc<Db>,
+	operations: TransactionOperations,
+	committed: AtomicBool,
+	txn_conflict_tracker: TransactionConflictTracker,
+	commit_mutex: Arc<Mutex<()>>,
+	last_applied_version: Arc<AtomicU64>,
+	begin_state: OnceCell<BeginState>,
+	active: Option<Arc<AtomicBool>>,
+}
+
+impl SlateDbTransactionDriver {
+	pub fn new(
+		db: Arc<Db>,
+		txn_conflict_tracker: TransactionConflictTracker,
+		commit_mutex: Arc<Mutex<()>>,
+		last_applied_version: Arc<AtomicU64>,
+		active: Option<Arc<AtomicBool>>,
+	) -> Self {
+		SlateDbTransactionDriver {
+			db,
+			operations: TransactionOperations::default(),
+			committed: AtomicBool::new(false),
+			txn_conflict_tracker,
+			commit_mutex,
+			last_applied_version,
+			begin_state: OnceCell::new(),
+			active,
+		}
+	}
+
+	fn is_active(&self) -> bool {
+		self.active
+			.as_ref()
+			.is_none_or(|active| active.load(Ordering::Acquire))
+	}
+
+	async fn begin(&self) -> Result<&BeginState> {
+		self.begin_state
+			.get_or_try_init(|| async {
+				let _guard = self.commit_mutex.lock().await;
+				let read_version = self.last_applied_version.load(Ordering::Acquire);
+				let snapshot = self
+					.db
+					.snapshot()
+					.await
+					.context("failed to create SlateDB snapshot")?;
+				anyhow::Ok(BeginState {
+					read_version,
+					snapshot,
+				})
+			})
+			.await
+	}
+
+	fn read_options() -> ReadOptions {
+		ReadOptions::new()
+			.with_durability_filter(DurabilityLevel::Memory)
+			.with_dirty(false)
+	}
+
+	fn scan_options(reverse: bool) -> ScanOptions {
+		let order = if reverse {
+			IterationOrder::Descending
+		} else {
+			IterationOrder::Ascending
+		};
+		ScanOptions::new()
+			.with_durability_filter(DurabilityLevel::Memory)
+			.with_dirty(false)
+			.with_order(order)
+	}
+
+	async fn snapshot_get(&self, key: &[u8]) -> Result<Option<Slice>> {
+		let begin = self.begin().await?;
+		Ok(begin
+			.snapshot
+			.get_with_options(key, &Self::read_options())
+			.await
+			.context("failed to read SlateDB snapshot value")?
+			.map(|value| value.to_vec().into()))
+	}
+
+	async fn snapshot_get_key(
+		&self,
+		key: &[u8],
+		or_equal: bool,
+		offset: i32,
+	) -> Result<Option<Slice>> {
+		let begin = self.begin().await?;
+
+		match (or_equal, offset) {
+			(false, 1) => {
+				let mut iter = begin
+					.snapshot
+					.scan_with_options(key.to_vec().., &Self::scan_options(false))
+					.await
+					.context("failed to scan SlateDB first_greater_or_equal")?;
+				Ok(iter
+					.next()
+					.await
+					.context("failed to iterate SlateDB first_greater_or_equal")?
+					.map(|kv| kv.key.to_vec().into()))
+			}
+			(true, 1) => {
+				let mut iter = begin
+					.snapshot
+					.scan_with_options(key.to_vec().., &Self::scan_options(false))
+					.await
+					.context("failed to scan SlateDB first_greater_than")?;
+				while let Some(kv) = iter
+					.next()
+					.await
+					.context("failed to iterate SlateDB first_greater_than")?
+				{
+					if kv.key.as_ref() > key {
+						return Ok(Some(kv.key.to_vec().into()));
+					}
+				}
+				Ok(None)
+			}
+			(false, 0) => {
+				let mut iter = begin
+					.snapshot
+					.scan_with_options(..key.to_vec(), &Self::scan_options(true))
+					.await
+					.context("failed to scan SlateDB last_less_than")?;
+				Ok(iter
+					.next()
+					.await
+					.context("failed to iterate SlateDB last_less_than")?
+					.map(|kv| kv.key.to_vec().into()))
+			}
+			(true, 0) => {
+				let mut iter = begin
+					.snapshot
+					.scan_with_options(..=key.to_vec(), &Self::scan_options(true))
+					.await
+					.context("failed to scan SlateDB last_less_or_equal")?;
+				Ok(iter
+					.next()
+					.await
+					.context("failed to iterate SlateDB last_less_or_equal")?
+					.map(|kv| kv.key.to_vec().into()))
+			}
+			_ => bail!("invalid key selector offset"),
+		}
+	}
+
+	async fn resolve_key_selector_for_range(
+		&self,
+		begin_state: &BeginState,
+		key: &[u8],
+		or_equal: bool,
+		offset: i32,
+	) -> Result<Vec<u8>> {
+		match (or_equal, offset) {
+			(false, 1) => {
+				let mut iter = begin_state
+					.snapshot
+					.scan_with_options(key.to_vec().., &Self::scan_options(false))
+					.await
+					.context("failed to scan SlateDB range first_greater_or_equal")?;
+				Ok(iter
+					.next()
+					.await
+					.context("failed to iterate SlateDB range first_greater_or_equal")?
+					.map(|kv| kv.key.to_vec())
+					.unwrap_or_else(|| vec![0xff; 255]))
+			}
+			(true, 1) => {
+				let mut iter = begin_state
+					.snapshot
+					.scan_with_options(key.to_vec().., &Self::scan_options(false))
+					.await
+					.context("failed to scan SlateDB range first_greater_than")?;
+				while let Some(kv) = iter
+					.next()
+					.await
+					.context("failed to iterate SlateDB range first_greater_than")?
+				{
+					if kv.key.as_ref() > key {
+						return Ok(kv.key.to_vec());
+					}
+				}
+				Ok(vec![0xff; 255])
+			}
+			_ => Ok(key.to_vec()),
+		}
+	}
+
+	async fn snapshot_get_range(
+		&self,
+		opt: &RangeOption<'_>,
+	) -> Result<Values> {
+		let begin_state = self.begin().await?;
+		let resolved_begin = self
+			.resolve_key_selector_for_range(
+				begin_state,
+				opt.begin.key(),
+				opt.begin.or_equal(),
+				opt.begin.offset(),
+			)
+			.await?;
+		let resolved_end = self
+			.resolve_key_selector_for_range(
+				begin_state,
+				opt.end.key(),
+				opt.end.or_equal(),
+				opt.end.offset(),
+			)
+			.await?;
+
+		if resolved_begin >= resolved_end {
+			return Ok(Values::new(Vec::new()));
+		}
+
+		let mut results = Vec::new();
+		let limit = opt.limit.unwrap_or(usize::MAX);
+		let mut iter = begin_state
+			.snapshot
+			.scan_with_options(
+				resolved_begin.clone()..resolved_end.clone(),
+				&Self::scan_options(opt.reverse),
+			)
+			.await
+			.context("failed to scan SlateDB range")?;
+
+		while let Some(kv) = iter
+			.next()
+			.await
+			.context("failed to iterate SlateDB range")?
+		{
+			results.push(KeyValue::new(kv.key.to_vec(), kv.value.to_vec()));
+			if results.len() >= limit {
+				break;
+			}
+		}
+
+		Ok(Values::new(results))
+	}
+
+	async fn commit_inner(&self) -> Result<()> {
+		if self.committed.load(Ordering::SeqCst) {
+			return Ok(());
+		}
+		if !self.is_active() {
+			return Err(DatabaseError::NotCommitted.into());
+		}
+		self.committed.store(true, Ordering::SeqCst);
+
+		let begin = self.begin().await?.clone();
+		let (operations, conflict_ranges) = self.operations.consume();
+
+		let _guard = self.commit_mutex.lock().await;
+		if !self.is_active() {
+			return Err(DatabaseError::NotCommitted.into());
+		}
+		let Some(commit_version) = self
+			.txn_conflict_tracker
+			.check_and_insert(begin.read_version, conflict_ranges)
+			.await
+		else {
+			return Err(DatabaseError::NotCommitted.into());
+		};
+
+		let batch = build_write_batch(self.db.clone(), operations).await?;
+		if !batch.is_empty() {
+			if let Err(error) = self
+				.db
+				.write_with_options(batch, &WriteOptions::default())
+				.await
+				.context("failed to write SlateDB batch")
+			{
+				if let Some(active) = &self.active {
+					active.store(false, Ordering::Release);
+					tracing::warn!(?error, "demoting SlateDB leader after write failure");
+					return Err(DatabaseError::NotCommitted.into());
+				}
+				return Err(error);
+			}
+		}
+		self.last_applied_version
+			.store(commit_version, Ordering::Release);
+
+		Ok(())
+	}
+}
+
+impl TransactionDriver for SlateDbTransactionDriver {
+	fn atomic_op(&self, key: &[u8], param: &[u8], op_type: MutationType) {
+		self.operations.atomic_op(key, param, op_type);
+	}
+
+	fn get<'a>(
+		&'a self,
+		key: &[u8],
+		isolation_level: IsolationLevel,
+	) -> Pin<Box<dyn Future<Output = Result<Option<Slice>>> + Send + 'a>> {
+		let key = key.to_vec();
+		Box::pin(async move {
+			self.operations
+				.get_with_callback(&key, isolation_level, || async {
+					self.snapshot_get(&key).await
+				})
+				.await
+		})
+	}
+
+	fn get_key<'a>(
+		&'a self,
+		selector: &KeySelector<'a>,
+		isolation_level: IsolationLevel,
+	) -> Pin<Box<dyn Future<Output = Result<Slice>> + Send + 'a>> {
+		let selector = selector.clone();
+		Box::pin(async move {
+			let key = selector.key().to_vec();
+			let offset = selector.offset();
+			let or_equal = selector.or_equal();
+			self.operations
+				.get_key(&selector, isolation_level, || async {
+					Ok(self
+						.snapshot_get_key(&key, or_equal, offset)
+						.await?
+						.unwrap_or_else(Slice::new))
+				})
+				.await
+		})
+	}
+
+	fn get_range<'a>(
+		&'a self,
+		opt: &RangeOption<'a>,
+		_iteration: usize,
+		isolation_level: IsolationLevel,
+	) -> Pin<Box<dyn Future<Output = Result<Values>> + Send + 'a>> {
+		let opt = opt.clone();
+		Box::pin(async move {
+			self.operations
+				.get_range(&opt, isolation_level, || async {
+					self.snapshot_get_range(&opt).await
+				})
+				.await
+		})
+	}
+
+	fn get_ranges_keyvalues<'a>(
+		&'a self,
+		opt: RangeOption<'a>,
+		isolation_level: IsolationLevel,
+	) -> crate::value::Stream<'a, Value> {
+		let fut = async move {
+			match self.get_range(&opt, 1, isolation_level).await {
+				Ok(values) => values
+					.into_iter()
+					.map(|kv| Ok(Value::from_keyvalue(kv)))
+					.collect::<Vec<_>>(),
+				Err(e) => vec![Err(e)],
+			}
+		};
+
+		Box::pin(stream::once(fut).flat_map(stream::iter))
+	}
+
+	fn set(&self, key: &[u8], value: &[u8]) {
+		self.operations.set(key, value);
+	}
+
+	fn clear(&self, key: &[u8]) {
+		self.operations.clear(key);
+	}
+
+	fn clear_range(&self, begin: &[u8], end: &[u8]) {
+		self.operations.clear_range(begin, end);
+	}
+
+	fn commit(self: Box<Self>) -> Pin<Box<dyn Future<Output = Result<()>> + Send>> {
+		Box::pin(async move { self.commit_inner().await })
+	}
+
+	fn reset(&mut self) {
+		self.operations.clear_all();
+		self.committed.store(false, Ordering::SeqCst);
+		self.begin_state.take();
+	}
+
+	fn cancel(&self) {
+		self.operations.clear_all();
+		self.committed.store(true, Ordering::SeqCst);
+	}
+
+	fn add_conflict_range(
+		&self,
+		begin: &[u8],
+		end: &[u8],
+		conflict_type: ConflictRangeType,
+	) -> Result<()> {
+		self.operations
+			.add_conflict_range(begin, end, conflict_type);
+		Ok(())
+	}
+
+	fn get_estimated_range_size_bytes<'a>(
+		&'a self,
+		begin: &'a [u8],
+		end: &'a [u8],
+	) -> Pin<Box<dyn Future<Output = Result<i64>> + Send + 'a>> {
+		let begin = begin.to_vec();
+		let end = end.to_vec();
+		Box::pin(async move {
+			if begin >= end {
+				return Ok(0);
+			}
+
+			let begin_state = self.begin().await?;
+			let mut iter = begin_state
+				.snapshot
+				.scan_with_options(begin..end, &Self::scan_options(false))
+				.await
+				.context("failed to scan SlateDB range for size estimate")?;
+			let mut total: i64 = 0;
+			let mut count = 0usize;
+			const MAX_KEYS: usize = 1024;
+			while let Some(kv) = iter
+				.next()
+				.await
+				.context("failed to iterate SlateDB range for size estimate")?
+			{
+				total = total.saturating_add((kv.key.len() + kv.value.len()) as i64);
+				count += 1;
+				if count >= MAX_KEYS {
+					break;
+				}
+			}
+			Ok(total)
+		})
+	}
+
+	fn commit_ref(&self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+		Box::pin(async move { self.commit_inner().await })
+	}
+}

--- a/engine/packages/universaldb/src/driver/slatedb/transaction_conflict_tracker.rs
+++ b/engine/packages/universaldb/src/driver/slatedb/transaction_conflict_tracker.rs
@@ -1,0 +1,86 @@
+use std::{
+	sync::{
+		Arc,
+		atomic::{AtomicU64, Ordering},
+	},
+	time::{Duration, Instant},
+};
+
+use tokio::sync::Mutex;
+
+use crate::options::ConflictRangeType;
+
+const TXN_CONFLICT_TTL: Duration = Duration::from_secs(10);
+
+#[derive(Debug)]
+struct PreviousTransaction {
+	insert_instant: Instant,
+	start_version: u64,
+	commit_version: u64,
+	conflict_ranges: Vec<(Vec<u8>, Vec<u8>, ConflictRangeType)>,
+}
+
+#[derive(Clone)]
+pub struct TransactionConflictTracker {
+	txns: Arc<Mutex<Vec<PreviousTransaction>>>,
+	global_version: Arc<AtomicU64>,
+}
+
+impl TransactionConflictTracker {
+	pub fn new() -> Self {
+		TransactionConflictTracker {
+			txns: Arc::new(Mutex::new(Vec::new())),
+			global_version: Arc::new(AtomicU64::new(1)),
+		}
+	}
+
+	fn next_global_version(&self) -> u64 {
+		self.global_version.fetch_add(1, Ordering::SeqCst)
+	}
+
+	pub async fn check_and_insert(
+		&self,
+		txn1_start_version: u64,
+		txn1_conflict_ranges: Vec<(Vec<u8>, Vec<u8>, ConflictRangeType)>,
+	) -> Option<u64> {
+		let mut txns = self.txns.lock().await;
+		let txn1_commit_version = self.next_global_version();
+
+		txns.retain(|txn| txn.insert_instant.elapsed() < TXN_CONFLICT_TTL);
+
+		for txn2 in &*txns {
+			if txn1_start_version < txn2.commit_version && txn2.start_version < txn1_commit_version
+			{
+				for (cr1_start, cr1_end, cr1_type) in &txn1_conflict_ranges {
+					for (cr2_start, cr2_end, cr2_type) in &txn2.conflict_ranges {
+						if cr1_start < cr2_end && cr2_start < cr1_end && cr1_type != cr2_type {
+							tracing::debug!(
+								cr1_start=%hex::encode(cr1_start),
+								cr1_end=%hex::encode(cr1_end),
+								?cr1_type,
+								cr2_start=%hex::encode(cr2_start),
+								cr2_end=%hex::encode(cr2_end),
+								?cr2_type,
+								txn1_start_version,
+								txn1_commit_version,
+								txn2_start_version = txn2.start_version,
+								txn2_commit_version = txn2.commit_version,
+								"transaction conflict detected"
+							);
+							return None;
+						}
+					}
+				}
+			}
+		}
+
+		txns.push(PreviousTransaction {
+			insert_instant: Instant::now(),
+			start_version: txn1_start_version,
+			commit_version: txn1_commit_version,
+			conflict_ranges: txn1_conflict_ranges,
+		});
+
+		Some(txn1_commit_version)
+	}
+}

--- a/engine/packages/universaldb/src/options.rs
+++ b/engine/packages/universaldb/src/options.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub enum StreamingMode {
 	/// Client intends to consume the entire range and would like it all transferred as early as possible.
@@ -16,7 +16,7 @@ pub enum StreamingMode {
 	/// Transfer data in batches large enough that an individual client can get reasonable read bandwidth from the database. If the client stops iteration early, considerable disk and network bandwidth may be wasted.
 	Serial,
 }
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub enum MutationType {
 	/// addend
@@ -80,7 +80,7 @@ pub enum MutationType {
 	/// Performs an atomic ``compare and clear`` operation. If the existing value in the database is equal to the given value, then given key is cleared.
 	CompareAndClear,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub enum ConflictRangeType {
 	/// Used to add a read conflict range
@@ -88,7 +88,7 @@ pub enum ConflictRangeType {
 	/// Used to add a write conflict range
 	Write,
 }
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize, serde::Serialize)]
 #[non_exhaustive]
 pub enum Priority {
 	Low,

--- a/engine/packages/universaldb/tests/integration.rs
+++ b/engine/packages/universaldb/tests/integration.rs
@@ -1,15 +1,30 @@
-use anyhow::Result;
+use anyhow::{Result, anyhow};
+use async_trait::async_trait;
 use rivet_test_deps_docker::TestDatabase;
-use std::{borrow::Cow, sync::Arc};
+use std::{
+	borrow::Cow,
+	collections::BTreeMap,
+	sync::{
+		Arc,
+		atomic::{AtomicUsize, Ordering},
+	},
+	time::Duration,
+};
+use parking_lot::RwLock;
 use universaldb::{
 	Database,
+	driver::slatedb::{
+		SlateDbForwardingClient, SlateDbForwardingDatabaseDriver, SlateDbForwardingHandler,
+		SlateDbForwardingServer, SlateDbForwardingServerHandle, SlateDbForwardingTransport,
+	},
 	key_selector::KeySelector,
-	options::{ConflictRangeType, StreamingMode},
+	options::{ConflictRangeType, MutationType, StreamingMode},
 	range_option::RangeOption,
 	tuple::{Element, Subspace, Versionstamp, pack_with_versionstamp},
 	utils::IsolationLevel::*,
 	versionstamp::generate_versionstamp,
 };
+use slatedb::object_store::{ObjectStore, memory::InMemory, path::Path as ObjectStorePath};
 use uuid::Uuid;
 
 mod integration_gas;
@@ -64,6 +79,383 @@ async fn test_rocksdb_driver() {
 	let db = Database::new(Arc::new(driver));
 
 	run_all_tests(db).await;
+}
+
+#[tokio::test]
+async fn test_slatedb_driver() {
+	let _ = tracing_subscriber::fmt::try_init();
+
+	let test_id = Uuid::new_v4();
+	let (db_config, _docker_config) = TestDatabase::SlateDb.config(test_id, 1).await.unwrap();
+
+	let rivet_config::config::Database::SlateDb(slatedb_config) = db_config else {
+		unreachable!()
+	};
+
+	let driver = universaldb::driver::SlateDbDatabaseDriver::new(
+		universaldb::driver::slatedb::SlateDbConfig {
+			object_store_url: slatedb_config.object_store_url,
+			path: slatedb_config.path,
+			lease: None,
+		},
+	)
+	.await
+	.unwrap();
+	let db = Database::new(Arc::new(driver));
+
+	run_all_tests(db).await;
+}
+
+#[tokio::test]
+async fn test_slatedb_forwarding_driver() {
+	let _ = tracing_subscriber::fmt::try_init();
+
+	let subject = format!("udb.slatedb.test.{}", Uuid::new_v4());
+	let transport = Arc::new(TestForwardingTransport::new());
+	let local_driver = Arc::new(
+		universaldb::driver::SlateDbDatabaseDriver::new(
+			universaldb::driver::slatedb::SlateDbConfig {
+				object_store_url: "memory:///".to_string(),
+				path: Some(format!("rivet-test-slatedb-forwarding-{}", Uuid::new_v4())),
+				lease: None,
+			},
+		)
+		.await
+		.unwrap(),
+	);
+	let _server =
+		SlateDbForwardingServer::spawn(transport.clone(), subject.clone(), local_driver)
+			.await
+			.unwrap();
+	let forwarding_client = SlateDbForwardingClient::new(transport, None, subject);
+	let forwarding_driver = SlateDbForwardingDatabaseDriver::new(forwarding_client);
+	let db = Database::new(Arc::new(forwarding_driver));
+
+	run_all_tests(db).await;
+}
+
+#[tokio::test]
+async fn test_slatedb_managed_forwarding_failover() {
+	let _ = tracing_subscriber::fmt()
+		.with_env_filter("info")
+		.with_test_writer()
+		.try_init();
+
+	let subject = format!("udb.slatedb.managed.{}", Uuid::new_v4());
+	let transport = Arc::new(TestForwardingTransport::new());
+	let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+	let db_path = ObjectStorePath::from(format!("managed-failover-{}", Uuid::new_v4()));
+	let config = universaldb::driver::slatedb::SlateDbConfig {
+		object_store_url: "memory:///".to_string(),
+		path: None,
+		lease: Some(universaldb::driver::slatedb::SlateDbLeaseConfig {
+			ttl_ms: 250,
+			heartbeat_ms: 50,
+			nats_subject: Some(subject),
+		}),
+	};
+	let key = Subspace::from("test-slatedb-managed-failover").pack(&("key",));
+
+	let leader_driver = universaldb::driver::SlateDbDatabaseDriver::new_managed_with_object_store(
+		config.clone(),
+		object_store.clone(),
+		db_path.clone(),
+		transport.clone(),
+		Uuid::new_v4(),
+	)
+	.await
+	.unwrap();
+	let follower_driver = universaldb::driver::SlateDbDatabaseDriver::new_managed_with_object_store(
+		config,
+		object_store,
+		db_path,
+		transport,
+		Uuid::new_v4(),
+	)
+	.await
+	.unwrap();
+
+	let leader_db = Database::new(leader_driver.clone());
+	let follower_db = Database::new(follower_driver.clone());
+
+	leader_db
+		.txn("test_universaldbintegration", |tx| {
+			let key = key.clone();
+			async move {
+				tx.set(&key, b"leader");
+				Ok(())
+			}
+		})
+		.await
+		.unwrap();
+
+	let forwarded_value = follower_db
+		.txn("test_universaldbintegration", |tx| {
+			let key = key.clone();
+			async move { tx.get(&key, Serializable).await }
+		})
+		.await
+		.unwrap()
+		.unwrap();
+	assert_eq!(forwarded_value.as_slice(), b"leader");
+
+	drop(leader_db);
+	drop(leader_driver);
+	tokio::time::sleep(Duration::from_millis(800)).await;
+
+	follower_db
+		.txn("test_universaldbintegration", |tx| {
+			let key = key.clone();
+			async move {
+				tx.set(&key, b"new-leader");
+				Ok(())
+			}
+		})
+		.await
+		.unwrap();
+
+	let value = follower_db
+		.txn("test_universaldbintegration", |tx| {
+			let key = key.clone();
+			async move { tx.get(&key, Serializable).await }
+		})
+		.await
+		.unwrap()
+		.unwrap();
+	assert_eq!(value.as_slice(), b"new-leader");
+}
+
+#[derive(Clone)]
+struct TestForwardingTransport {
+	handlers: Arc<RwLock<BTreeMap<String, Arc<dyn SlateDbForwardingHandler>>>>,
+}
+
+impl TestForwardingTransport {
+	fn new() -> Self {
+		Self {
+			handlers: Arc::new(RwLock::new(BTreeMap::new())),
+		}
+	}
+}
+
+#[async_trait]
+impl SlateDbForwardingTransport for TestForwardingTransport {
+	async fn request(
+		&self,
+		subject: &str,
+		payload: &[u8],
+		_timeout: Duration,
+	) -> Result<Option<Vec<u8>>> {
+		let Some(handler) = self.handlers.read().get(subject).cloned() else {
+			return Ok(None);
+		};
+
+		Ok(Some(handler.handle(payload.to_vec()).await?))
+	}
+
+	async fn serve(
+		&self,
+		subject: String,
+		handler: Arc<dyn SlateDbForwardingHandler>,
+	) -> Result<Box<dyn SlateDbForwardingServerHandle>> {
+		let existing = self.handlers.write().insert(subject.clone(), handler);
+		if existing.is_some() {
+			return Err(anyhow!("duplicate SlateDB forwarding subject: {subject}"));
+		}
+		Ok(Box::new(TestForwardingServerHandle {
+			handlers: self.handlers.clone(),
+			subject,
+		}))
+	}
+}
+
+struct TestForwardingServerHandle {
+	handlers: Arc<RwLock<BTreeMap<String, Arc<dyn SlateDbForwardingHandler>>>>,
+	subject: String,
+}
+
+impl SlateDbForwardingServerHandle for TestForwardingServerHandle {}
+
+impl Drop for TestForwardingServerHandle {
+	fn drop(&mut self) {
+		self.handlers.write().remove(&self.subject);
+	}
+}
+
+#[tokio::test]
+async fn test_slatedb_write_skew_retries() {
+	let _ = tracing_subscriber::fmt()
+		.with_env_filter("info")
+		.with_test_writer()
+		.try_init();
+
+	let db = create_memory_slatedb_database("write-skew").await;
+	let test_subspace = Subspace::from("test-slatedb-write-skew");
+	let key_a = test_subspace.pack(&("a",));
+	let key_b = test_subspace.pack(&("b",));
+
+	let barrier = Arc::new(tokio::sync::Barrier::new(2));
+	let attempts_a = Arc::new(AtomicUsize::new(0));
+	let attempts_b = Arc::new(AtomicUsize::new(0));
+
+	let task_a = {
+		let db = db.clone();
+		let barrier = barrier.clone();
+		let attempts = attempts_a.clone();
+		let key_a = key_a.clone();
+		let key_b = key_b.clone();
+		tokio::spawn(async move {
+			db.txn("test_universaldbintegration", |tx| {
+				let barrier = barrier.clone();
+				let attempts = attempts.clone();
+				let key_a = key_a.clone();
+				let key_b = key_b.clone();
+				async move {
+					let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+					let _ = tx.get(&key_a, Serializable).await?;
+					if attempt == 1 {
+						barrier.wait().await;
+					}
+					tx.set(&key_b, b"from-a");
+					Ok(())
+				}
+			})
+			.await
+		})
+	};
+
+	let task_b = {
+		let db = db.clone();
+		let barrier = barrier.clone();
+		let attempts = attempts_b.clone();
+		let key_a = key_a.clone();
+		let key_b = key_b.clone();
+		tokio::spawn(async move {
+			db.txn("test_universaldbintegration", |tx| {
+				let barrier = barrier.clone();
+				let attempts = attempts.clone();
+				let key_a = key_a.clone();
+				let key_b = key_b.clone();
+				async move {
+					let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+					let _ = tx.get(&key_b, Serializable).await?;
+					if attempt == 1 {
+						barrier.wait().await;
+					}
+					tx.set(&key_a, b"from-b");
+					Ok(())
+				}
+			})
+			.await
+		})
+	};
+
+	task_a.await.unwrap().unwrap();
+	task_b.await.unwrap().unwrap();
+
+	let total_attempts = attempts_a.load(Ordering::SeqCst) + attempts_b.load(Ordering::SeqCst);
+	assert!(
+		total_attempts > 2,
+		"write-skew repro should force at least one retry, got {total_attempts} attempts"
+	);
+}
+
+#[tokio::test]
+async fn test_slatedb_clear_range_atomic_overlay() {
+	let db = create_memory_slatedb_database("clear-range-atomic").await;
+	let test_subspace = Subspace::from("test-slatedb-clear-range-atomic");
+	let key = test_subspace.pack(&("counter",));
+	let (begin, end) = test_subspace.range();
+
+	db.txn("test_universaldbintegration", |tx| {
+		let key = key.clone();
+		async move {
+			tx.set(&key, &100i64.to_le_bytes());
+			Ok(())
+		}
+	})
+	.await
+	.unwrap();
+
+	db.txn("test_universaldbintegration", |tx| {
+		let key = key.clone();
+		let begin = begin.clone();
+		let end = end.clone();
+		async move {
+			tx.clear_range(&begin, &end);
+			tx.informal()
+				.atomic_op(&key, &1i64.to_le_bytes(), MutationType::Add);
+			Ok(())
+		}
+	})
+	.await
+	.unwrap();
+
+	let value = db
+		.txn("test_universaldbintegration", |tx| {
+			let key = key.clone();
+			async move { tx.get(&key, Serializable).await }
+		})
+		.await
+		.unwrap()
+		.unwrap();
+	assert_eq!(i64::from_le_bytes(value.as_slice().try_into().unwrap()), 1);
+}
+
+#[tokio::test]
+async fn test_slatedb_durability_reopen() {
+	let temp_dir = tempfile::tempdir().unwrap();
+	let config = universaldb::driver::slatedb::SlateDbConfig {
+		object_store_url: format!("file://{}", temp_dir.path().join("udb").display()),
+		path: None,
+		lease: None,
+	};
+	let key = Subspace::from("test-slatedb-durability").pack(&("key",));
+
+	let driver = universaldb::driver::SlateDbDatabaseDriver::new(config.clone())
+		.await
+		.unwrap();
+	let driver = Arc::new(driver);
+	let db = Database::new(driver.clone());
+	db.txn("test_universaldbintegration", |tx| {
+		let key = key.clone();
+		async move {
+			tx.set(&key, b"durable");
+			Ok(())
+		}
+	})
+	.await
+	.unwrap();
+
+	drop(db);
+	driver.close().await.unwrap();
+
+	let driver = universaldb::driver::SlateDbDatabaseDriver::new(config)
+		.await
+		.unwrap();
+	let db = Database::new(Arc::new(driver));
+	let value = db
+		.txn("test_universaldbintegration", |tx| {
+			let key = key.clone();
+			async move { tx.get(&key, Serializable).await }
+		})
+		.await
+		.unwrap();
+
+	assert_eq!(value.unwrap().as_slice(), b"durable");
+}
+
+async fn create_memory_slatedb_database(name: &str) -> Database {
+	let driver = universaldb::driver::SlateDbDatabaseDriver::new(
+		universaldb::driver::slatedb::SlateDbConfig {
+			object_store_url: "memory:///".to_string(),
+			path: Some(format!("rivet-test-slatedb-{}-{}", name, Uuid::new_v4())),
+			lease: None,
+		},
+	)
+	.await
+	.unwrap();
+	Database::new(Arc::new(driver))
 }
 
 async fn run_all_tests(db: universaldb::Database) {
@@ -137,11 +529,9 @@ async fn test_database_options(db: &Database) {
 	use std::sync::Arc;
 	use std::sync::atomic::{AtomicU32, Ordering};
 	use universaldb::error::DatabaseError;
-	use universaldb::options::DatabaseOption;
 
 	// Test setting transaction retry limit
-	db.set_option(DatabaseOption::TransactionRetryLimit(5))
-		.unwrap();
+	db.txn_retry_limit(5).unwrap();
 
 	// Test that retry limit is respected by forcing conflicts
 	let conflict_counter = Arc::new(AtomicU32::new(0));
@@ -172,8 +562,7 @@ async fn test_database_options(db: &Database) {
 	assert_eq!(final_attempts, 3, "Should have taken 3 attempts");
 
 	// Now set a very low retry limit and verify it fails
-	db.set_option(DatabaseOption::TransactionRetryLimit(1))
-		.unwrap();
+	db.txn_retry_limit(1).unwrap();
 
 	let conflict_counter2 = Arc::new(AtomicU32::new(0));
 	let counter_clone2 = conflict_counter2.clone();
@@ -204,8 +593,7 @@ async fn test_database_options(db: &Database) {
 	assert!(attempts <= 2, "Should not retry more than limit + 1");
 
 	// Reset to a reasonable retry limit
-	db.set_option(DatabaseOption::TransactionRetryLimit(100))
-		.unwrap();
+	db.txn_retry_limit(100).unwrap();
 }
 
 async fn clear_test_namespace(db: &Database) -> Result<()> {


### PR DESCRIPTION
## Summary

- add a SlateDB-backed UniversalDB driver with snapshot reads, serializable conflict tracking, atomic mutations, clear-range overlay handling, and durable commits
- add object-store CAS lease support plus managed leader/follower forwarding over the existing UPS request/reply layer
- wire SlateDB config, pool setup, test database selection, and engine DB command handling
- add coverage for local SlateDB semantics, forwarding semantics, CAS lease behavior, managed failover, durability reopen, write-skew retries, and clear-range atomic overlay behavior

## Validation

- `cargo test -p universaldb slatedb -- --nocapture`
- `cargo check -p universaldb -p rivet-config -p rivet-test-deps-docker -p rivet-pools -p rivet-engine`

Existing generated/protocol/depot warnings appear during the broad check and are unrelated to this change.
