### PR TITLE
fix(next-js): set local dev drain grace period

### DIFF
--- a/rivetkit-typescript/packages/next-js/src/mod.ts
+++ b/rivetkit-typescript/packages/next-js/src/mod.ts
@@ -33,6 +33,7 @@ export const toNextHandler = (registry: Registry<any>) => {
 		registry.config.configurePool = {
 			url: `${publicUrl}/api/rivet`,
 			requestLifespan: 300,
+			drainGracePeriod: 30,
 			metadata: { provider: "next-js" },
 		};
 


### PR DESCRIPTION
## Summary
- Sets `drainGracePeriod: 30` in the Next.js local dev auto-config alongside the existing `requestLifespan: 300`.
- Prevents the engine from rejecting the runner config because its default drain grace is 1800s, which is longer than Next's 300s request lifespan.

## Validation
- `pnpm --filter @rivetkit/framework-base build`
- `pnpm --filter @rivetkit/react build`
- `pnpm --filter @rivetkit/next-js check-types`
- `pnpm --filter @rivetkit/next-js build`