### PR TITLE
fix(website): de-duplicate agentos in header stars (14.9k → real ~11.5k)

### DIFF
--- a/website/src/components/v2/GitHubDropdown.tsx
+++ b/website/src/components/v2/GitHubDropdown.tsx
@@ -23,7 +23,6 @@ const REPOS = [
 	"rivet-dev/secure-exec",
 	"rivet-dev/sandbox-agent",
 	"rivet-dev/antiox",
-	"rivet-dev/agentos",
 ];
 
 export function GitHubDropdown({ className, ...props }: GitHubDropdownProps) {


### PR DESCRIPTION
The squash-merge of #5346 combined a newly-added `rivet-dev/agentos` entry with the one already on main, so `GitHubDropdown` listed it **twice** and double-counted its ~3.3k stars — the header showed ~14.9k instead of the real sum (rivet 5649 + agentos 3312 + secure-exec 919 + sandbox-agent 1453 + antiox 219 = **11,552**). Removes the duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)