### PR TITLE
fix(api): preserve method not allowed responses

### DIFF
--- a/engine/packages/api-public/Cargo.toml
+++ b/engine/packages/api-public/Cargo.toml
@@ -41,3 +41,6 @@ utoipa.workspace = true
 [build-dependencies]
 anyhow.workspace = true
 fs_extra.workspace = true
+
+[dev-dependencies]
+axum-test.workspace = true

--- a/engine/packages/api-public/src/router.rs
+++ b/engine/packages/api-public/src/router.rs
@@ -167,6 +167,7 @@ async fn auth_middleware(
 	// Verify auth was handled
 	if res.extensions().get::<FailedExtraction>().is_none()
 		&& method != reqwest::Method::OPTIONS
+		&& res.status() != reqwest::StatusCode::METHOD_NOT_ALLOWED
 		&& path != "/"
 		&& path != "/ui"
 		&& !path.starts_with("/ui/")

--- a/engine/packages/api-public/tests/router.rs
+++ b/engine/packages/api-public/tests/router.rs
@@ -1,0 +1,18 @@
+use axum::http::StatusCode;
+use axum_test::TestServer;
+
+#[tokio::test]
+async fn unsupported_route_method_returns_method_not_allowed() {
+	let config = rivet_config::Config::from_root(rivet_config::config::Root::default());
+	let pools = rivet_pools::Pools::new(config.clone())
+		.await
+		.expect("failed to create test pools");
+	let app = rivet_api_public::router(config, pools)
+		.await
+		.expect("failed to create router");
+	let server = TestServer::new(app).expect("failed to create test server");
+
+	let response = server.get("/actors/foo").await;
+
+	response.assert_status(StatusCode::METHOD_NOT_ALLOWED);
+}


### PR DESCRIPTION
- Preserve router-generated 405 responses instead of replacing them with auth developer errors.
- Add regression coverage for GET requests to routes that only support other methods.