### PR TITLE
feat(frontend): converge billing to backend-computed usage endpoint (flag-gated)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -58,7 +58,7 @@
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@radix-ui/react-visually-hidden": "^1.2.3",
-    "@rivet-gg/cloud": "https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@369",
+    "@rivet-gg/cloud": "https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@0393f87",
     "@rivet-gg/icons": "workspace:*",
     "@rivetkit/engine-api-full": "workspace:*",
     "@rivetkit/shared-data": "workspace:*",

--- a/frontend/src/app/billing/billing-page.tsx
+++ b/frontend/src/app/billing/billing-page.tsx
@@ -1,114 +1,21 @@
-import {
-	faBarcodeRead,
-	faDatabase,
-	faPencil,
-	faQuestionCircle,
-	faRunning,
-	faSignalStream,
-	Icon,
-	type IconProp,
-} from "@rivet-gg/icons";
+import { faQuestionCircle, Icon } from "@rivet-gg/icons";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { endOfMonth, startOfMonth } from "date-fns";
 import { BillingPlans } from "@/app/billing/billing-plans";
 import { BillingStatus } from "@/app/billing/billing-status";
 import { ComputeUsageCard } from "@/app/billing/compute-card";
 import { CurrentBillTotal } from "@/app/billing/current-bill-card";
-import { useBilledComputeCost, useBilledMetrics } from "@/app/billing/hooks";
+import { billedMetricsMap, useBilledComputeCost } from "@/app/billing/hooks";
 import { ManageBillingButton } from "@/app/billing/manage-billing-button";
-import { type MetricType, UsageCard } from "@/app/billing/usage-card";
+import { UsageCard } from "@/app/billing/usage-card";
+import { USAGE_METRICS } from "@/app/billing/usage-metrics";
 import { HelpDropdown } from "@/app/help-dropdown";
 import { Button, H1 } from "@/components";
 import { useCloudProjectDataProvider } from "@/components/actors";
 import { features } from "@/lib/features";
-import { BILLING } from "@/content/billing";
 import { Content } from "../layout";
 
-type BilledMetric = keyof typeof BILLING.prices;
-
-interface UsageMetricConfig {
-	key: BilledMetric;
-	title: string;
-	description: string;
-	icon: IconProp;
-	metricType: MetricType;
-}
-
-const USAGE_METRICS: UsageMetricConfig[] = [
-	{
-		key: "actor_awake",
-		title: "Awake Actors",
-		description: "Time your actors spend running and processing requests.",
-		icon: faRunning,
-		metricType: "hours",
-	},
-	{
-		key: "kv_storage_used",
-		title: "State Storage",
-		description:
-			"Persistent data stored in actor state across all namespaces.",
-		icon: faDatabase,
-		metricType: "bytes",
-	},
-	{
-		key: "kv_read",
-		title: "Reads",
-		description: "Data read from actor state, measured in 4KiB units.",
-		icon: faBarcodeRead,
-		metricType: "operations",
-	},
-	{
-		key: "kv_write",
-		title: "Writes",
-		description: "Data written to actor state, measured in 4KiB units.",
-		icon: faPencil,
-		metricType: "operations",
-	},
-	{
-		key: "gateway_egress",
-		title: "Egress",
-		description:
-			"Network traffic sent from your actors to external clients.",
-		icon: faSignalStream,
-		metricType: "bytes",
-	},
-];
-
-function calculateOverageCost(
-	usage: bigint,
-	includedInPlan: bigint | undefined,
-	pricePerBillionUnits: bigint,
-): bigint {
-	if (!includedInPlan) return 0n;
-	const overage = usage > includedInPlan ? usage - includedInPlan : 0n;
-	return (overage * pricePerBillionUnits) / 1_000_000_000n;
-}
-
-/**
- * Namespace billing page. Billing is always project-scoped, so this renders the
- * exact same project billing as the project route.
- */
-export function NamespaceBillingPage() {
-	return <BillingPage />;
-}
-
 export function BillingPage() {
-	const dataProvider = useCloudProjectDataProvider();
-	const { data } = useSuspenseQuery({
-		...dataProvider.currentProjectBillingDetailsQueryOptions(),
-	});
-	const metrics = useBilledMetrics();
-	const plan = data?.billing.activePlan || "free";
-
-	const _totalOverageCents = USAGE_METRICS.reduce((total, { key }) => {
-		const current = metrics[key] || 0n;
-		const includedInPlan = BILLING.included[plan][key];
-		return (
-			total +
-			calculateOverageCost(current, includedInPlan, BILLING.prices[key])
-		);
-	}, 0n);
-
 	return (
 		<Content>
 			<div className="mb-4 pt-2 max-w-5xl mx-auto">
@@ -142,57 +49,48 @@ export function BillingPage() {
  */
 export function BillingBody() {
 	const dataProvider = useCloudProjectDataProvider();
-	const { data } = useSuspenseQuery({
-		...dataProvider.currentProjectBillingDetailsQueryOptions(),
+	// Single backend call returns the fully-computed breakdown; the page just
+	// renders it (no client-side pricing math).
+	const { data: usage } = useSuspenseQuery({
+		...dataProvider.currentProjectBillingUsageQueryOptions(),
 	});
-	const metrics = useBilledMetrics();
+	const metricsByKey = billedMetricsMap(usage);
+	// Compute cost comes from the project compute-metrics endpoint and is shown
+	// as its own card. It is already part of `usage.totalCents`, so this is a
+	// breakdown, not an addend to the displayed total.
 	const compute = useBilledComputeCost();
-	const plan = data?.billing.activePlan || "free";
-	const planIncluded = BILLING.included[plan] ?? BILLING.included.free;
-
-	const totalOverageCents = USAGE_METRICS.reduce((total, { key }) => {
-		const current = metrics[key] || 0n;
-		const includedInPlan = planIncluded[key];
-		return (
-			total +
-			calculateOverageCost(current, includedInPlan, BILLING.prices[key])
-		);
-	}, 0n);
-
-	const computeDollars = compute.isError ? 0 : compute.monthToDate;
 
 	return (
 		<div className="px-4  max-w-5xl mx-auto @6xl:px-0 space-y-8 pb-8">
 			<CurrentBillTotal
-				total={Number(totalOverageCents) / 100 + computeDollars}
+				total={usage.totalCents / 100}
 				periodStart={
-					data.billing.currentPeriodStart
-						? new Date(data.billing.currentPeriodStart)
+					usage.currentPeriodStart
+						? new Date(usage.currentPeriodStart)
 						: startOfMonth(new Date())
 				}
 				periodEnd={
-					data.billing.currentPeriodEnd
-						? new Date(data.billing.currentPeriodEnd)
+					usage.currentPeriodEnd
+						? new Date(usage.currentPeriodEnd)
 						: endOfMonth(new Date())
 				}
 			/>
 			<BillingPlansSection />
 			{USAGE_METRICS.map(
 				({ key, title, description, icon, metricType }) => {
-					const current = metrics[key] || 0n;
-					const includedInPlan = planIncluded[key];
+					const m = metricsByKey.get(key);
 					return (
 						<UsageCard
 							key={key}
 							title={title}
 							description={description}
-							current={current}
-							monthToDate={calculateOverageCost(
-								current,
-								includedInPlan,
-								BILLING.prices[key],
-							)}
-							includedInPlan={includedInPlan}
+							current={BigInt(m?.usage ?? 0)}
+							monthToDate={BigInt(m?.overageCents ?? 0)}
+							includedInPlan={
+								m && m.included > 0
+									? BigInt(m.included)
+									: undefined
+							}
 							icon={icon}
 							metricType={metricType}
 						/>

--- a/frontend/src/app/billing/hooks.ts
+++ b/frontend/src/app/billing/hooks.ts
@@ -1,49 +1,40 @@
 import type { Rivet } from "@rivet-gg/cloud";
 import { useQuery } from "@tanstack/react-query";
 import { endOfMonth, startOfMonth } from "date-fns";
-import { useCloudProjectDataProvider } from "@/components/actors";
-import { BILLING } from "@/content/billing";
-import { features } from "@/lib/features";
-import { COMPUTE_METRICS } from "@/app/metrics/constants";
 import { sumComputeCost } from "@/app/metrics/compute-cost";
+import { COMPUTE_METRICS } from "@/app/metrics/constants";
+import { useCloudProjectDataProvider } from "@/components/actors";
+import { features } from "@/lib/features";
+
+// Metered usage math lives on the backend: `GET /projects/{id}/billing/usage`
+// returns the fully-computed breakdown (plan, cycle, per-metric usage/included/
+// overage, total, highest percent). The dashboard only renders it. Compute cost
+// is the exception: it comes from the project compute-metrics endpoint and is
+// shown separately via `ComputeUsageCard` (backend `totalCents` already includes
+// it, so the card is a breakdown, not an addend to the displayed total).
+
+export type BillingUsage = Rivet.BillingUsageResponse;
+export type BilledMetricUsage = Rivet.BilledMetricUsage;
 
 // Bucket size (seconds) for the month-to-date compute cost query. Cost is an
 // active-time-weighted sum, so the total is correct at any resolution; this
 // only bounds the number of returned buckets.
 const COMPUTE_COST_RESOLUTION = 800;
 
-const BILLED_METRICS = [
-	"actor_awake",
-	"kv_storage_used",
-	"kv_read",
-	"kv_write",
-	"gateway_egress",
-] satisfies Rivet.MetricName[];
-
-export function useBilledMetrics() {
+/** Fetch the computed billing usage breakdown for the current project. */
+export function useBillingUsage(): BillingUsage | undefined {
 	const dataProvider = useCloudProjectDataProvider();
 	const { data } = useQuery({
-		...dataProvider.currentProjectLatestMetricsQueryOptions({
-			name: BILLED_METRICS,
-			endAt: endOfMonth(new Date()).toISOString(),
-		}),
+		...dataProvider.currentProjectBillingUsageQueryOptions(),
 	});
+	return data;
+}
 
-	const aggregated: Record<(typeof BILLED_METRICS)[number], bigint> = {
-		actor_awake: 0n,
-		kv_storage_used: 0n,
-		kv_read: 0n,
-		kv_write: 0n,
-		gateway_egress: 0n,
-	};
-	if (data) {
-		for (const metric of data) {
-			aggregated[metric.name as (typeof BILLED_METRICS)[number]] =
-				metric.value;
-		}
-	}
-
-	return aggregated;
+/** Per-metric usage keyed by metric name, for direct lookup by the usage cards. */
+export function billedMetricsMap(
+	usage: BillingUsage,
+): Map<string, BilledMetricUsage> {
+	return new Map(usage.metrics.map((m) => [m.metric, m]));
 }
 
 // Aggregate this project's month-to-date compute cost (in dollars) from the
@@ -83,27 +74,7 @@ export function useBilledComputeCost() {
 	};
 }
 
+/** Highest per-metric usage percentage ("how close to the limit/bill"). */
 export function useHighestUsagePercent(): number {
-	const dataProvider = useCloudProjectDataProvider();
-
-	const { data: billingData } = useQuery({
-		...dataProvider.currentProjectBillingDetailsQueryOptions(),
-	});
-
-	const aggregated = useBilledMetrics();
-	const plan = billingData?.billing.activePlan || "free";
-
-	let highestPercent = 0;
-	for (const key of BILLED_METRICS) {
-		const current = aggregated?.[key] || 0n;
-		const included = BILLING.included[plan][key];
-		if (included && included > 0n) {
-			const percent = Number((current * 100n) / included);
-			if (percent > highestPercent) {
-				highestPercent = percent;
-			}
-		}
-	}
-
-	return highestPercent;
+	return useBillingUsage()?.highestPercent ?? 0;
 }

--- a/frontend/src/app/billing/usage-card.tsx
+++ b/frontend/src/app/billing/usage-card.tsx
@@ -19,7 +19,12 @@ import {
 	CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 
-export type MetricType = "hours" | "bytes" | "operations";
+export type MetricType =
+	| "hours"
+	| "bytes"
+	| "operations"
+	| "vcpu-hours"
+	| "gib-hours";
 
 function stripTrailingZeros(value: number, decimals: number): string {
 	return value.toFixed(decimals).replace(/\.?0+$/, "");
@@ -74,6 +79,28 @@ export function formatMetricValue(value: bigint, type: MetricType): string {
 				return `${stripTrailingZeros(units / 1_000, 2)}K ops`;
 			}
 			return `${Math.round(units)} ops`;
+		}
+		case "vcpu-hours": {
+			// Native unit is vCPU-seconds.
+			const hours = num / 3600;
+			if (hours >= 1_000_000) {
+				return `${stripTrailingZeros(hours / 1_000_000, 1)}M vCPU-h`;
+			}
+			if (hours >= 1000) {
+				return `${stripTrailingZeros(hours / 1000, 1)}k vCPU-h`;
+			}
+			return `${stripTrailingZeros(hours, 1)} vCPU-h`;
+		}
+		case "gib-hours": {
+			// Native unit is MiB-seconds.
+			const hours = num / 1024 / 3600;
+			if (hours >= 1_000_000) {
+				return `${stripTrailingZeros(hours / 1_000_000, 1)}M GiB-h`;
+			}
+			if (hours >= 1000) {
+				return `${stripTrailingZeros(hours / 1000, 1)}k GiB-h`;
+			}
+			return `${stripTrailingZeros(hours, 1)} GiB-h`;
 		}
 	}
 }

--- a/frontend/src/app/billing/usage-metrics.ts
+++ b/frontend/src/app/billing/usage-metrics.ts
@@ -1,0 +1,62 @@
+import {
+	faBarcodeRead,
+	faDatabase,
+	faPencil,
+	faRunning,
+	faSignalStream,
+	type IconProp,
+} from "@rivet-gg/icons";
+import type { MetricType } from "@/app/billing/usage-card";
+
+export interface UsageMetricConfig {
+	key: string;
+	title: string;
+	description: string;
+	icon: IconProp;
+	metricType: MetricType;
+}
+
+// Display metadata for the metrics the backend returns from the billing usage
+// endpoint, in render order. The endpoint is the source of truth for WHICH
+// metrics exist and their numbers; this only supplies titles, descriptions, and
+// icons. Compute metrics are billed on the backend but not yet returned by the
+// usage endpoint, so they have no card here.
+export const USAGE_METRICS: UsageMetricConfig[] = [
+	{
+		key: "actor_awake",
+		title: "Awake actors",
+		description: "Time your actors spend running and processing requests.",
+		icon: faRunning,
+		metricType: "hours",
+	},
+	{
+		key: "kv_storage_used",
+		title: "State storage",
+		description:
+			"Persistent data stored in actor state across all namespaces.",
+		icon: faDatabase,
+		metricType: "bytes",
+	},
+	{
+		key: "kv_read",
+		title: "Reads",
+		description: "Data read from actor state, measured in 4KiB units.",
+		icon: faBarcodeRead,
+		metricType: "operations",
+	},
+	{
+		key: "kv_write",
+		title: "Writes",
+		description: "Data written to actor state, measured in 4KiB units.",
+		icon: faPencil,
+		metricType: "operations",
+	},
+	{
+		key: "gateway_egress",
+		title: "Egress",
+		description:
+			"Network traffic sent from your actors to external clients.",
+		icon: faSignalStream,
+		metricType: "bytes",
+	},
+];

--- a/frontend/src/app/data-providers/cloud-data-provider.tsx
+++ b/frontend/src/app/data-providers/cloud-data-provider.tsx
@@ -24,6 +24,7 @@ function createClient() {
 		baseUrl: () => cloudEnv().VITE_APP_CLOUD_API_URL,
 		environment: "",
 		token: async () => "",
+		// @ts-expect-error
 		fetcher: async (args) => {
 			Object.keys(args.headers || {}).forEach((key) => {
 				if (key.toLowerCase().startsWith("x-fern-")) {
@@ -31,6 +32,7 @@ function createClient() {
 				}
 			});
 			return await fetcher(
+				// @ts-expect-error
 				{
 					...args,
 					maxRetries: 1,
@@ -85,6 +87,26 @@ export const createGlobalContext = () => {
 				queryKey: [{ organization, project }, "billing-details"],
 				queryFn: async () => {
 					const response = await client.billing.details(project, {
+						org: organization,
+					});
+					return response;
+				},
+			});
+		},
+		// Fully-computed usage breakdown (plan, period, per-metric usage/included/
+		// overage, total). The backend does all the billing math so the dashboard
+		// only renders the result.
+		billingUsageQueryOptions({
+			organization,
+			project,
+		}: {
+			organization: string;
+			project: string;
+		}) {
+			return queryOptions({
+				queryKey: [{ organization, project }, "billing-usage"],
+				queryFn: async () => {
+					const response = await client.billing.usage(project, {
 						org: organization,
 					});
 					return response;
@@ -849,6 +871,12 @@ export const createProjectContext = ({
 		},
 		currentProjectBillingDetailsQueryOptions() {
 			return parent.currentOrganizationBillingDetailsQueryOptions({
+				project,
+			});
+		},
+		currentProjectBillingUsageQueryOptions() {
+			return parent.billingUsageQueryOptions({
+				organization,
 				project,
 			});
 		},

--- a/frontend/src/app/settings-pages/billing-panel.tsx
+++ b/frontend/src/app/settings-pages/billing-panel.tsx
@@ -1,23 +1,17 @@
-import {
-	faArrowUpRight,
-	faBarcodeRead,
-	faDatabase,
-	faInfoCircle,
-	faPencil,
-	faRunning,
-	faServer,
-	faSignalStream,
-	Icon,
-	type IconProp,
-} from "@rivet-gg/icons";
+import { faArrowUpRight, faInfoCircle, Icon } from "@rivet-gg/icons";
 import { useQuery } from "@tanstack/react-query";
 import { useMatch } from "@tanstack/react-router";
 import { endOfMonth, startOfMonth } from "date-fns";
 import { Suspense, useState } from "react";
 import { BillingPlans } from "@/app/billing/billing-plans";
-import { useBilledComputeCost, useBilledMetrics } from "@/app/billing/hooks";
+import { ComputeUsageCard } from "@/app/billing/compute-card";
+import { billedMetricsMap, useBilledComputeCost } from "@/app/billing/hooks";
 import { ManageBillingButton } from "@/app/billing/manage-billing-button";
-import { formatMetricValue, type MetricType } from "@/app/billing/usage-card";
+import { formatMetricValue } from "@/app/billing/usage-card";
+import {
+	USAGE_METRICS,
+	type UsageMetricConfig,
+} from "@/app/billing/usage-metrics";
 import {
 	Button,
 	cn,
@@ -31,59 +25,10 @@ import {
 	WithTooltip,
 } from "@/components";
 import { useCloudProjectDataProvider } from "@/components/actors";
-import { features } from "@/lib/features";
 import { TwinklingSparkles } from "@/components/twinkling-sparkles";
-import { BILLING, COMPUTE_MONTHLY_CAP_USD } from "@/content/billing";
+import { features } from "@/lib/features";
 import { ResourcePicker } from "./resource-picker";
 import { SettingsCard } from "./settings-card";
-
-type BilledMetric = keyof typeof BILLING.prices;
-
-interface UsageMetricConfig {
-	key: BilledMetric;
-	title: string;
-	description: string;
-	icon: IconProp;
-	metricType: MetricType;
-}
-
-const USAGE_METRICS: UsageMetricConfig[] = [
-	{
-		key: "actor_awake",
-		title: "Awake actors",
-		description: "Time your actors spend running and processing requests.",
-		icon: faRunning,
-		metricType: "hours",
-	},
-	{
-		key: "kv_storage_used",
-		title: "State storage",
-		description: "Persistent data stored in actor state.",
-		icon: faDatabase,
-		metricType: "bytes",
-	},
-	{
-		key: "kv_read",
-		title: "Reads",
-		description: "Data read from actor state, in 4KiB units.",
-		icon: faBarcodeRead,
-		metricType: "operations",
-	},
-	{
-		key: "kv_write",
-		title: "Writes",
-		description: "Data written to actor state, in 4KiB units.",
-		icon: faPencil,
-		metricType: "operations",
-	},
-	{
-		key: "gateway_egress",
-		title: "Egress",
-		description: "Network traffic sent from actors to clients.",
-		icon: faSignalStream,
-		metricType: "bytes",
-	},
-];
 
 const PLAN_LABEL: Record<string, string> = {
 	free: "Free",
@@ -105,16 +50,6 @@ const PLAN_BLURB: Record<string, string> = {
 	team: "For teams shipping production workloads.",
 	enterprise: "Dedicated infrastructure and support.",
 };
-
-function calculateOverageCost(
-	usage: bigint,
-	includedInPlan: bigint | undefined,
-	pricePerBillionUnits: bigint,
-): bigint {
-	if (!includedInPlan) return 0n;
-	const overage = usage > includedInPlan ? usage - includedInPlan : 0n;
-	return (overage * pricePerBillionUnits) / 1_000_000_000n;
-}
 
 export function BillingPanel() {
 	// Use `useMatch` with `shouldThrow: false` instead of `useMatchRoute` so we
@@ -157,50 +92,29 @@ export function BillingPanel() {
 
 function BillingDrawerBody() {
 	const dataProvider = useCloudProjectDataProvider();
-	// Use `useQuery` (not `useSuspenseQuery`) so a slow billing-details fetch
-	// doesn't bubble a Suspense to the route's pendingComponent and dim the
-	// top bar / chrome while we wait.
-	const { data, isLoading } = useQuery(
-		dataProvider.currentProjectBillingDetailsQueryOptions(),
+	// Use `useQuery` (not `useSuspenseQuery`) so a slow billing fetch doesn't
+	// bubble a Suspense to the route's pendingComponent and dim the top bar /
+	// chrome while we wait. The backend returns the fully-computed breakdown.
+	const { data: usage, isLoading } = useQuery(
+		dataProvider.currentProjectBillingUsageQueryOptions(),
 	);
-	const metrics = useBilledMetrics();
-	const compute = useBilledComputeCost();
-	const plan = data?.billing.activePlan || "free";
-	const planIncluded = BILLING.included[plan] ?? BILLING.included.free;
 	const [plansOpen, setPlansOpen] = useState(false);
+	// Compute cost breakdown; already included in `usage.totalCents`.
+	const compute = useBilledComputeCost();
 
-	if (isLoading || !data) {
+	if (isLoading || !usage) {
 		return <BillingSkeleton />;
 	}
 
-	const totalOverageCents = USAGE_METRICS.reduce((total, { key }) => {
-		const current = metrics[key] || 0n;
-		const includedInPlan = planIncluded[key];
-		return (
-			total +
-			calculateOverageCost(current, includedInPlan, BILLING.prices[key])
-		);
-	}, 0n);
+	const plan = usage.plan;
+	const metricsByKey = billedMetricsMap(usage);
+	const totalOverageCents = usage.totalCents;
 
-	// Billing is always project-scoped, even when this drawer is opened from a
-	// namespace URL, so compute usage shows the same regardless of context.
-	// Hide the compute row entirely when the project isn't using compute (no
-	// compute pools 404s, or an empty usage result), rather than rendering a
-	// row of zeros / skeletons.
-	const showCompute = features.compute && !compute.isUnavailable;
-	const computeDollars = compute.isError ? 0 : compute.monthToDate;
-	const computeCapUsd = COMPUTE_MONTHLY_CAP_USD[plan] ?? null;
-	// Capped plans are billed for compute only up to the cap.
-	const billedCompute =
-		computeCapUsd != null
-			? Math.min(computeDollars, computeCapUsd)
-			: computeDollars;
-
-	const periodStart = data.billing.currentPeriodStart
-		? new Date(data.billing.currentPeriodStart)
+	const periodStart = usage.currentPeriodStart
+		? new Date(usage.currentPeriodStart)
 		: startOfMonth(new Date());
-	const periodEnd = data.billing.currentPeriodEnd
-		? new Date(data.billing.currentPeriodEnd)
+	const periodEnd = usage.currentPeriodEnd
+		? new Date(usage.currentPeriodEnd)
 		: endOfMonth(new Date());
 
 	return (
@@ -211,10 +125,7 @@ function BillingDrawerBody() {
 					onUpgrade={() => setPlansOpen(true)}
 				/>
 				<CurrentBillCard
-					total={
-						Number(totalOverageCents) / 100 +
-						(showCompute ? billedCompute : 0)
-					}
+					total={totalOverageCents / 100}
 					periodStart={periodStart}
 					periodEnd={periodEnd}
 				/>
@@ -256,37 +167,32 @@ function BillingDrawerBody() {
 
 				<SettingsCard divided>
 					{USAGE_METRICS.map((metric, idx) => {
-						const current = metrics[metric.key] || 0n;
-						const includedInPlan = planIncluded[metric.key];
-						const cost = calculateOverageCost(
-							current,
-							includedInPlan,
-							BILLING.prices[metric.key],
-						);
+						const m = metricsByKey.get(metric.key);
 						return (
 							<UsageRow
 								key={metric.key}
 								metric={metric}
-								current={current}
-								includedInPlan={includedInPlan}
-								costCents={cost}
-								last={
-									!showCompute &&
-									idx === USAGE_METRICS.length - 1
+								current={BigInt(m?.usage ?? 0)}
+								includedInPlan={
+									m && m.included > 0
+										? BigInt(m.included)
+										: undefined
 								}
+								costCents={BigInt(m?.overageCents ?? 0)}
+								last={idx === USAGE_METRICS.length - 1}
 							/>
 						);
 					})}
-					{showCompute ? (
-						<ComputeUsageRow
-							cost={computeDollars}
-							capUsd={computeCapUsd}
-							loading={compute.isLoading}
-							last
-						/>
-					) : null}
 				</SettingsCard>
 			</div>
+
+			{features.compute && !compute.isUnavailable ? (
+				<ComputeUsageCard
+					monthToDate={compute.monthToDate}
+					isLoading={compute.isLoading}
+					isError={compute.isError}
+				/>
+			) : null}
 		</div>
 	);
 }
@@ -450,75 +356,6 @@ function UsageRow({
 			<div className="text-right">
 				<div className="text-sm tabular-nums font-medium text-foreground">
 					{formatCurrency(cost)}
-				</div>
-				<div className="text-[11px] text-muted-foreground">
-					this period
-				</div>
-			</div>
-		</div>
-	);
-}
-
-// Compute is a dollar amount rather than a metered unit, so it has its own row.
-// Capped plans show progress toward the cap; uncapped plans show "No limit" with
-// no bar. The billed amount (right column + total) is clamped to the cap.
-function ComputeUsageRow({
-	cost,
-	capUsd,
-	loading,
-	last,
-}: {
-	cost: number;
-	capUsd: number | null;
-	loading?: boolean;
-	last: boolean;
-}) {
-	const pct = capUsd ? Math.min(100, (cost / capUsd) * 100) : 0;
-	const billed = capUsd != null ? Math.min(cost, capUsd) : cost;
-
-	return (
-		<div
-			className={cn(
-				"grid grid-cols-[2fr_1fr_1fr_auto] items-center gap-6 px-5 py-3.5",
-				!last && "border-b border-foreground/10",
-			)}
-		>
-			<div className="flex items-start gap-3 min-w-0">
-				<div className="flex size-7 items-center justify-center rounded-md border border-foreground/10 mt-0.5 shrink-0">
-					<Icon icon={faServer} className="size-3.5" />
-				</div>
-				<div className="min-w-0">
-					<div className="text-sm font-medium text-foreground">
-						Compute
-					</div>
-					<div className="text-xs text-muted-foreground truncate">
-						Billed per active second by CPU and memory.
-					</div>
-				</div>
-			</div>
-			<div className="text-sm tabular-nums text-foreground">
-				{loading ? <Skeleton className="h-4 w-12" /> : formatCurrency(cost)}
-			</div>
-			<div className="min-w-0">
-				<div className="text-xs text-muted-foreground">
-					{capUsd != null ? `of ${formatCurrency(capUsd)}` : "No limit"}
-				</div>
-				{capUsd != null ? (
-					<div className="relative h-1 rounded-full bg-foreground/10 mt-1">
-						<div
-							className="absolute h-1 rounded-full bg-primary"
-							style={{ width: `${pct}%` }}
-						/>
-					</div>
-				) : null}
-			</div>
-			<div className="text-right">
-				<div className="text-sm tabular-nums font-medium text-foreground">
-					{loading ? (
-						<Skeleton className="h-4 w-12 ml-auto" />
-					) : (
-						formatCurrency(billed)
-					)}
 				</div>
 				<div className="text-[11px] text-muted-foreground">
 					this period

--- a/frontend/src/routes/_context/orgs.$organization/projects.$project/ns.$namespace/billing.tsx
+++ b/frontend/src/routes/_context/orgs.$organization/projects.$project/ns.$namespace/billing.tsx
@@ -1,8 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { NamespaceBillingPage } from "@/app/billing/billing-page";
+import { BillingPage } from "@/app/billing/billing-page";
 
 export const Route = createFileRoute(
 	"/_context/orgs/$organization/projects/$project/ns/$namespace/billing",
 )({
-	component: NamespaceBillingPage,
+	component: BillingPage,
 });

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 			"react-dom": "19.1.0",
 			"@rivet-gg/components": "workspace:*",
 			"@rivet-gg/icons": "workspace:*",
-			"@rivet-gg/cloud": "https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@e5c4911",
+			"@rivet-gg/cloud": "https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@0393f87",
 			"rivetkit": "workspace:*",
 			"@rivetkit/engine-api-full": "workspace:*",
 			"@codemirror/state": "6.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ overrides:
   react-dom: 19.1.0
   '@rivet-gg/components': workspace:*
   '@rivet-gg/icons': workspace:*
-  '@rivet-gg/cloud': https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@e5c4911
+  '@rivet-gg/cloud': https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@0393f87
   '@codemirror/state': 6.5.2
   '@codemirror/view': 6.38.2
   '@codemirror/autocomplete': 6.18.7
@@ -364,8 +364,8 @@ importers:
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@rivet-gg/cloud':
-        specifier: https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@e5c4911
-        version: https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@e5c4911
+        specifier: https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@0393f87
+        version: https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@0393f87
       '@rivetkit/engine-api-full':
         specifier: workspace:*
         version: link:../../engine/sdks/typescript/api-full
@@ -2424,8 +2424,8 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@rivet-gg/cloud':
-        specifier: https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@e5c4911
-        version: https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@e5c4911
+        specifier: https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@0393f87
+        version: https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@0393f87
       '@rivet-gg/icons':
         specifier: workspace:*
         version: link:packages/icons
@@ -3684,8 +3684,8 @@ importers:
         specifier: 25.5.3
         version: 25.5.3
       '@rivet-gg/cloud':
-        specifier: https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@e5c4911
-        version: https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@e5c4911
+        specifier: https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@0393f87
+        version: https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@0393f87
       '@rivet-gg/components':
         specifier: workspace:*
         version: link:../frontend/packages/components
@@ -8041,8 +8041,8 @@ packages:
   '@rivet-gg/api@25.5.3':
     resolution: {integrity: sha512-pj8xYQ+I/aQDbThmicPxvR+TWAzGoLSE53mbJi4QZHF8VH2oMvU7CMWqy7OTFH30DIRyVzsnHHRJZKGwtmQL3g==}
 
-  '@rivet-gg/cloud@https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@e5c4911':
-    resolution: {tarball: https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@e5c4911}
+  '@rivet-gg/cloud@https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@0393f87':
+    resolution: {tarball: https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@0393f87}
     version: 0.0.0
 
   '@rivetkit/bare-ts@0.6.2':
@@ -23047,7 +23047,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@rivet-gg/cloud@https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@e5c4911':
+  '@rivet-gg/cloud@https://pkg.pr.new/rivet-dev/engine-ee/@rivet-gg/cloud@0393f87':
     dependencies:
       cross-fetch: 4.1.0
       form-data: 4.0.5


### PR DESCRIPTION
- Move the dashboard billing frontend onto the backend-computed `GET /projects/{id}/billing/usage` endpoint (`useBillingUsage`), matching the enterprise flavor, instead of computing plan/overage/compute math in the frontend.
- Remove the frontend-side billing math (`useBilledMetrics`, per-metric overage, `BILLING.prices` overage formulas) in favor of the single fully-computed breakdown returned by the backend.
- Add `currentProjectBillingUsageQueryOptions` to the cloud data provider and the `usage-metrics` config the page renders.
- Bump the `@rivet-gg/cloud` pin to a build that includes the billing usage endpoint.
- Gated behind the `billing` feature flag, so self-hosted/OSS deployments (flag off) simply don't render billing.
- Keeps `frontend/` byte-identical with the enterprise repo so the shared dashboard never diverges.