### PR TITLE
fix(frontend): settings drawer alignment and changelog images

### DIFF
--- a/frontend/src/app/changelog.tsx
+++ b/frontend/src/app/changelog.tsx
@@ -62,7 +62,7 @@ export function ChangelogEntry({
 					</PictureFallback>
 					<PictureImage
 						className="size-full object-cover animate-in fade-in-0 duration-300 fill-mode-forwards"
-						src={`https://www.rivet.dev/${images[0].url}`}
+						src={images[0].url}
 						width={images[0].width}
 						height={images[0].height}
 						alt={"Changelog entry"}
@@ -89,7 +89,7 @@ export function ChangelogEntry({
 								{authors[0].name[0]}
 							</AvatarFallback>
 							<AvatarImage
-								src={`https://www.rivet.dev/${authors[0].avatar.url}`}
+								src={authors[0].avatar.url}
 								alt={authors[0].name}
 							/>
 						</Avatar>

--- a/frontend/src/app/dialogs/connect-provider-sheet.tsx
+++ b/frontend/src/app/dialogs/connect-provider-sheet.tsx
@@ -6,9 +6,9 @@ import { ErrorBoundary } from "react-error-boundary";
 import { cn, Frame, Skeleton, VisuallyHidden } from "@/components";
 import dialogStyles from "@/components/ui/dialog.module.css";
 
-// Match the settings drawer's `top: 60px` so all panels visually align with the
+// Match the settings drawer's `top: 56px` so all panels visually align with the
 // top bar / chrome below it.
-const TOP_BAR_OUTER_HEIGHT = "60px";
+const TOP_BAR_OUTER_HEIGHT = "56px";
 
 type FrameLoader = () => Promise<{
 	default: ComponentType<{ onClose?: () => void }>;

--- a/frontend/src/app/dialogs/edit-runner-config-sheet.tsx
+++ b/frontend/src/app/dialogs/edit-runner-config-sheet.tsx
@@ -10,9 +10,9 @@ const EditRunnerConfigFrameContent = lazy(
 	() => import("@/app/dialogs/edit-runner-config"),
 );
 
-// Match the settings drawer's `top: 60px` so both panels visually align with
+// Match the settings drawer's `top: 56px` so both panels visually align with
 // the top bar / chrome below it.
-const TOP_BAR_OUTER_HEIGHT = "60px";
+const TOP_BAR_OUTER_HEIGHT = "56px";
 
 interface EditRunnerConfigSheetProps {
 	open: boolean;

--- a/frontend/src/app/settings-drawer.tsx
+++ b/frontend/src/app/settings-drawer.tsx
@@ -119,9 +119,9 @@ interface SettingsDrawerProps {
 	onOpenChange: (open: boolean) => void;
 }
 
-// TopBar is `h-11` with `mt-2` (8 + 44 = 52px). Add another 8px gap to match the
-// content view's `my-2` so the drawer's top edge aligns with the card below.
-const TOP_BAR_OUTER_HEIGHT = "60px";
+// TopBar is a flush `h-12` bar (48px, border included). Add the content view's
+// `my-2` gap (8px) so the drawer's outline aligns with the card below.
+const TOP_BAR_OUTER_HEIGHT = "56px";
 
 export function SettingsDrawer({
 	open,

--- a/frontend/src/app/settings-pages/whats-new-panel.tsx
+++ b/frontend/src/app/settings-pages/whats-new-panel.tsx
@@ -86,7 +86,7 @@ function Entry({
 					</PictureFallback>
 					<PictureImage
 						className="size-full object-cover animate-in fade-in-0 duration-300 fill-mode-forwards"
-						src={`https://www.rivet.dev/${image.url}`}
+						src={image.url}
 						width={image.width}
 						height={image.height}
 						alt={title}
@@ -117,7 +117,7 @@ function Entry({
 									{author.name[0]}
 								</AvatarFallback>
 								<AvatarImage
-									src={`https://www.rivet.dev/${author.avatar.url}`}
+									src={author.avatar.url}
 									alt={author.name}
 								/>
 							</Avatar>

--- a/frontend/src/queries/global.ts
+++ b/frontend/src/queries/global.ts
@@ -105,6 +105,12 @@ const mutationCache = new MutationCache({
 	},
 });
 
+// changelog.json media URLs are absolute assets.rivet.dev URLs on current
+// entries but were site-relative paths historically. Resolve both shapes to
+// absolute URLs here so consumers can pass them straight to src attributes.
+const resolveChangelogMediaUrl = (url: string) =>
+	new URL(url, "https://www.rivet.dev/").toString();
+
 export const changelogQueryOptions = () => {
 	return queryOptions({
 		queryKey: ["changelog", __APP_BUILD_ID__],
@@ -115,7 +121,20 @@ export const changelogQueryOptions = () => {
 				throw new Error("Failed to fetch changelog");
 			}
 			const result = Changelog.parse(await response.json());
-			return result;
+			return result.map((entry) => ({
+				...entry,
+				images: entry.images.map((image) => ({
+					...image,
+					url: resolveChangelogMediaUrl(image.url),
+				})),
+				authors: entry.authors.map((author) => ({
+					...author,
+					avatar: {
+						...author.avatar,
+						url: resolveChangelogMediaUrl(author.avatar.url),
+					},
+				})),
+			}));
 		},
 	});
 };


### PR DESCRIPTION
- Align the settings drawer and the provider/runner-config side sheets with the dashboard content outline after the flush top bar change (top offset 60px to 56px)
- Resolve changelog media URLs at the query layer so absolute asset URLs pass through, fixing broken hero images and author avatars in the What's new panel and the sidebar changelog popover