### PR TITLE
fix(publish): include actor socket protocol in previews

### DIFF
--- a/scripts/publish/src/ci/bin.ts
+++ b/scripts/publish/src/ci/bin.ts
@@ -47,6 +47,7 @@ const RUST_CRATES = [
 	"rivet-error",
 	"rivet-metrics",
 	"rivet-util-serde",
+	"rivet-actor-runtime-socket-protocol",
 	// rivet-envoy-protocol must precede rivet-depot-client, which pins it as an
 	// exact dependency. Publishing depot-client first makes cargo fail to
 	// resolve rivet-envoy-protocol because it is not yet on crates.io.

--- a/scripts/publish/src/lib/version.ts
+++ b/scripts/publish/src/lib/version.ts
@@ -50,6 +50,7 @@ const PUBLISHED_RUST_WORKSPACE_DEPS = new Set([
 	"rivet-error",
 	"rivet-metrics",
 	"rivet-util-serde",
+	"rivet-actor-runtime-socket-protocol",
 	"depot-client-types",
 	"depot-client",
 	"rivet-envoy-protocol",


### PR DESCRIPTION
- Include the Actor Runtime Socket protocol in preview Cargo version bumps.
- Publish the protocol crate before RivetKit core packages that depend on it.