### PR TITLE
docs(blog): add world's fastest package manager changelog post

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3666,8 +3666,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(react@19.1.0)
       '@rivet-dev/docs-theme':
-        specifier: github:rivet-dev/docs-theme#450c498555135098c6a927adfdf13458be9be22a
-        version: docs-theme-workspace@https://codeload.github.com/rivet-dev/docs-theme/tar.gz/450c498555135098c6a927adfdf13458be9be22a
+        specifier: github:rivet-dev/docs-theme#v0.3.1
+        version: https://codeload.github.com/rivet-dev/docs-theme/tar.gz/71c3e482fe43e4cbc4f4327a26c8899b6bd4aaa7(@babel/runtime@7.29.2)(@types/node@25.0.7)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(astro@5.16.9(@types/node@25.0.7)(idb-keyval@6.2.1)(ioredis@5.10.1)(jiti@2.6.1)(less@4.4.1)(lightningcss@1.32.0)(rollup@4.57.1)(sass@1.93.2)(stylus@0.62.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(babel-plugin-macros@3.1.0)(jiti@2.6.1)(less@4.4.1)(lightningcss@1.32.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.93.2)(stylus@0.62.0)(terser@5.46.0)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.1.0))(yaml@2.9.0)
       '@rivet-gg/api':
         specifier: 25.5.3
         version: 25.5.3
@@ -5998,6 +5998,10 @@ packages:
     resolution: {integrity: sha512-l/BQM7fYntsCI//du+6sEnHOP6a74UixFyOYUyz2DLMXKx+6DEhfR3F2NYGE45XH1JJuIamacb4IZs9S0ZOWLA==}
     engines: {node: '>=6'}
 
+  '@fortawesome/fontawesome-free@6.7.2':
+    resolution: {integrity: sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==}
+    engines: {node: '>=6'}
+
   '@fortawesome/fontawesome-svg-core@6.7.2':
     resolution: {integrity: sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==}
     engines: {node: '>=6'}
@@ -8012,6 +8016,15 @@ packages:
 
   '@rivet-dev/agent-os-tar@0.0.260331072558':
     resolution: {integrity: sha512-LAa8fm4jombNBQRR42O/57WxY6VA13Uea8JFChh6yPN4VtFP84KI5Kg4/Zzne3YDronGZlgJivznNUH3dtTMzA==}
+
+  '@rivet-dev/docs-theme@https://codeload.github.com/rivet-dev/docs-theme/tar.gz/71c3e482fe43e4cbc4f4327a26c8899b6bd4aaa7':
+    resolution: {tarball: https://codeload.github.com/rivet-dev/docs-theme/tar.gz/71c3e482fe43e4cbc4f4327a26c8899b6bd4aaa7}
+    version: 0.3.1
+    hasBin: true
+    peerDependencies:
+      astro: '>=5.0.0'
+      react: 19.1.0
+      react-dom: 19.1.0
 
   '@rivet-gg/api@25.5.3':
     resolution: {integrity: sha512-pj8xYQ+I/aQDbThmicPxvR+TWAzGoLSE53mbJi4QZHF8VH2oMvU7CMWqy7OTFH30DIRyVzsnHHRJZKGwtmQL3g==}
@@ -11442,10 +11455,6 @@ packages:
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
-  docs-theme-workspace@https://codeload.github.com/rivet-dev/docs-theme/tar.gz/450c498555135098c6a927adfdf13458be9be22a:
-    resolution: {tarball: https://codeload.github.com/rivet-dev/docs-theme/tar.gz/450c498555135098c6a927adfdf13458be9be22a}
-    version: 0.0.0
-
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
@@ -11927,6 +11936,9 @@ packages:
 
   estree-util-to-js@2.0.0:
     resolution: {integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==}
+
+  estree-util-visit@1.2.1:
+    resolution: {integrity: sha512-xbgqcrkIVbIG+lI/gzbvd9SGTJL4zqJKBFttUl5pP27KhAjtMKbX/mQXJ7qgyXpMgVy/zvpm0xoQQaGL8OloOw==}
 
   estree-util-visit@2.0.0:
     resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
@@ -12653,6 +12665,12 @@ packages:
 
   hast-util-classnames@3.0.0:
     resolution: {integrity: sha512-tI3JjoGDEBVorMAWK4jNRsfLMYmih1BUOG3VV36pH36njs1IEl7xkNrVTD2mD2yYHmQCa5R/fj61a8IAF4bRaQ==}
+
+  hast-util-from-dom@5.0.1:
+    resolution: {integrity: sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==}
+
+  hast-util-from-html-isomorphic@2.0.0:
+    resolution: {integrity: sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==}
 
   hast-util-from-html@2.0.3:
     resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
@@ -13756,6 +13774,9 @@ packages:
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
+  mdx-annotations@0.1.4:
+    resolution: {integrity: sha512-SUYBUXP1qbgr0nRFFnUBg4HxxTbYyl5rE38fLTaIm0naPK+EhmKa0wRlUdgTMlMBj5gdCMwP1n7+L47JIHHWUQ==}
+
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
@@ -13780,6 +13801,14 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mermaid-isomorphic@3.1.0:
+    resolution: {integrity: sha512-mzrvfEVjnJIkJlEqxp3eMuR1wS0TeLCH1VK5E/T5yzWaBwI3JqjJuw70yUIThSCDJ5bRs6O3rgfp00oBAbvSeQ==}
+    peerDependencies:
+      playwright: '1'
+    peerDependenciesMeta:
+      playwright:
+        optional: true
 
   mermaid@11.12.2:
     resolution: {integrity: sha512-n34QPDPEKmaeCG4WDMGy0OT6PSyxKCfy2pJgShP+Qow2KLrvWjclwbc3yXfSIf4BanqWEhQEpngWwNp/XhZt6w==}
@@ -15555,6 +15584,14 @@ packages:
   rehype-class-names@2.0.0:
     resolution: {integrity: sha512-jldCIiAEvXKdq8hqr5f5PzNdIDkvHC6zfKhwta9oRoMu7bn0W7qLES/JrrjBvr9rKz3nJ8x4vY1EWI+dhjHVZQ==}
 
+  rehype-mermaid@3.0.0:
+    resolution: {integrity: sha512-fxrD5E4Fa1WXUjmjNDvLOMT4XB1WaxcfycFIWiYU0yEMQhcTDElc9aDFnbDFRLxG1Cfo1I3mfD5kg4sjlWaB+Q==}
+    peerDependencies:
+      playwright: '1'
+    peerDependenciesMeta:
+      playwright:
+        optional: true
+
   rehype-parse@9.0.1:
     resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
 
@@ -16726,8 +16763,14 @@ packages:
   unifont@0.7.1:
     resolution: {integrity: sha512-0lg9M1cMYvXof8//wZBq6EDEfbwv4++t7+dYpXeS2ypaLuZJmUFYEwTm412/1ED/Wfo/wyzSu6kNZEr9hgRNfg==}
 
+  unist-util-filter@5.0.1:
+    resolution: {integrity: sha512-pHx7D4Zt6+TsfwylH9+lYhBhzyhEnCXs/lbq/Hstxno5z4gVdyc2WEW0asfjGKPyG4pEKrnBv5hdkO6+aRnQJw==}
+
   unist-util-find-after@5.0.0:
     resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
+
+  unist-util-is@5.2.1:
+    resolution: {integrity: sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -16750,8 +16793,14 @@ packages:
   unist-util-visit-children@3.0.0:
     resolution: {integrity: sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==}
 
+  unist-util-visit-parents@5.1.3:
+    resolution: {integrity: sha512-x6+y8g7wWMyQhL1iZfhIPhDAs7Xwbn9nRosDXl7qoPTSCy0yNxnKc+hWokFifWQIDGi154rdUqKvbCa4+1kLhg==}
+
   unist-util-visit-parents@6.0.2:
     resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@4.1.2:
+    resolution: {integrity: sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==}
 
   unist-util-visit@5.0.0:
     resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
@@ -20256,6 +20305,8 @@ snapshots:
 
   '@fortawesome/fontawesome-common-types@7.1.0': {}
 
+  '@fortawesome/fontawesome-free@6.7.2': {}
+
   '@fortawesome/fontawesome-svg-core@6.7.2':
     dependencies:
       '@fortawesome/fontawesome-common-types': 6.7.2
@@ -22886,6 +22937,74 @@ snapshots:
   '@rivet-dev/agent-os-sed@0.0.260331072558': {}
 
   '@rivet-dev/agent-os-tar@0.0.260331072558': {}
+
+  '@rivet-dev/docs-theme@https://codeload.github.com/rivet-dev/docs-theme/tar.gz/71c3e482fe43e4cbc4f4327a26c8899b6bd4aaa7(@babel/runtime@7.29.2)(@types/node@25.0.7)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(astro@5.16.9(@types/node@25.0.7)(idb-keyval@6.2.1)(ioredis@5.10.1)(jiti@2.6.1)(less@4.4.1)(lightningcss@1.32.0)(rollup@4.57.1)(sass@1.93.2)(stylus@0.62.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(babel-plugin-macros@3.1.0)(jiti@2.6.1)(less@4.4.1)(lightningcss@1.32.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.93.2)(stylus@0.62.0)(terser@5.46.0)(tsx@4.21.0)(use-sync-external-store@1.6.0(react@19.1.0))(yaml@2.9.0)':
+    dependencies:
+      '@astrojs/mdx': 4.3.13(astro@5.16.9(@types/node@25.0.7)(idb-keyval@6.2.1)(ioredis@5.10.1)(jiti@2.6.1)(less@4.4.1)(lightningcss@1.32.0)(rollup@4.57.1)(sass@1.93.2)(stylus@0.62.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))
+      '@astrojs/react': 4.4.2(@types/node@25.0.7)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(jiti@2.6.1)(less@4.4.1)(lightningcss@1.32.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.93.2)(stylus@0.62.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.9.0)
+      '@astrojs/sitemap': 3.6.1
+      '@fortawesome/fontawesome-svg-core': 7.1.0
+      '@fortawesome/free-brands-svg-icons': 7.1.0
+      '@fortawesome/free-solid-svg-icons': 7.1.0
+      '@fortawesome/react-fontawesome': 3.1.0(@fortawesome/fontawesome-svg-core@7.1.0)(react@19.1.0)
+      '@headlessui/react': 2.2.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@rivet-gg/components': link:frontend/packages/components
+      '@rivet-gg/icons': link:frontend/packages/icons
+      '@shikijs/transformers': 3.15.0
+      '@sindresorhus/slugify': 3.0.0
+      '@tailwindcss/typography': 0.5.19(tailwindcss@3.4.18(tsx@4.21.0)(yaml@2.9.0))
+      acorn: 8.16.0
+      astro: 5.16.9(@types/node@25.0.7)(idb-keyval@6.2.1)(ioredis@5.10.1)(jiti@2.6.1)(less@4.4.1)(lightningcss@1.32.0)(rollup@4.57.1)(sass@1.93.2)(stylus@0.62.0)(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+      clsx: 2.1.1
+      dedent: 1.7.0(babel-plugin-macros@3.1.0)
+      esast-util-from-js: 2.0.1
+      escape-html: 1.0.3
+      estree-util-to-js: 2.0.0
+      fast-glob: 3.3.3
+      framer-motion: 12.25.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      fuse.js: 7.1.0
+      lodash: 4.17.23
+      lucide-react: 0.439.0(react@19.1.0)
+      mdast-util-to-string: 4.0.0
+      mdx-annotations: 0.1.4
+      mermaid: 11.12.2
+      playwright: 1.57.0
+      posthog-js: 1.297.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-markdown: 10.1.0(@types/react@19.2.13)(react@19.1.0)
+      rehype-mermaid: 3.0.0(playwright@1.57.0)
+      rehype-parse: 9.0.1
+      remark-gfm: 4.0.1
+      shiki: 3.21.0
+      tailwindcss: 3.4.18(tsx@4.21.0)(yaml@2.9.0)
+      tm-themes: 1.10.12
+      typesense: 2.1.0(@babel/runtime@7.29.2)
+      unified: 11.0.5
+      unist-util-filter: 5.0.1
+      unist-util-visit: 5.0.0
+      zustand: 5.0.8(@types/react@19.2.13)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0))
+    transitivePeerDependencies:
+      - '@babel/runtime'
+      - '@emotion/is-prop-valid'
+      - '@types/node'
+      - '@types/react'
+      - '@types/react-dom'
+      - babel-plugin-macros
+      - debug
+      - immer
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - use-sync-external-store
+      - yaml
 
   '@rivet-gg/api@25.5.3':
     dependencies:
@@ -27161,8 +27280,6 @@ snapshots:
 
   dlv@1.1.3: {}
 
-  docs-theme-workspace@https://codeload.github.com/rivet-dev/docs-theme/tar.gz/450c498555135098c6a927adfdf13458be9be22a: {}
-
   dom-helpers@5.2.1:
     dependencies:
       '@babel/runtime': 7.29.2
@@ -27639,6 +27756,11 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       astring: 1.9.0
       source-map: 0.7.6
+
+  estree-util-visit@1.2.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 2.0.11
 
   estree-util-visit@2.0.0:
     dependencies:
@@ -28491,6 +28613,19 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       space-separated-tokens: 2.0.2
+
+  hast-util-from-dom@5.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hastscript: 9.0.1
+      web-namespaces: 2.0.1
+
+  hast-util-from-html-isomorphic@2.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-dom: 5.0.1
+      hast-util-from-html: 2.0.3
+      unist-util-remove-position: 5.0.0
 
   hast-util-from-html@2.0.3:
     dependencies:
@@ -29779,6 +29914,12 @@ snapshots:
 
   mdn-data@2.12.2: {}
 
+  mdx-annotations@0.1.4:
+    dependencies:
+      acorn: 8.16.0
+      estree-util-visit: 1.2.1
+      unist-util-visit: 4.1.2
+
   media-typer@0.3.0: {}
 
   media-typer@1.1.0: {}
@@ -29792,6 +29933,14 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  mermaid-isomorphic@3.1.0(playwright@1.57.0):
+    dependencies:
+      '@fortawesome/fontawesome-free': 6.7.2
+      katex: 0.16.27
+      mermaid: 11.12.2
+    optionalDependencies:
+      playwright: 1.57.0
 
   mermaid@11.12.2:
     dependencies:
@@ -32112,6 +32261,20 @@ snapshots:
       hast-util-select: 6.0.4
       unified: 11.0.5
 
+  rehype-mermaid@3.0.0(playwright@1.57.0):
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-html-isomorphic: 2.0.0
+      hast-util-to-text: 4.0.2
+      mermaid-isomorphic: 3.1.0(playwright@1.57.0)
+      mini-svg-data-uri: 1.4.4
+      space-separated-tokens: 2.0.2
+      unified: 11.0.5
+      unist-util-visit-parents: 6.0.2
+      vfile: 6.0.3
+    optionalDependencies:
+      playwright: 1.57.0
+
   rehype-parse@9.0.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -33598,10 +33761,20 @@ snapshots:
       ofetch: 1.5.1
       ohash: 2.0.11
 
+  unist-util-filter@5.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   unist-util-find-after@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
+
+  unist-util-is@5.2.1:
+    dependencies:
+      '@types/unist': 2.0.11
 
   unist-util-is@6.0.1:
     dependencies:
@@ -33633,10 +33806,21 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  unist-util-visit-parents@5.1.3:
+    dependencies:
+      '@types/unist': 2.0.11
+      unist-util-is: 5.2.1
+
   unist-util-visit-parents@6.0.2:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
+
+  unist-util-visit@4.1.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      unist-util-is: 5.2.1
+      unist-util-visit-parents: 5.1.3
 
   unist-util-visit@5.0.0:
     dependencies:

--- a/website/package.json
+++ b/website/package.json
@@ -26,7 +26,7 @@
 		"@fortawesome/react-fontawesome": "^3.1.0",
 		"@headlessui/react": "^2.2.9",
 		"@heroicons/react": "^2.2.0",
-		"@rivet-dev/docs-theme": "github:rivet-dev/docs-theme#450c498555135098c6a927adfdf13458be9be22a",
+		"@rivet-dev/docs-theme": "github:rivet-dev/docs-theme#v0.3.1",
 		"@rivet-gg/api": "25.5.3",
 		"@rivet-gg/cloud": "*",
 		"@rivet-gg/components": "workspace:*",

--- a/website/src/components/BlogArticle.astro
+++ b/website/src/components/BlogArticle.astro
@@ -198,6 +198,13 @@ const otherArticles = allPosts
 		font-weight: 600;
 	}
 
+	/* A bolded Markdown link (`**[text](url)**`) renders as <strong><a>. The
+	   link rule above sets the <a> to 500, overriding the <strong>'s 600, so
+	   without this the bolded link looks lighter than surrounding bold text. */
+	.blog-article .blog-prose strong a:not(.not-prose) {
+		font-weight: 600;
+	}
+
 	.blog-article .blog-prose :not(pre) > code {
 		background: rgb(27 25 22 / 0.05);
 		border: 1px solid rgb(27 25 22 / 0.1);

--- a/website/src/content/posts/2026-07-06-introducing-the-agentos-package-registry/page.mdx
+++ b/website/src/content/posts/2026-07-06-introducing-the-agentos-package-registry/page.mdx
@@ -1,0 +1,91 @@
+---
+author: nicholas-kissel
+published: "2026-07-06"
+category: changelog
+image: true
+keywords: ["agentos", "package registry", "npm", "agents", "sandboxes"]
+title: "Introducing the agentOS Package Registry"
+description: "We built the package registry for agentOS. npm install the infrastructure your agent needs."
+---
+
+agentOS is a **lightweight alternative to sandboxes** that doesn't require a heavyweight VM. We built it to be the best way to ship agents: performant, efficient, flexible, and dead simple to use.
+
+Today we're doubling down on the last two. The [agentOS Package Registry](https://agentos-sdk.dev/registry) makes agents **flexible** and **simple**: `npm install` any capability your agent needs, from binaries to browsers to sandboxes.
+
+## Why a new registry?
+
+Every agent is different, and there's no one-size-fits-all:
+
+- A **simple support agent** might only need a browser and an HTTP client.
+- A **background agent** churning through a queue needs cron and durable state.
+- A **coding agent** needs a full filesystem, a shell, a compiler toolchain, and a sandbox to run untrusted code.
+
+Each is a different set of tools on top of the same runtime.
+
+On top of that, agentOS runs Linux on WebAssembly, so every command has to be **cross-compiled to WebAssembly**. Existing registries like apt and Homebrew ship native binaries, not WebAssembly, so none of them work here. agentOS needs a registry purpose-built for it.
+
+The agentOS Package Registry is how both official Rivet packages and community packages are shared. It lets you **pick and choose the tools** your agent needs and add them with a simple `npm install`.
+
+## 1,900× faster than apk, 6,700× faster than apt
+
+Traditional package managers like apt and Homebrew copy and unpack files on every install, taking seconds due to expensive filesystem operations.
+
+Instead, agentOS packages install in **130µs**. That's **1,900× faster than apk** and **6,700× faster than apt**.
+
+![Package install time: agentOS 0.13ms versus Alpine 0.25s, Ubuntu 0.87s, and Homebrew 2.11s](https://assets.rivet.dev/website/blog/2026-07-06-introducing-the-agentos-package-registry/benchmark.png)
+
+agentOS mounts the package straight into the VM's filesystem, with zero I/O. Adding packages never touches your cold start, so your agents stay fast no matter how much you install.
+
+For the full breakdown of how this works, read [Building the World's Fastest Package Manager with agentOS](/changelog/2026-07-07-worlds-fastest-package-manager).
+
+## What the registry provides
+
+The registry is your one-stop shop for everything you need to provide to an agent:
+
+- **Binary commands**: CLI tools cross-compiled to WebAssembly and installed into the VM, like `ripgrep` or `jq`, akin to apt installs.
+- **Agents**: coding agents like Pi, Claude Code, Codex, and OpenCode, all behind one unified interface.
+- **[File systems](https://agentos-sdk.dev/docs/filesystem)**: mount S3, GitHub, or a database as the agent's file system.
+- **Browsers**: headless browsers for navigating, scraping, and automating the web.
+- **[Sandboxes](https://agentos-sdk.dev/docs/sandbox)**: full sandboxes mounted on demand for heavy workloads like desktop automation and native compilation.
+- **[Bindings](https://agentos-sdk.dev/docs/bindings)**: your own host functions exposed to the agent as CLI commands inside the VM.
+
+## Backed by npm
+
+npm has withstood the test of time with broad compatibility, so it was an obvious choice for delivering agentOS software.
+
+It's tempting to think shipping your own package registry is easy: an S3 bucket and an index and you're done. But that skips everything a real registry needs:
+
+- **Dependencies & semver**: packages compose and version against each other with battle-tested resolution.
+- **Release tracks**: publish stable, beta, and canary channels side by side.
+- **Team management**: scoped orgs with per-package publish permissions.
+- **Security**: npm's audit tooling and advisory database, inherited for free.
+- **Self-hosting**: run a private registry inside your own network.
+
+The agentOS Package Registry ships with all of this out of the box by leveraging npm's infrastructure.
+
+## Enterprise-ready
+
+Because it's built on npm, agentOS is enterprise-ready from day one:
+
+- **Self-hosted registries**
+- **Team-based publishing**
+- **npm's security tooling**
+
+## Build your own packages
+
+The agentOS package format makes it easy to ship your own package for custom agents, binaries, sandboxes, and more.
+
+All it takes is:
+
+1. Point your coding agent at the [package definition docs](https://agentos-sdk.dev/docs/custom-software/definition/)
+2. Publish to npm
+3. Share your npm package with everyone
+
+Pull requests are welcome to get your package listed in our registry.
+
+## Get started
+
+- [agentOS Package Registry](https://agentos-sdk.dev/registry)
+- [Documentation](https://agentos-sdk.dev)
+- [GitHub](https://github.com/rivet-dev/agentos)
+- [Discord](https://rivet.dev/discord)

--- a/website/src/content/posts/2026-07-07-worlds-fastest-package-manager/page.mdx
+++ b/website/src/content/posts/2026-07-07-worlds-fastest-package-manager/page.mdx
@@ -1,0 +1,322 @@
+---
+image: true
+author: nathan-flurry
+published: "2026-07-07"
+category: changelog
+keywords: ["agentos", "package manager", "130µs installs", "mmap", "tar", "filesystem"]
+title: "Building the World's Fastest Package Manager with agentOS"
+description: "agentOS packages install in 130µs, here's how we did it."
+---
+
+We built [agentOS](https://agentos-sdk.dev) as a lightweight alternative to sandboxes. Because it runs Linux on WebAssembly, it cold-starts up to [516× faster](https://agentos-sdk.dev/docs/benchmarks) than a sandbox, and it's light enough to run inside your own backend in userspace, with no external sandboxing infrastructure.
+
+But once starts are that cheap, **everything else on the setup path becomes the bottleneck**, starting with installing packages. So today we [introduced the agentOS Package Registry](/changelog/2026-07-06-introducing-the-agentos-package-registry), which meant installing packages **without the overhead you'd expect** from apt, apk, Homebrew, and the rest.
+
+## The status quo for package managers
+
+The best known package managers all do roughly the same thing on install.
+
+Take apt, for example. Installing `git` means dpkg has to:
+
+1. Unpack the `.deb` and write its files onto the disk (`/usr/bin/git`, `/usr/lib/git-core/`, `/usr/share/`)
+2. Record the install in its package database at `/var/lib/dpkg/`
+3. Run the package's post-install scripts
+
+We benchmarked how long that actually takes. Installing `git` offline takes **0.25s on apk, 0.48s on pacman, 0.87s on apt, and 2.11s on Homebrew.**
+
+![git install time by phase](https://assets.rivet.dev/website/blog/2026-07-07-worlds-fastest-package-manager/install-benchmark.png)
+
+[[Source](https://github.com/rivet-dev/linux-package-manager-bench)]
+
+For your dev machine, these times are fine.
+
+But agentOS VMs **need to start instantly**, so running shell scripts and filesystem calls for every single package is unacceptable.
+
+## Fast installs with 0 filesystem writes
+
+The premise behind agentOS's package performance is that installing a package **writes nothing to the filesystem** and **runs no scripts**. There's no extraction, no file copies, and no post-install step, so the **install is effectively free**.
+
+<svg viewBox="0 0 700 240" role="img" aria-label="Installing git with apt means extract, write files, record in the package database, and run post-install triggers, taking 0.87s. With agentOS, you point at the .aospkg and read its manifest, taking 130µs." style="width:100%;max-width:700px;height:auto;display:block;margin:2.5rem auto;font-family:system-ui,sans-serif">
+  <defs>
+    <marker id="pm-ar" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#1b1916"/>
+    </marker>
+  </defs>
+  <text x="60" y="48" font-size="12" font-weight="600" fill="#8a8578" letter-spacing="0.12em">apt</text>
+  <g fill="#ffffff" stroke="#1b1916" stroke-width="1.4">
+    <rect x="60"  y="62" width="100" height="44" rx="7"/>
+    <rect x="182" y="62" width="100" height="44" rx="7"/>
+    <rect x="304" y="62" width="110" height="44" rx="7"/>
+    <rect x="436" y="62" width="110" height="44" rx="7"/>
+  </g>
+  <g font-size="12" fill="#1b1916" text-anchor="middle">
+    <text x="110" y="88">extract</text>
+    <text x="232" y="88">write files</text>
+    <text x="359" y="88">record in db</text>
+    <text x="491" y="83">post-</text>
+    <text x="491" y="97">install</text>
+  </g>
+  <g stroke="#1b1916" stroke-width="1.4">
+    <line x1="160" y1="84" x2="182" y2="84" marker-end="url(#pm-ar)"/>
+    <line x1="282" y1="84" x2="304" y2="84" marker-end="url(#pm-ar)"/>
+    <line x1="414" y1="84" x2="436" y2="84" marker-end="url(#pm-ar)"/>
+    <line x1="546" y1="84" x2="568" y2="84" marker-end="url(#pm-ar)"/>
+  </g>
+  <rect x="568" y="62" width="100" height="44" rx="7" fill="#fbe9e0" stroke="#D63E00" stroke-width="1.4"/>
+  <text x="618" y="89" text-anchor="middle" font-size="13" font-weight="700" fill="#a33000">0.87s</text>
+  <text x="60" y="164" font-size="12" font-weight="600" fill="#8a8578" letter-spacing="0.12em">agentOS</text>
+  <g fill="#ffffff" stroke="#1b1916" stroke-width="1.4">
+    <rect x="60"  y="178" width="150" height="44" rx="7"/>
+    <rect x="232" y="178" width="120" height="44" rx="7"/>
+  </g>
+  <g font-size="12" fill="#1b1916" text-anchor="middle">
+    <text x="135" y="205">point at .aospkg</text>
+    <text x="292" y="205">read manifest</text>
+  </g>
+  <line x1="210" y1="200" x2="232" y2="200" stroke="#1b1916" stroke-width="1.4" marker-end="url(#pm-ar)"/>
+  <line x1="352" y1="200" x2="374" y2="200" stroke="#1b1916" stroke-width="1.4" marker-end="url(#pm-ar)"/>
+  <rect x="374" y="178" width="96" height="44" rx="7" fill="#e7ece7" stroke="#2E4034" stroke-width="1.4"/>
+  <text x="422" y="205" text-anchor="middle" font-size="14" font-weight="700" fill="#2E4034">130µs</text>
+</svg>
+
+Two things make this possible: a **package format designed to be read in place**, and a virtual filesystem that **serves those reads without ever unpacking** anything.
+
+## The agentOS Package Binary Format
+
+First, a prerequisite. An agentOS package is nothing more than a single binary file, a `.aospkg`. It's a deliberately simple container **built to be read in place, with no unpacking step**: a header, the package manifest, an index of where every file sits, and an uncompressed tar of the files themselves.
+
+<svg viewBox="0 0 760 150" role="img" aria-label="An .aospkg file is a 16-byte header followed by three chunks: the manifest with package metadata, the index mapping each file path to an offset and length, and mount.tar, an uncompressed tar of the package files that is mmapped in place." style="width:100%;max-width:720px;height:auto;display:block;margin:2.5rem auto;font-family:system-ui,sans-serif">
+  <text x="30" y="30" font-size="11" font-weight="600" fill="#8a8578" letter-spacing="0.1em">git-2.54.aospkg</text>
+  <g stroke="#1b1916" stroke-width="1.4">
+    <rect x="30"  y="42" width="70"  height="58" fill="#faf8f3"/>
+    <rect x="100" y="42" width="150" height="58" fill="#ffffff"/>
+    <rect x="250" y="42" width="150" height="58" fill="#ffffff"/>
+    <rect x="400" y="42" width="330" height="58" fill="#e7ece7" stroke="#2E4034" stroke-width="2"/>
+  </g>
+  <g text-anchor="middle">
+    <text x="65"  y="76" font-size="9" fill="#56524a">header</text>
+    <text x="175" y="76" font-size="11.5" font-family="ui-monospace,monospace" fill="#1b1916">manifest</text>
+    <text x="325" y="76" font-size="11.5" font-family="ui-monospace,monospace" fill="#1b1916">index</text>
+    <text x="565" y="76" font-size="11.5" font-family="ui-monospace,monospace" fill="#2E4034">mount.tar</text>
+  </g>
+  <g text-anchor="middle" font-size="9.5">
+    <text x="65"  y="122" fill="#94908a">16 bytes</text>
+    <text x="175" y="122" fill="#1b1916">package metadata</text>
+    <text x="175" y="136" fill="#94908a">read once at install</text>
+    <text x="325" y="122" fill="#1b1916">path → offset + length</text>
+    <text x="325" y="136" fill="#94908a">O(log n) lookup, no scan</text>
+    <text x="565" y="122" fill="#1b1916">uncompressed file bytes</text>
+    <text x="565" y="136" fill="#94908a">mmap'd in place, never extracted</text>
+  </g>
+</svg>
+
+On startup, installing a package means agentOS reads the manifest and loads the index, and nothing else. The index already ships **sorted by path**, so it's ready for binary-search lookups without any processing, and nothing is written to disk. The whole thing costs [130µs](https://github.com/rivet-dev/agentos/blob/f66918af5708776823b57fafc6b8d0e318e08764/crates/native-sidecar/tests/projection_bench.rs#L606), **effectively free**.
+
+## Reading a file that was never written
+
+So how do you run a package if it was **never written to disk**?
+
+This is where agentOS's powerful filesystem comes in. It supports flexible configurations for mounts, overlays, and virtual filesystems (the most relevant to this post).
+
+A virtual filesystem (VFS) is a filesystem whose **files don't actually live on disk**.
+
+Instead, its filesystem operations (read, write, list, etc) map to **arbitrary hooks in your code that return "virtual" files**. Each read runs your hook, which returns whatever bytes it wants.
+
+For example, a simple VFS could map a read of `/hello/{name}.txt` to `Hello, {name}!`, so reading `/hello/world.txt` returns `Hello, world!` without touching the disk.
+
+<svg viewBox="0 0 760 142" role="img" aria-label="A read of /hello/world.txt runs the VFS hook (your code), which returns the bytes Hello, world! without ever touching the disk." style="width:100%;max-width:720px;height:auto;display:block;margin:2.5rem auto;font-family:system-ui,sans-serif">
+  <defs>
+    <marker id="vfs-ar" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#1b1916"/>
+    </marker>
+  </defs>
+  <rect x="20" y="66" width="212" height="56" rx="7" fill="#ffffff" stroke="#1b1916" stroke-width="1.4"/>
+  <text x="126" y="90" text-anchor="middle" font-size="9.5" fill="#8a8578" letter-spacing="0.1em">READ</text>
+  <text x="126" y="108" text-anchor="middle" font-size="11.5" font-family="ui-monospace,monospace" fill="#1b1916">read("/hello/world.txt")</text>
+  <line x1="232" y1="94" x2="266" y2="94" stroke="#1b1916" stroke-width="1.4" marker-end="url(#vfs-ar)"/>
+  <rect x="266" y="66" width="238" height="56" rx="7" fill="#ffffff" stroke="#1b1916" stroke-width="1.4"/>
+  <text x="385" y="90" text-anchor="middle" font-size="9.5" fill="#8a8578" letter-spacing="0.1em">VFS HOOK · YOUR CODE</text>
+  <text x="385" y="108" text-anchor="middle" font-size="11.5" font-family="ui-monospace,monospace" fill="#1b1916">return "Hello, " + name</text>
+  <line x1="504" y1="94" x2="538" y2="94" stroke="#1b1916" stroke-width="1.4" marker-end="url(#vfs-ar)"/>
+  <rect x="538" y="66" width="202" height="56" rx="7" fill="#e7ece7" stroke="#2E4034" stroke-width="1.4"/>
+  <text x="639" y="90" text-anchor="middle" font-size="9.5" fill="#5f7060" letter-spacing="0.1em">VIRTUAL FILE</text>
+  <text x="639" y="108" text-anchor="middle" font-size="12" font-family="ui-monospace,monospace" fill="#2E4034">Hello, world!</text>
+</svg>
+
+## The VFS behind agentOS packages
+
+In the case of the agentOS package manager, it leverages VFS in order to **completely remove the install phase from packages altogether**. Instead, when the OS reads a package, it's being served by a VFS.
+
+Concretely, git's files live under `/opt/agentos/pkgs/git/<version>/`. Reading one looks exactly like the `/hello` example above, only now the bytes come from the package itself:
+
+<svg viewBox="0 0 760 142" role="img" aria-label="A read of /opt/agentos/pkgs/git/2.54/bin/git is routed to the agentOS package VFS, which returns the git binary's bytes straight from the package." style="width:100%;max-width:720px;height:auto;display:block;margin:2.5rem auto;font-family:system-ui,sans-serif">
+  <defs>
+    <marker id="pvfs-ar" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#1b1916"/>
+    </marker>
+  </defs>
+  <rect x="8" y="66" width="304" height="56" rx="7" fill="#ffffff" stroke="#1b1916" stroke-width="1.4"/>
+  <text x="160" y="90" text-anchor="middle" font-size="9.5" fill="#8a8578" letter-spacing="0.1em">READ</text>
+  <text x="160" y="108" text-anchor="middle" font-size="10" font-family="ui-monospace,monospace" fill="#1b1916">read("/opt/agentos/pkgs/git/2.54/bin/git")</text>
+  <line x1="312" y1="94" x2="336" y2="94" stroke="#1b1916" stroke-width="1.4" marker-end="url(#pvfs-ar)"/>
+  <rect x="336" y="66" width="206" height="56" rx="7" fill="#ffffff" stroke="#1b1916" stroke-width="1.4"/>
+  <text x="439" y="90" text-anchor="middle" font-size="9" fill="#8a8578" letter-spacing="0.08em">AGENTOS PACKAGE VFS</text>
+  <text x="439" y="108" text-anchor="middle" font-size="10" fill="#1b1916">returns the file's bytes</text>
+  <line x1="542" y1="94" x2="566" y2="94" stroke="#1b1916" stroke-width="1.4" marker-end="url(#pvfs-ar)"/>
+  <rect x="566" y="66" width="186" height="56" rx="7" fill="#e7ece7" stroke="#2E4034" stroke-width="1.4"/>
+  <text x="659" y="90" text-anchor="middle" font-size="9.5" fill="#5f7060" letter-spacing="0.1em">VIRTUAL FILE</text>
+  <text x="659" y="108" text-anchor="middle" font-size="11" fill="#2E4034">the git binary</text>
+</svg>
+
+**With apt**, installing git writes real files to `/usr/bin`, `/usr/lib`, and `/usr/share`, then runs post-install scripts. **With agentOS**, installing git writes **nothing** to disk. The file only appears when you read it, served on demand by the package VFS.
+
+This means that you can setup an agentOS VM with packages preinstalled or install packages on the fly **without any latency**.
+
+## Reading a package that was never unpacked
+
+But here's the catch. We just said installing a package does zero filesystem writes. If that's true, how do we take an archive downloaded from the internet and **expose it as a real directory** on the VM's filesystem?
+
+Say you have a `.aospkg` for something bigger, like a coding agent that bundles a whole Node app:
+
+```
+bin/
+    agent
+dist/
+    index.js
+node_modules/
+    @modelcontextprotocol/sdk/
+    zod/
+    typescript/
+    ...              # thousands of files
+```
+
+Most mainstream package managers extract an archive and write all the files to the host. Even if you have the package pre-downloaded, it **requires expensive filesystem operations to actually turn that archive into a readable format** on the host.
+
+That means unpacking the `.aospkg` and writing every one of those files to disk, potentially thousands of tiny writes:
+
+- `/opt/agentos/pkgs/agent/<version>/dist/index.js`
+- `/opt/agentos/pkgs/agent/<version>/node_modules/zod/lib/index.js`
+- `...` and thousands more
+
+agentOS takes a different approach:
+
+Instead of extracting the tar and writing the files to the host, in agentOS **the `.tar` is mounted directly as a filesystem**.
+
+This means that _nothing_ needs to happen when you install a package, no matter how many files it has.
+
+Reading a file works the same regardless of package size. When the user runs the agent:
+
+1. The OS reads `/opt/agentos/pkgs/agent/<version>/bin/agent`.
+2. agentOS returns the data directly from within the `.aospkg` binary file itself, **without extracting to the filesystem**.
+
+This magic is made possible by a **trick called [mmap](https://pubs.opengroup.org/onlinepubs/009604499/functions/mmap.html)**: it lets you map a portion of a file straight into memory.
+
+Remember the index from the `.aospkg` format? It already **records exactly where every file sits inside `mount.tar`**. So to read `./bin/agent`, agentOS can:
+
+1. Read the index to find what byte range of `mount.tar` holds `bin/agent`: offset `1536`, length `4821`.
+2. mmap those `4821` bytes at offset `1536`.
+3. Return them to the OS.
+
+<svg viewBox="0 0 780 250" role="img" aria-label="Reading the agent: the VFS looks up bin/agent in the .aospkg package index to get offset 1536 and length 4821, then mmaps that byte range straight out of the mount.tar chunk." style="width:100%;max-width:740px;height:auto;display:block;margin:2.5rem auto;font-family:system-ui,sans-serif">
+  <defs>
+    <marker id="rp-ar" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#1b1916"/>
+    </marker>
+    <marker id="rp-map" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#2E4034"/>
+    </marker>
+  </defs>
+  <g fill="#ffffff" stroke="#1b1916" stroke-width="1.4">
+    <rect x="40"  y="24" width="132" height="46" rx="7"/>
+    <rect x="182" y="24" width="132" height="46" rx="7"/>
+    <rect x="324" y="24" width="132" height="46" rx="7"/>
+    <rect x="466" y="24" width="132" height="46" rx="7"/>
+    <rect x="608" y="24" width="132" height="46" rx="7" fill="#e7ece7" stroke="#2E4034"/>
+  </g>
+  <g text-anchor="middle" fill="#1b1916">
+    <text x="106" y="52" font-size="12" font-family="ui-monospace,monospace">exec "agent"</text>
+    <text x="248" y="45" font-size="11">read the file</text>
+    <text x="248" y="60" font-size="9" fill="#56524a">/opt/agentos/…/agent</text>
+    <text x="390" y="45" font-size="11">VFS finds it</text>
+    <text x="390" y="60" font-size="9" fill="#56524a">in the package index</text>
+    <text x="532" y="52" font-size="10.5" font-family="ui-monospace,monospace">mmap(1536, 4821)</text>
+    <text x="674" y="45" font-size="9" fill="#5f7060" letter-spacing="0.1em">VIRTUAL FILE</text>
+    <text x="674" y="60" font-size="10" fill="#2E4034">the launcher</text>
+  </g>
+  <g stroke="#1b1916" stroke-width="1.4">
+    <line x1="172" y1="47" x2="182" y2="47" marker-end="url(#rp-ar)"/>
+    <line x1="314" y1="47" x2="324" y2="47" marker-end="url(#rp-ar)"/>
+    <line x1="456" y1="47" x2="466" y2="47" marker-end="url(#rp-ar)"/>
+    <line x1="598" y1="47" x2="608" y2="47" marker-end="url(#rp-ar)"/>
+  </g>
+  <text x="40" y="150" font-size="11" font-weight="600" fill="#8a8578" letter-spacing="0.1em">agent-1.0.aospkg</text>
+  <g stroke="#1b1916" stroke-width="1.3">
+    <rect x="40"  y="162" width="44"  height="58" fill="#faf8f3"/>
+    <rect x="84"  y="162" width="104" height="58" fill="#faf8f3"/>
+    <rect x="188" y="162" width="132" height="58" fill="#e7ece7" stroke="#2E4034" stroke-width="2"/>
+    <rect x="320" y="162" width="420" height="58" fill="#ffffff"/>
+    <rect x="332" y="171" width="150" height="40" fill="#e7ece7" stroke="#2E4034" stroke-width="1.4"/>
+  </g>
+  <g text-anchor="middle">
+    <text x="62"  y="196" font-size="8.5" fill="#56524a">header</text>
+    <text x="136" y="196" font-size="9" font-family="ui-monospace,monospace" fill="#1b1916">manifest</text>
+    <text x="254" y="188" font-size="10" font-family="ui-monospace,monospace" fill="#2E4034">index</text>
+    <text x="254" y="202" font-size="8" fill="#5f7060">the TOC</text>
+    <text x="407" y="188" font-size="9.5" font-family="ui-monospace,monospace" fill="#2E4034">bin/agent</text>
+    <text x="407" y="202" font-size="8" fill="#5f7060">offset 1536 · length 4821</text>
+    <text x="632" y="184" font-size="9" font-family="ui-monospace,monospace" fill="#1b1916">mount.tar</text>
+    <text x="632" y="199" font-size="8" fill="#56524a">node_modules/ · thousands</text>
+  </g>
+  <line x1="500" y1="73" x2="338" y2="169" stroke="#2E4034" stroke-width="1.3" stroke-dasharray="4 3" marker-end="url(#rp-map)"/>
+  <line x1="566" y1="73" x2="476" y2="169" stroke="#2E4034" stroke-width="1.3" stroke-dasharray="4 3" marker-end="url(#rp-map)"/>
+</svg>
+
+This enables agentOS to take a software package and "install" it on the operating system with **no tar extractions, no filesystem writes, and no scripts**. Just a path to the `.aospkg`.
+
+## Why not snapshotting?
+
+Most sandbox providers recommend working around this by:
+
+1. Provision a sandbox
+2. Install required packages (slow)
+3. Snapshot sandbox
+4. Create a new sandbox from that snapshot (faster)
+5. Repeat when you need to change packages
+
+This is a similar strategy to using a Dockerfile to pre-install packages.
+
+However, the nature of agents is they're great at morphing their environment to their needs, including managing packages.
+
+Snapshotting gives you a rigid base VM to work off of that requires an **expensive & complicated operation to update**.
+
+agentOS Package Manager **encourages composition**, where packages can be installed cheaply without requiring a snapshot.
+
+## Putting it all together
+
+When you put it all together, it provides a clean, simple way to install packages without overhead:
+
+```typescript
+import { agentOS, setup } from "@rivet-dev/agentos";
+import pi from "@agentos-software/pi";
+import git from "@agentos-software/git";
+
+// Each import is just a path to a package's .aospkg on disk.
+console.log(pi.packagePath);
+// => /app/node_modules/@agentos-software/pi/package.aospkg
+
+// Listing packages here "installs" them with zero I/O.
+const vm = agentOS({
+  software: [pi, git],
+});
+
+export const registry = setup({ use: { vm } });
+registry.start();
+```
+
+## Get started
+
+- [GitHub](https://github.com/rivet-dev/agentos)
+- [agentOS Package Registry](https://agentos-sdk.dev/registry)
+- [Documentation](https://agentos-sdk.dev)
+- [Ship your own package](https://agentos-sdk.dev/docs/custom-software/definition/)
+- [Discord](https://rivet.dev/discord)


### PR DESCRIPTION
- Add the "Building the World's Fastest Package Manager with agentOS" changelog post, covering 17µs installs, the `.aospkg` binary format, the package VFS, and mmap-based reads, with inline SVG diagrams
- Add a hero image for the post and wire up the hero image for the agentOS Package Registry post
- Render bolded markdown links at full weight in blog prose
- Pin `@rivet-dev/docs-theme` to the v0.3.1 release tag