### PR TITLE
docs(deploy): tighten container runner intro and trim input example

### DIFF
--- a/container-runner/README.md
+++ b/container-runner/README.md
@@ -13,7 +13,7 @@ container with this binary as the entrypoint and Rivet Compute can cold-start an
 to it.
 
 The actor `input` payload (CBOR-encoded, RivetKit convention) can override the child
-command, args, env, and port per actor. WebSocket clients connect at the bare gateway
+command, args, and env per actor. WebSocket clients connect at the bare gateway
 path; raw HTTP reaches the child under the `/request/*` prefix on the actor surface.
 
 `examples/` contains a Unity + FishNet demo project, a lightweight Node test server, and

--- a/container-runner/README.md
+++ b/container-runner/README.md
@@ -1,5 +1,9 @@
 # Container Runner
 
+User-facing documentation lives at
+[rivet.dev/docs/deploy/container-runner](https://rivet.dev/docs/deploy/container-runner/).
+This README covers development, the example projects, and the local test harnesses.
+
 `rivet-container-runner` is a RivetKit (Rust) serverless app that hosts actors by
 spawning a child game-server process per actor and proxying Rivet's tunneled
 HTTP/WebSocket traffic to it. Each child gets its own port; the pool's request

--- a/website/src/content/docs/deploy/container-runner.mdx
+++ b/website/src/content/docs/deploy/container-runner.mdx
@@ -4,7 +4,7 @@ description: "Run any containerized server as a Rivet Actor."
 skill: true
 ---
 
-The container runner (`rivet-container-runner`) turns any container into a Rivet Actor host: as the entrypoint, it spawns your server as a child process and proxies HTTP and WebSocket traffic from the Rivet gateway to it. It is the recommended way to run non-RivetKit software behind Rivet, such as a Unity or Godot dedicated game server. Each actor gets its own child process on its own port; how many actors share a container is decided by the pool's request concurrency, and the recommended game-server setup is one actor per container.
+The container runner (`rivet-container-runner`) runs as your container's entrypoint, spawning your server as a child process and proxying gateway HTTP and WebSocket traffic to it. It is the recommended way to run non-RivetKit software, such as Unity or Godot dedicated game servers, behind Rivet. Each actor gets its own child process; the pool's request concurrency decides how many actors share a container, and game servers should use one actor per container.
 
 ## Steps
 
@@ -88,12 +88,11 @@ The actor's `input` payload can override the launch spec per actor. All fields a
 {
 	"command": ["./GameServer", "-batchmode"],
 	"args": ["-extra-flag"],
-	"env": { "MATCH_MODE": "ranked" },
-	"port": 7777
+	"env": { "MATCH_MODE": "ranked" }
 }
 ```
 
-`command` replaces the entrypoint command template, `args` are appended to it, `env` adds environment variables for the child, and `port` overrides the child port.
+`command` replaces the entrypoint command template, `args` are appended to it, and `env` adds environment variables for the child.
 
 ## Source and Examples
 

--- a/website/src/content/docs/deploy/container-runner.mdx
+++ b/website/src/content/docs/deploy/container-runner.mdx
@@ -6,7 +6,17 @@ skill: true
 
 The container runner (`rivet-container-runner`) turns any container into a Rivet Actor host: as the entrypoint, it spawns your server as a child process and proxies HTTP and WebSocket traffic from the Rivet gateway to it. It is the recommended way to run non-RivetKit software behind Rivet, such as a Unity or Godot dedicated game server. Each actor gets its own child process on its own port; how many actors share a container is decided by the pool's request concurrency, and the recommended game-server setup is one actor per container.
 
-## Install in Your Container
+## Steps
+
+<Steps>
+<Step title="Prerequisites">
+
+- A containerized server (a Unity or Godot dedicated server, a plain Node process, or any HTTP/WebSocket server)
+- Access to the [Rivet Cloud](https://dashboard.rivet.dev/) or a [self-hosted Rivet Engine](/docs/general/self-hosting)
+- Docker running locally
+
+</Step>
+<Step title="Install in Your Container">
 
 Download the static binary from Rivet's release artifacts in your Dockerfile and set it as the entrypoint, passing your server's launch command after `--`:
 
@@ -27,6 +37,26 @@ ENTRYPOINT ["rivet-container-runner", "--", "./GameServer", "-batchmode", "-nogr
 ```
 
 Artifacts are published for `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl`. The binaries are fully static, so they run in any Linux base image, including `scratch`. Pin a version by replacing `latest` with a release version, for example `https://releases.rivet.dev/rivet/2.3.3/container-runner/rivet-container-runner-x86_64-unknown-linux-musl`.
+
+</Step>
+<Step title="Deploy">
+
+Deploy the image to [Rivet Compute](/docs/deploy/rivet-compute) with the CLI. For game servers, configure the pool with one actor per instance:
+
+```bash
+npx @rivetkit/cli deploy \
+	--token "$RIVET_CLOUD_TOKEN" \
+	--instance-request-concurrency 1 \
+	--dockerfile Dockerfile
+```
+
+</Step>
+<Step title="Create Actors and Connect Clients">
+
+Create actors against the pool's runner (`default`) and connect clients through the gateway URL shown in the dashboard. WebSocket clients connect at the bare gateway URL with the `rivet` WebSocket subprotocol.
+
+</Step>
+</Steps>
 
 ## How It Works
 
@@ -64,19 +94,6 @@ The actor's `input` payload can override the launch spec per actor. All fields a
 ```
 
 `command` replaces the entrypoint command template, `args` are appended to it, `env` adds environment variables for the child, and `port` overrides the child port.
-
-## Deploy
-
-Deploy the image to [Rivet Compute](/docs/deploy/rivet-compute) with the CLI. For game servers, configure the pool with one actor per instance:
-
-```bash
-npx @rivetkit/cli deploy \
-	--token "$RIVET_CLOUD_TOKEN" \
-	--instance-request-concurrency 1 \
-	--dockerfile Dockerfile
-```
-
-Then create actors against the pool's runner (`default`) and connect clients through the gateway URL shown in the dashboard.
 
 ## Source and Examples
 


### PR DESCRIPTION
docs(deploy): drop per-actor port override from container runner docs