### PR TITLE
fix(frontend): restore free plan usage limit banner in sidebarless layout

### DIFF
--- a/frontend/src/app/billing/billing-limit-alert.tsx
+++ b/frontend/src/app/billing/billing-limit-alert.tsx
@@ -1,13 +1,29 @@
 import { faExclamationTriangle, Icon } from "@rivet-gg/icons";
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "@tanstack/react-router";
+import { Link, useMatch } from "@tanstack/react-router";
 import { Button, cn } from "@/components";
 import { useCloudProjectDataProvider } from "@/components/actors";
+import { PLAN_LABELS } from "@/content/billing";
 import { features } from "@/lib/features";
 import { useHighestUsagePercent } from "./hooks";
 
 export function BillingLimitAlert() {
 	if (!features.billing) return null;
+	return <BillingLimitAlertGuard />;
+}
+
+// Billing is project-scoped, but this banner renders from the shared route
+// layout. `useMatch` with `shouldThrow: false` keeps it out of routes where
+// `useCloudProjectDataProvider` would throw, and waiting on `loaderData`
+// avoids reading the provider before the project loader resolves.
+function BillingLimitAlertGuard() {
+	const projectMatch = useMatch({
+		from: "/_context/orgs/$organization/projects/$project",
+		shouldThrow: false,
+	});
+
+	if (!projectMatch?.loaderData) return null;
+
 	return <BillingLimitAlertInner />;
 }
 
@@ -24,53 +40,47 @@ function BillingLimitAlertInner() {
 		return null;
 	}
 
+	const atLimit = usagePercent >= 100;
+
 	return (
 		<div
 			className={cn(
-				"mx-0.5 mb-2 p-2 rounded-md border  text-xs",
-				usagePercent < 100 && "border-warning/60 bg-warning/10",
-				usagePercent >= 100 &&
-					"border-destructive/60 bg-destructive/20",
+				"flex items-center gap-2 border-b px-3 py-1.5 text-xs",
+				atLimit
+					? "border-destructive/60 bg-destructive/15"
+					: "border-warning/60 bg-warning/10",
 			)}
 		>
-			<div className="flex items-start gap-2">
-				<Icon
-					icon={faExclamationTriangle}
-					className={cn(
-						"text-warning shrink-0 mt-0.5",
-						usagePercent >= 100 && "text-destructive",
-					)}
-				/>
-				<div className="flex-1 flex min-w-0 items-center justify-center">
-					<div className="flex-1">
-						<p className="text-foreground font-medium">
-							{usagePercent >= 100
-								? "Usage limit reached"
-								: "Approaching usage limit"}
-						</p>
-						<p className="text-muted-foreground mt-0.5">
-							{usagePercent >= 100
-								? "Upgrade to continue using Actors."
-								: `You have used ${usagePercent}% of your plan's free usage.`}
-						</p>
-					</div>
-					<div>
-						<Button
-							size="sm"
-							className="h-7 text-xs"
-							variant="ghost"
-							asChild
-						>
-							<Link
-								from="/orgs/$organization/projects/$project/ns/$namespace"
-								to="/orgs/$organization/projects/$project/ns/$namespace/billing"
-							>
-								Upgrade
-							</Link>
-						</Button>
-					</div>
-				</div>
-			</div>
+			<Icon
+				icon={faExclamationTriangle}
+				className={cn(
+					"shrink-0",
+					atLimit ? "text-destructive" : "text-warning",
+				)}
+			/>
+			<p className="text-foreground font-medium">
+				{atLimit
+					? `${PLAN_LABELS[plan] ?? "Plan"} plan limit reached`
+					: "Approaching your plan limit"}
+			</p>
+			<p className="text-muted-foreground min-w-0 truncate">
+				{atLimit
+					? "Upgrade your plan to avoid service interruptions."
+					: `You have used ${usagePercent}% of your plan's free usage.`}
+			</p>
+			<Button
+				size="sm"
+				variant="ghost"
+				className="ml-auto h-6 shrink-0 text-xs"
+				asChild
+			>
+				<Link
+					from="/orgs/$organization/projects/$project"
+					to="/orgs/$organization/projects/$project/billing"
+				>
+					Upgrade
+				</Link>
+			</Button>
 		</div>
 	);
 }

--- a/frontend/src/app/billing/billing-page.tsx
+++ b/frontend/src/app/billing/billing-page.tsx
@@ -20,8 +20,8 @@ import { type MetricType, UsageCard } from "@/app/billing/usage-card";
 import { HelpDropdown } from "@/app/help-dropdown";
 import { Button, H1 } from "@/components";
 import { useCloudProjectDataProvider } from "@/components/actors";
+import { BILLING, calculateOverageCost } from "@/content/billing";
 import { features } from "@/lib/features";
-import { BILLING } from "@/content/billing";
 import { Content } from "../layout";
 
 type BilledMetric = keyof typeof BILLING.prices;
@@ -73,16 +73,6 @@ const USAGE_METRICS: UsageMetricConfig[] = [
 		metricType: "bytes",
 	},
 ];
-
-function calculateOverageCost(
-	usage: bigint,
-	includedInPlan: bigint | undefined,
-	pricePerBillionUnits: bigint,
-): bigint {
-	if (!includedInPlan) return 0n;
-	const overage = usage > includedInPlan ? usage - includedInPlan : 0n;
-	return (overage * pricePerBillionUnits) / 1_000_000_000n;
-}
 
 /**
  * Namespace billing page. Billing is always project-scoped, so this renders the

--- a/frontend/src/app/billing/billing-plan-badge.tsx
+++ b/frontend/src/app/billing/billing-plan-badge.tsx
@@ -6,13 +6,7 @@ import {
 	useCloudProjectDataProvider,
 } from "@/components/actors";
 import { VisibilitySensor } from "@/components/visibility-sensor";
-
-const planLabels: Record<string, string> = {
-	free: "Free",
-	pro: "Hobby",
-	team: "Team",
-	enterprise: "Enterprise",
-};
+import { PLAN_LABELS } from "@/content/billing";
 
 const getPlanVariant = (
 	plan: string | undefined,
@@ -39,7 +33,7 @@ export function BillingPlanBadge() {
 			variant={getPlanVariant(plan)}
 			className="min-w-12 justify-center my-px"
 		>
-			{planLabels[plan]}
+			{PLAN_LABELS[plan]}
 		</Badge>
 	);
 }
@@ -71,7 +65,7 @@ export function LazyBillingPlanBadge({
 					variant={getPlanVariant(plan)}
 					className={cn("min-w-12 justify-center my-px", className)}
 				>
-					{planLabels[plan]}
+					{PLAN_LABELS[plan]}
 				</Badge>
 			)}
 			<VisibilitySensor onChange={() => setIsVisible(true)} />

--- a/frontend/src/app/billing/billing-usage-gauge.tsx
+++ b/frontend/src/app/billing/billing-usage-gauge.tsx
@@ -59,7 +59,11 @@ export function BillingUsageGauge() {
 			trigger={
 				<div
 					className={cn(
-						"rounded-full border size-6 flex items-center justify-center",
+						// Sized and margined to match `Badge`, which sits next to it
+						// in the billing row. Badge is 22px tall (text-xs leading +
+						// py-0.5 + border), so `size-6` made the circle read as
+						// oversized against it.
+						"rounded-full border size-[22px] my-px flex items-center justify-center",
 						progressColors[progressVariant].border,
 						progressColors[progressVariant].background,
 					)}
@@ -71,7 +75,7 @@ export function BillingUsageGauge() {
 						/>
 					) : (
 						<svg
-							className="h-6 w-6"
+							className="size-full"
 							viewBox="0 0 24 24"
 							fill="none"
 							strokeWidth="3"

--- a/frontend/src/app/billing/hooks.ts
+++ b/frontend/src/app/billing/hooks.ts
@@ -1,11 +1,11 @@
 import type { Rivet } from "@rivet-gg/cloud";
 import { useQuery } from "@tanstack/react-query";
 import { endOfMonth, startOfMonth } from "date-fns";
+import { sumComputeCost } from "@/app/metrics/compute-cost";
+import { COMPUTE_METRICS } from "@/app/metrics/constants";
 import { useCloudProjectDataProvider } from "@/components/actors";
 import { BILLING } from "@/content/billing";
 import { features } from "@/lib/features";
-import { COMPUTE_METRICS } from "@/app/metrics/constants";
-import { sumComputeCost } from "@/app/metrics/compute-cost";
 
 // Bucket size (seconds) for the month-to-date compute cost query. Cost is an
 // active-time-weighted sum, so the total is correct at any resolution; this
@@ -92,11 +92,12 @@ export function useHighestUsagePercent(): number {
 
 	const aggregated = useBilledMetrics();
 	const plan = billingData?.billing.activePlan || "free";
+	const planIncluded = BILLING.included[plan] ?? BILLING.included.free;
 
 	let highestPercent = 0;
 	for (const key of BILLED_METRICS) {
 		const current = aggregated?.[key] || 0n;
-		const included = BILLING.included[plan][key];
+		const included = planIncluded[key];
 		if (included && included > 0n) {
 			const percent = Number((current * 100n) / included);
 			if (percent > highestPercent) {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -57,7 +57,6 @@ import { ensureTrailingSlash } from "@/lib/utils";
 import type { RivetActorError } from "@/queries/types";
 import { TEST_IDS } from "@/utils/test-ids";
 import { ActorBuildsList } from "./actor-builds-list";
-import { BillingLimitAlert } from "./billing/billing-limit-alert";
 import { BillingPlanBadge } from "./billing/billing-plan-badge";
 import { BillingUsageGauge } from "./billing/billing-usage-gauge";
 import { Changelog } from "./changelog";
@@ -663,7 +662,6 @@ function CloudSidebarContentInner() {
 		<div className="flex gap-0.5 flex-col">
 			{hasDataProvider && hasQuery ? (
 				<div className="w-full pt-1.5">
-					<BillingLimitAlert />
 					<div className="flex gap-0.5 mb-2 flex-col">
 						{matchRoute({
 							to: "/orgs/$organization/projects/$project/ns/$namespace",

--- a/frontend/src/app/route-layout.tsx
+++ b/frontend/src/app/route-layout.tsx
@@ -3,6 +3,7 @@ import { useRef } from "react";
 import type { ImperativePanelHandle } from "react-resizable-panels";
 import { H2, Skeleton } from "@/components";
 import { RootLayoutContextProvider } from "@/components/actors/root-layout-context";
+import { BillingLimitAlert } from "./billing/billing-limit-alert";
 import { TopBar } from "./top-bar";
 
 export function RouteLayout({
@@ -15,6 +16,7 @@ export function RouteLayout({
 	return (
 		<div className="flex h-screen flex-col bg-background">
 			<TopBar />
+			<BillingLimitAlert />
 			<main className="flex flex-1 min-h-0 flex-col bg-background min-w-0 pl-2">
 				{/*
 				 * `isSidebarCollapsed: false` so the inner Content / ActorsListPreview

--- a/frontend/src/app/settings-pages/billing-panel.tsx
+++ b/frontend/src/app/settings-pages/billing-panel.tsx
@@ -31,9 +31,14 @@ import {
 	WithTooltip,
 } from "@/components";
 import { useCloudProjectDataProvider } from "@/components/actors";
-import { features } from "@/lib/features";
 import { TwinklingSparkles } from "@/components/twinkling-sparkles";
-import { BILLING, COMPUTE_MONTHLY_CAP_USD } from "@/content/billing";
+import {
+	BILLING,
+	COMPUTE_MONTHLY_CAP_USD,
+	calculateOverageCost,
+	PLAN_LABELS,
+} from "@/content/billing";
+import { features } from "@/lib/features";
 import { ResourcePicker } from "./resource-picker";
 import { SettingsCard } from "./settings-card";
 
@@ -85,13 +90,6 @@ const USAGE_METRICS: UsageMetricConfig[] = [
 	},
 ];
 
-const PLAN_LABEL: Record<string, string> = {
-	free: "Free",
-	pro: "Hobby",
-	team: "Team",
-	enterprise: "Enterprise",
-};
-
 const PLAN_PRICE: Record<string, string> = {
 	free: "$0/mo",
 	pro: "$20/mo",
@@ -105,16 +103,6 @@ const PLAN_BLURB: Record<string, string> = {
 	team: "For teams shipping production workloads.",
 	enterprise: "Dedicated infrastructure and support.",
 };
-
-function calculateOverageCost(
-	usage: bigint,
-	includedInPlan: bigint | undefined,
-	pricePerBillionUnits: bigint,
-): bigint {
-	if (!includedInPlan) return 0n;
-	const overage = usage > includedInPlan ? usage - includedInPlan : 0n;
-	return (overage * pricePerBillionUnits) / 1_000_000_000n;
-}
 
 export function BillingPanel() {
 	// Use `useMatch` with `shouldThrow: false` instead of `useMatchRoute` so we
@@ -298,7 +286,7 @@ function CurrentPlanCard({
 	plan: string;
 	onUpgrade: () => void;
 }) {
-	const label = PLAN_LABEL[plan] ?? "Free";
+	const label = PLAN_LABELS[plan] ?? "Free";
 	const price = PLAN_PRICE[plan] ?? "$0/mo";
 	const blurb = PLAN_BLURB[plan] ?? PLAN_BLURB.free;
 	return (
@@ -497,11 +485,17 @@ function ComputeUsageRow({
 				</div>
 			</div>
 			<div className="text-sm tabular-nums text-foreground">
-				{loading ? <Skeleton className="h-4 w-12" /> : formatCurrency(cost)}
+				{loading ? (
+					<Skeleton className="h-4 w-12" />
+				) : (
+					formatCurrency(cost)
+				)}
 			</div>
 			<div className="min-w-0">
 				<div className="text-xs text-muted-foreground">
-					{capUsd != null ? `of ${formatCurrency(capUsd)}` : "No limit"}
+					{capUsd != null
+						? `of ${formatCurrency(capUsd)}`
+						: "No limit"}
 				</div>
 				{capUsd != null ? (
 					<div className="relative h-1 rounded-full bg-foreground/10 mt-1">

--- a/frontend/src/content/billing.ts
+++ b/frontend/src/content/billing.ts
@@ -88,6 +88,25 @@ export const BILLING = {
 	} satisfies Record<BilledMetrics, bigint>,
 };
 
+/** Human-readable plan names. `pro` is presented as "Hobby". */
+export const PLAN_LABELS: Record<string, string> = {
+	free: "Free",
+	pro: "Hobby",
+	team: "Team",
+	enterprise: "Enterprise",
+};
+
+/** Overage charge in cents for usage beyond the plan's included allotment. */
+export function calculateOverageCost(
+	usage: bigint,
+	includedInPlan: bigint | undefined,
+	pricePerBillionUnits: bigint,
+): bigint {
+	if (!includedInPlan) return 0n;
+	const overage = usage > includedInPlan ? usage - includedInPlan : 0n;
+	return (overage * pricePerBillionUnits) / 1_000_000_000n;
+}
+
 /**
  * Rivet Compute pricing. Compute is billed per active second based on each
  * actor's configured CPU and memory.


### PR DESCRIPTION
- Restore the free plan usage limit banner, which had stopped rendering entirely: it lived in the old `layout.tsx` sidebar, and that sidebar is no longer mounted anywhere since the top bar replaced it. It now renders from `RouteLayout` as a full-width strip beneath the top bar.
- Guard the banner with a project route match so it stays out of routes where the project data provider is unavailable, and restyle it for full width rather than the old narrow sidebar column.
- Reword the at-limit message to "Free plan limit reached / Upgrade your plan to avoid service interruptions."
- Derive the plan name in that message from the active plan instead of hardcoding "Free". The banner only renders for the free plan today, so the string was correct, but it was correct only because of a guard a few lines above it. Warning paid plans about overage means removing that guard, which would otherwise have shown "Free plan limit reached" to a Team user.
- Share one `PLAN_LABELS` map from `content/billing.ts`, replacing the two identical copies in the plan badge and the billing settings panel.
- Size the usage gauge to match the plan badge sitting next to it (22px), so the circle no longer reads as oversized.
- Share a single `calculateOverageCost` from `content/billing.ts` instead of duplicating it in the billing page and the billing settings panel.
- Give `useHighestUsagePercent` the same included-allotment fallback its two sibling call sites already had.
