### PR TITLE
fix(rivetkit): emit CJS-safe import.meta.url so CommonJS consumers can load rivetkit

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/tsup.config.ts
+++ b/rivetkit-typescript/packages/rivetkit/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 	// browser builds when importing from rivetkit/client.
 	// See: https://github.com/egoist/tsup/issues/958
 	shims: false,
-	esbuildOptions(options) {
+	esbuildOptions(options, context) {
 		// Mark @rivetkit workspace packages as external to preserve their dependency chains
 		options.external = [
 			...(options.external || []),
@@ -21,6 +21,18 @@ export default defineConfig({
 			"@rivetkit/workflow-engine",
 			"@rivet-dev/agent-os-core",
 		];
+		// `shims: false` (above) keeps ESM shims out of the browser build, but it
+		// also leaves `import.meta.url` (used by getRequireFn in src/utils/node.ts)
+		// emitted verbatim into the CJS output — a SyntaxError at load time for any
+		// CommonJS consumer (e.g. importing `rivetkit` under ts-node / a CJS host).
+		// Define a CJS-safe replacement for the CJS format only; ESM keeps native
+		// import.meta.
+		if (context.format === "cjs") {
+			options.define = {
+				...(options.define || {}),
+				"import.meta.url": "require('url').pathToFileURL(__filename).href",
+			};
+		}
 	},
 	define: {
 		"globalThis.CUSTOM_RIVETKIT_DEVTOOLS_URL": process.env


### PR DESCRIPTION
## Summary

`rivetkit`'s CJS build ships a verbatim `import.meta.url`, which is a **load-time SyntaxError** in any CommonJS consumer (e.g. importing `rivetkit` under `ts-node` / a CJS host process).

## Root cause

`getRequireFn()` in `rivetkit-typescript/packages/rivetkit/src/utils/node.ts` uses `createRequire(import.meta.url)` (and carries a `// TODO: This causes issues in tsup` with the CJS `require` branch commented out). The package's `tsup.config.ts` deliberately sets **`shims: false`** — correctly, since the ESM shims pull in Node-only modules that break the browser build (`rivetkit/client`). But with shims off, tsup emits `import.meta.url` **verbatim into the `.cjs` output**, so:

```
dist/tsup/mod.cjs:  return _module.createRequire.call(void 0, import.meta.url);
```

fails to load in CommonJS.

## Fix

Keep `shims: false` (don't regress the browser build) and instead define a CJS-safe replacement for `import.meta.url` **only for the `cjs` format**, via tsup's format-aware `esbuildOptions(options, context)`:

```ts
if (context.format === "cjs") {
  options.define = {
    ...(options.define || {}),
    "import.meta.url": "require('url').pathToFileURL(__filename).href",
  };
}
```

ESM output is untouched (keeps native `import.meta.url`); only the CJS bundle gets the load-safe form. Single-file change to `tsup.config.ts`.

## Notes

- Repro: `require('rivetkit')` from a CommonJS module against the current published build throws on `import.meta`.
- There is a companion packaging gap (some `@rivetkit/*` subpackages declare a `require` export condition but don't ship `.cjs`) — happy to follow up separately; this PR fixes the main `rivetkit` entry.
- Draft pending your CI (I can't build the full monorepo locally); the change is minimal and format-scoped.