### PR TITLE
fix(frontend): fix inspector tab flash, keep metadata tab usable while connecting, skip duplicate metadata fetch

### DIFF
--- a/frontend/apps/inspector-ui/src/main.tsx
+++ b/frontend/apps/inspector-ui/src/main.tsx
@@ -81,11 +81,13 @@ function InspectorApp({
 	credentials,
 	bridge,
 	activeTab,
+	initialVersion,
 }: {
 	actorId: ActorId;
 	credentials: { url: string; inspectorToken: string; token: string };
 	bridge: BridgeClient;
 	activeTab: string | undefined;
+	initialVersion?: string;
 }) {
 	const queryClient = useMemo(
 		() =>
@@ -115,6 +117,7 @@ function InspectorApp({
 					<ActorInspectorProvider
 						actorId={actorId}
 						credentials={credentials}
+						initialVersion={initialVersion}
 					>
 						<InspectorContent
 							actorId={actorId}
@@ -181,6 +184,10 @@ function BootGate({ bridge }: { bridge: BridgeClient }) {
 			}}
 			bridge={bridge}
 			activeTab={activeTab}
+			// The SPA is served from the same rivetkit build that runs the
+			// actor, so its baked-in version matches the actor runtime. Seed
+			// it so the WebSocket opens without waiting on a `/metadata` fetch.
+			initialVersion={__RIVETKIT_VERSION__}
 		/>
 	);
 }

--- a/frontend/apps/inspector-ui/src/vite-env.d.ts
+++ b/frontend/apps/inspector-ui/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="vite/client" />
+
+// rivetkit's package version, baked in at build time. See vite.config.ts.
+declare const __RIVETKIT_VERSION__: string;

--- a/frontend/apps/inspector-ui/vite.config.ts
+++ b/frontend/apps/inspector-ui/vite.config.ts
@@ -1,8 +1,23 @@
 import * as crypto from "node:crypto";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
+
+// The inspector-ui bundle is embedded into the rivetkit build that serves it,
+// so rivetkit's package version IS the version of the actor runtime this bundle
+// talks to. Baking it in lets the SPA seed its metadata query and open the
+// inspector WebSocket without a `/metadata` round trip.
+const rivetkitVersion = JSON.parse(
+	readFileSync(
+		path.resolve(
+			__dirname,
+			"../../../rivetkit-typescript/packages/rivetkit/package.json",
+		),
+		"utf8",
+	),
+).version as string;
 
 // Single-entry SPA that renders the entire actor inspector right panel:
 // tab strip, guard, WebSocket client, and every tab. Served by the engine at
@@ -20,6 +35,7 @@ export default defineConfig({
 		__APP_BUILD_ID__: JSON.stringify(
 			`${new Date().toISOString()}@${crypto.randomUUID()}`,
 		),
+		__RIVETKIT_VERSION__: JSON.stringify(rivetkitVersion),
 	},
 	optimizeDeps: {
 		include: ["@fortawesome/*", "@rivet-gg/icons", "@rivet-gg/cloud"],

--- a/frontend/src/components/actors/actor-details-iframe.tsx
+++ b/frontend/src/components/actors/actor-details-iframe.tsx
@@ -180,6 +180,7 @@ export const ActorsActorDetails = memo(function ActorsActorDetails({
 			tab={tab}
 			onTabChange={onTabChange}
 			inspectorToken={credentials.inspectorToken}
+			rivetkitVersion={metadataQuery.data.version}
 		/>
 	);
 
@@ -511,10 +512,15 @@ function ActorDetailsIframePath({
 									trigger={
 										<TabsTrigger
 											value={t.id}
-											disabled={inSkeletonMode}
+											disabled={
+												inSkeletonMode &&
+												t.kind === "inspector"
+											}
 											className={cn(
 												"text-xs px-2.5 py-1 pb-2 min-w-0 shrink gap-1 isolate before:absolute before:inset-x-0.5 before:top-1 before:bottom-2 before:-z-10 before:rounded-md before:transition-colors hover:before:bg-foreground/[0.06]",
-												inSkeletonMode && "opacity-60",
+												inSkeletonMode &&
+													t.kind === "inspector" &&
+													"opacity-60",
 											)}
 										>
 											<Icon

--- a/frontend/src/components/actors/actor-details-legacy.tsx
+++ b/frontend/src/components/actors/actor-details-legacy.tsx
@@ -29,6 +29,7 @@ interface Props {
 	tab?: string;
 	onTabChange?: (tab: string) => void;
 	inspectorToken: string;
+	rivetkitVersion: string;
 }
 
 /**
@@ -46,6 +47,7 @@ export function ActorDetailsLegacy({
 	tab,
 	onTabChange,
 	inspectorToken,
+	rivetkitVersion,
 }: Props) {
 	const engineUrl = getConfig().apiUrl;
 	const rivetToken = useRivetToken();
@@ -60,7 +62,11 @@ export function ActorDetailsLegacy({
 	);
 
 	return (
-		<ActorInspectorProvider actorId={actorId} credentials={credentials}>
+		<ActorInspectorProvider
+			actorId={actorId}
+			credentials={credentials}
+			initialVersion={rivetkitVersion}
+		>
 			<LegacyTabShell
 				actorId={actorId}
 				tab={tab}

--- a/frontend/src/components/actors/actor-inspector-context.tsx
+++ b/frontend/src/components/actors/actor-inspector-context.tsx
@@ -48,6 +48,8 @@ export const actorInspectorQueriesKeys = {
 		["actor", actorId, "is-workflow-enabled"] as const,
 	actorTabConfig: (actorId: ActorId) =>
 		["actor", actorId, "tab-config"] as const,
+	actorInspectorInitialized: (actorId: ActorId) =>
+		["actor", actorId, "inspector-initialized"] as const,
 };
 
 type QueueStatusSummary = {
@@ -440,6 +442,19 @@ export const createDefaultActorInspectorContext = ({
 		});
 	},
 
+	// Flipped to `true` by the WS `Init` handler once the real capability
+	// flags (workflow/state/database enabled) have landed. Tab computation
+	// waits on this instead of on metadata success so it never emits a
+	// premature list that omits capability-gated tabs and then re-adds them.
+	actorInspectorInitializedQueryOptions(actorId: ActorId) {
+		return queryOptions({
+			staleTime: Infinity,
+			queryKey:
+				actorInspectorQueriesKeys.actorInspectorInitialized(actorId),
+			queryFn: () => false,
+		});
+	},
+
 	actorWorkflowReplayMutation(actorId: ActorId) {
 		return mutationOptions({
 			mutationKey: ["actor", actorId, "workflow", "replay"],
@@ -660,10 +675,18 @@ export const ActorInspectorProvider = ({
 	children,
 	actorId,
 	credentials,
+	initialVersion,
 }: {
 	children: React.ReactNode;
 	actorId: ActorId;
 	credentials: { url: string; inspectorToken: string; token: string };
+	/**
+	 * RivetKit version the host already resolved via its own `/metadata`
+	 * fetch. When provided it seeds the metadata query so `isInspectorAvailable`
+	 * is true on first render and the WebSocket opens without waiting on a
+	 * duplicate `/metadata` round trip. Liveness polling still runs.
+	 */
+	initialVersion?: string;
 }) => {
 	const protocols = useMemo(
 		() =>
@@ -687,6 +710,15 @@ export const ActorInspectorProvider = ({
 	const { data: actorMetadata, isSuccess: isActorMetadataSuccess } = useQuery(
 		{
 			...actorMetadataQueryOptions({ actorId, credentials }),
+			...(initialVersion
+				? {
+						initialData: { version: initialVersion },
+						// Mark the seed as fresh so it doesn't trigger an
+						// immediate refetch; `refetchInterval` still polls for
+						// liveness a beat later.
+						initialDataUpdatedAt: () => Date.now(),
+					}
+				: {}),
 		},
 	);
 
@@ -1167,6 +1199,16 @@ const createMessageHandler =
 						),
 					);
 				}
+
+				// Mark capabilities as known only now — the flags above are
+				// the source of truth for which tabs exist. Tab computation
+				// gates on this to avoid a skeleton → partial → full flash.
+				queryClient.setQueryData(
+					actorInspectorQueriesKeys.actorInspectorInitialized(
+						actorId,
+					),
+					true,
+				);
 			})
 			.with({ tag: "ConnectionsResponse" }, (body) => {
 				const { rid } = body.val;

--- a/frontend/src/components/actors/inspector-tab-registry.tsx
+++ b/frontend/src/components/actors/inspector-tab-registry.tsx
@@ -141,7 +141,13 @@ export function useAvailableInspectorTabs(
 		inspector.actorTabConfigQueryOptions(actorId),
 	);
 
-	const capabilitiesKnown = inspector.isInspectorAvailable;
+	// Wait for the WS `Init` message, not just metadata success. The
+	// capability flags (workflow/state/database enabled) arrive with `Init`;
+	// gating on metadata alone emits a list missing those tabs and then
+	// re-adds them once `Init` lands, which reads as a flash.
+	const { data: capabilitiesKnown = false } = useQuery(
+		inspector.actorInspectorInitializedQueryOptions(actorId),
+	);
 
 	return useMemo(() => {
 		if (!capabilitiesKnown) return null;


### PR DESCRIPTION
Fixes several issues in the actor inspector's initial load.

- Fix the tab strip flashing from skeleton → partial list → full list. Tab computation now waits for the inspector WebSocket `Init` (which carries the real workflow/state/database capability flags) instead of firing as soon as `/metadata` resolves, so the list renders once with the correct tabs.
- Keep the Metadata tab (and other dashboard-rendered cloud tabs) enabled and usable while the inspector is still connecting; only the inspector-owned tabs are disabled during the skeleton state.
- Skip the duplicate `/metadata` fetch on inspector load. The inspector-ui bundle is embedded in the rivetkit build that serves the actor, so it now seeds its version from a build-time constant and opens the WebSocket immediately instead of blocking on a second metadata round trip.