### PR TITLE
fix engine websocket frame limit

### DIFF
--- a/engine/artifacts/config-schema.json
+++ b/engine/artifacts/config-schema.json
@@ -685,6 +685,24 @@
             "boolean",
             "null"
           ]
+        },
+        "websocket_max_frame_size": {
+          "description": "Max WebSocket frame size in bytes.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "websocket_max_message_size": {
+          "description": "Max WebSocket message size in bytes.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
         }
       },
       "additionalProperties": false

--- a/engine/packages/config/src/config/guard.rs
+++ b/engine/packages/config/src/config/guard.rs
@@ -2,6 +2,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{net::IpAddr, path::PathBuf};
 
+pub const DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE: usize = 32 * 1024 * 1024;
+pub const DEFAULT_WEBSOCKET_MAX_FRAME_SIZE: usize = 32 * 1024 * 1024;
+
 #[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Guard {
@@ -45,6 +48,10 @@ pub struct Guard {
 	pub https: Option<Https>,
 	/// Max HTTP request body size in bytes (first line of defense).
 	pub http_max_request_body_size: Option<usize>,
+	/// Max WebSocket message size in bytes.
+	pub websocket_max_message_size: Option<usize>,
+	/// Max WebSocket frame size in bytes.
+	pub websocket_max_frame_size: Option<usize>,
 
 	/// Enables W3C trace context propagation (extract from incoming requests, inject into
 	/// upstream requests/websockets).
@@ -132,6 +139,16 @@ impl Guard {
 
 	pub fn http_max_request_body_size(&self) -> usize {
 		self.http_max_request_body_size.unwrap_or(20 * 1024 * 1024) // 20 MiB
+	}
+
+	pub fn websocket_max_message_size(&self) -> usize {
+		self.websocket_max_message_size
+			.unwrap_or(DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE)
+	}
+
+	pub fn websocket_max_frame_size(&self) -> usize {
+		self.websocket_max_frame_size
+			.unwrap_or(DEFAULT_WEBSOCKET_MAX_FRAME_SIZE)
 	}
 
 	pub fn trace_propagation(&self) -> bool {

--- a/engine/packages/guard-core/src/proxy_service.rs
+++ b/engine/packages/guard-core/src/proxy_service.rs
@@ -8,6 +8,7 @@ use hyper::{
 	header::{HeaderName, HeaderValue},
 };
 use hyper_tungstenite;
+use hyper_tungstenite::tungstenite::protocol::WebSocketConfig;
 use hyper_util::{client::legacy::Client, rt::TokioExecutor};
 use moka::future::Cache;
 use opentelemetry_http::{HeaderExtractor, HeaderInjector};
@@ -42,6 +43,12 @@ pub const X_RIVET_ERROR: HeaderName = HeaderName::from_static("x-rivet-error");
 
 const PROXY_STATE_CACHE_TTL: Duration = Duration::from_secs(60 * 60); // 1 hour
 const WEBSOCKET_CLOSE_LINGER: Duration = Duration::from_millis(5); // Keep TCP connection open briefly after WebSocket close
+
+fn websocket_config(guard_config: &rivet_config::config::guard::Guard) -> WebSocketConfig {
+	WebSocketConfig::default()
+		.max_message_size(Some(guard_config.websocket_max_message_size()))
+		.max_frame_size(Some(guard_config.websocket_max_frame_size()))
+}
 
 // State shared across all request handlers
 pub struct ProxyState {
@@ -483,7 +490,10 @@ impl ProxyService {
 				// HTTP errors in a meaningful way resulting in unhelpful errors for the user
 				if is_websocket {
 					tracing::debug!("Upgrading client connection to WebSocket for error proxy");
-					match hyper_tungstenite::upgrade(mock_req, None) {
+					match hyper_tungstenite::upgrade(
+						mock_req,
+						Some(websocket_config(self.state.config.guard())),
+					) {
 						Ok((client_response, client_ws)) => {
 							tracing::debug!("Client WebSocket upgrade for error proxy successful");
 
@@ -1032,7 +1042,10 @@ impl ProxyService {
 
 		// Handle WebSocket upgrade properly with hyper_tungstenite
 		tracing::debug!(path=%req_ctx.path, "Upgrading client connection to WebSocket");
-		let (client_response, client_ws) = match hyper_tungstenite::upgrade(req, None) {
+		let (client_response, client_ws) = match hyper_tungstenite::upgrade(
+			req,
+			Some(websocket_config(self.state.config.guard())),
+		) {
 			Ok(x) => {
 				tracing::debug!("Client WebSocket upgrade successful");
 				x
@@ -1180,7 +1193,11 @@ impl ProxyService {
 
 							match tokio::time::timeout(
 								Duration::from_secs(5), // 5 second timeout per connection attempt
-								tokio_tungstenite::connect_async(ws_request),
+								tokio_tungstenite::connect_async_with_config(
+									ws_request,
+									Some(websocket_config(state.config.guard())),
+									false,
+								),
 							)
 							.instrument(tracing::info_span!("connect_upstream_ws"))
 							.await
@@ -1911,5 +1928,38 @@ impl ProxyServiceFactory {
 
 	pub fn remaining_tasks(&self) -> usize {
 		self.state.tasks.remaining_tasks()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn websocket_config_uses_documented_limit() {
+		let guard_config = rivet_config::config::guard::Guard::default();
+		let config = websocket_config(&guard_config);
+
+		assert_eq!(
+			config.max_message_size,
+			Some(rivet_config::config::guard::DEFAULT_WEBSOCKET_MAX_MESSAGE_SIZE)
+		);
+		assert_eq!(
+			config.max_frame_size,
+			Some(rivet_config::config::guard::DEFAULT_WEBSOCKET_MAX_FRAME_SIZE)
+		);
+	}
+
+	#[test]
+	fn websocket_config_uses_guard_overrides() {
+		let guard_config = rivet_config::config::guard::Guard {
+			websocket_max_message_size: Some(8 * 1024 * 1024),
+			websocket_max_frame_size: Some(4 * 1024 * 1024),
+			..Default::default()
+		};
+		let config = websocket_config(&guard_config);
+
+		assert_eq!(config.max_message_size, Some(8 * 1024 * 1024));
+		assert_eq!(config.max_frame_size, Some(4 * 1024 * 1024));
 	}
 }

--- a/engine/packages/guard-core/tests/common/mod.rs
+++ b/engine/packages/guard-core/tests/common/mod.rs
@@ -467,6 +467,7 @@ pub fn create_test_config(
 		host: None,    // Use default host
 		port: Some(0), // Use 0 to let the OS choose a port
 		https: None,   // No HTTPS by default in tests
+		..Default::default()
 	};
 	mutate(&mut guard);
 	root.guard = Some(guard);

--- a/website/src/content/docs/actors/limits.mdx
+++ b/website/src/content/docs/actors/limits.mdx
@@ -27,8 +27,9 @@ These limits affect actions that use `.connect()` and [low-level WebSockets](/do
 
 | Name | Soft Limit | Hard Limit | Description |
 |------|------------|------------|-------------|
-| Max incoming message size | 64 KiB | 32 MiB | Maximum size of incoming WebSocket messages. Soft limit configurable via `maxIncomingMessageSize`. |
-| Max outgoing message size | 1 MiB | 32 MiB | Maximum size of outgoing WebSocket messages. Soft limit configurable via `maxOutgoingMessageSize`. |
+| Max incoming message size | 64 KiB | 32 MiB | Maximum size of incoming WebSocket messages. Soft limit configurable via `maxIncomingMessageSize`; hard limit configurable in self-hosted engine config via `guard.websocket_max_message_size`. |
+| Max outgoing message size | 1 MiB | 32 MiB | Maximum size of outgoing WebSocket messages. Soft limit configurable via `maxOutgoingMessageSize`; hard limit configurable in self-hosted engine config via `guard.websocket_max_message_size`. |
+| Max WebSocket frame size | — | 32 MiB | Maximum size of a single WebSocket frame accepted by Rivet's transport edge. Configurable in self-hosted engine config via `guard.websocket_max_frame_size`. This is not configurable by browser clients and is not negotiated during the WebSocket handshake. |
 | WebSocket open timeout | — | 15 seconds | Time allowed for WebSocket connection to be established, including `onBeforeConnect` and `createConnState` hooks. Connection is closed if exceeded. |
 | Message ack timeout | — | 30 seconds | Time allowed for message acknowledgment before connection is closed. Only relevant in the case of a network issue and does not affect your application. |
 
@@ -50,7 +51,7 @@ These limits affect actions that do not use `.connect()` and [low-level HTTP req
 |------|------------|------------|-------------|
 | Max request body size | — | 20 MiB | Maximum size of HTTP request bodies. |
 | Max response body size | — | 20 MiB | Maximum size of HTTP response bodies. |
-| Request timeout | — | 5 minutes | Maximum time for a request to complete. |
+| Request timeout | 60 seconds | — | Maximum time for an `onRequest` handler to complete. Defaults to `actionTimeout`; configure with `actionTimeout`. |
 
 ### Networking
 
@@ -123,12 +124,17 @@ See [Actor Input](/docs/actors/input) for details.
 | Name | Soft Limit | Hard Limit | Description |
 |------|------------|------------|-------------|
 | Action timeout | 60 seconds | — | Timeout for RPC actions. Configurable via `actionTimeout`. |
+| On request timeout | 60 seconds | — | Timeout for raw `onRequest` handlers. Defaults to `actionTimeout`; configure with `actionTimeout`. |
+| On before connect timeout | 5 seconds | — | Timeout for the `onBeforeConnect` hook. Configurable via `onBeforeConnectTimeout`. |
 | Create vars timeout | 5 seconds | — | Timeout for `createVars` hook. Configurable via `createVarsTimeout`. |
 | Create conn state timeout | 5 seconds | — | Timeout for `createConnState` hook. Configurable via `createConnStateTimeout`. |
 | On connect timeout | 5 seconds | — | Timeout for `onConnect` hook. Configurable via `onConnectTimeout`. |
+| On migrate timeout | 30 seconds | — | Timeout for `onMigrate` hook. Configurable via `onMigrateTimeout`. |
 | Sleep grace period | 15 seconds | — | Total graceful shutdown budget for both sleep and destroy. Covers `onSleep`/`onDestroy`, run handler shutdown, `waitUntil`, `keepAwake`, async raw WebSocket handlers, and connection cleanup. Configurable via `sleepGracePeriod`. |
 | Sleep timeout | 30 seconds | — | Time of inactivity before actor hibernates. Configurable via `sleepTimeout`. |
 | State save interval | 1 second | — | Interval between automatic state saves. Configurable via `stateSaveInterval`. |
+| Connection liveness timeout | 2.5 seconds | — | Time a stateful connection can miss liveness checks before RivetKit treats it as unhealthy. Configurable via `connectionLivenessTimeout`. |
+| Connection liveness interval | 5 seconds | — | Interval between stateful connection liveness checks. Configurable via `connectionLivenessInterval`. |
 
 ### Serverless Shutdown
 


### PR DESCRIPTION
## What changed

- Set guard WebSocket transport max frame size and max message size to the documented 32 MiB cap.
- Apply the same tungstenite config to client upgrades, error-proxy upgrades, and upstream WebSocket connections.
- Add a unit test locking the configured transport cap.

## Why

RivetKit documents a 32 MiB WebSocket hard limit, but guard was passing `None` to tungstenite, inheriting the 16 MiB default max frame size. Payloads between 16 MiB and 32 MiB could be rejected before RivetKit soft-limit handling ran.

## Validation

- `cargo test -p rivet-guard-core --lib websocket_config_uses_documented_limit -- --nocapture`
- `cargo check -p rivet-guard-core`

Note: `cargo test -p rivet-guard-core --test websocket ...` currently fails to compile due pre-existing stale integration-test API usage unrelated to this change; the failure log was captured separately.
