### PR TITLE
fix(rivetkit): make runtime imports statically traceable

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/registry/napi-runtime.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/napi-runtime.ts
@@ -828,7 +828,7 @@ export async function loadNapiRuntime(): Promise<{
 	bindings: NapiBindings;
 	runtime: NapiCoreRuntime;
 }> {
-	const bindings = await import(["@rivetkit", "rivetkit-napi"].join("/"));
+	const bindings = await import("@rivetkit/rivetkit-napi");
 	return {
 		bindings,
 		runtime: new NapiCoreRuntime(bindings),

--- a/rivetkit-typescript/packages/rivetkit/src/registry/wasm-runtime.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/registry/wasm-runtime.ts
@@ -935,8 +935,7 @@ export async function loadWasmRuntime(config?: WasmRuntimeLoadConfig): Promise<{
 	runtime: WasmCoreRuntime;
 }> {
 	const bindings =
-		config?.bindings ??
-		(await import(["@rivetkit", "rivetkit-wasm"].join("/")));
+		config?.bindings ?? (await import("@rivetkit/rivetkit-wasm"));
 	await bindings.default(config?.initInput);
 	return {
 		bindings,


### PR DESCRIPTION
# Description

## Summary

Replace computed dynamic imports for the RivetKit runtime packages with literal dynamic imports.

This changes:

- `import(["@rivetkit", "rivetkit-napi"].join("/"))`
- `import(["@rivetkit", "rivetkit-wasm"].join("/"))`

to:

- `import("@rivetkit/rivetkit-napi")`
- `import("@rivetkit/rivetkit-wasm")`

## Motivation

Turbopack do not reliably include packages referenced through computed dynamic import specifiers leading to runtime `ERR_MODULE_NOT_FOUND` errors for the native or wasm runtime packages even though they are declared dependencies of `rivetkit`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Verified the fix in a Next.js Turbopack app by applying the same change locally with `pnpm patch` against `rivetkit@2.3.2`.

Before the patch, the serverless bundle failed at runtime with `ERR_MODULE_NOT_FOUND` for `@rivetkit/rivetkit-napi` / `@rivetkit/rivetkit-wasm` because the runtime packages were referenced through computed dynamic imports. After patching those imports to literal dynamic import specifiers, the runtime packages were traced correctly.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes