### PR TITLE
fix(rivetkit): detect unsupported inspector workflows

### DIFF
--- a/rivetkit-typescript/packages/rivetkit-napi/src/napi_actor_events.rs
+++ b/rivetkit-typescript/packages/rivetkit-napi/src/napi_actor_events.rs
@@ -692,7 +692,8 @@ pub(crate) async fn dispatch_event(
 		}
 		ActorEvent::WorkflowHistoryRequested { reply } => {
 			let Some(callback) = bindings.get_workflow_history.clone() else {
-				reply.send(Ok(None));
+				// Dropped means unsupported; `Ok(None)` means supported without history.
+					drop(reply);
 				return;
 			};
 			let ctx = ctx.clone();

--- a/rivetkit-typescript/packages/rivetkit-napi/src/napi_actor_events.rs
+++ b/rivetkit-typescript/packages/rivetkit-napi/src/napi_actor_events.rs
@@ -703,7 +703,7 @@ pub(crate) async fn dispatch_event(
 		}
 		ActorEvent::WorkflowReplayRequested { entry_id, reply } => {
 			let Some(callback) = bindings.replay_workflow.clone() else {
-				reply.send(Ok(None));
+				drop(reply);
 				return;
 			};
 			let ctx = ctx.clone();

--- a/rivetkit-typescript/packages/rivetkit-napi/src/napi_actor_events.rs
+++ b/rivetkit-typescript/packages/rivetkit-napi/src/napi_actor_events.rs
@@ -693,7 +693,7 @@ pub(crate) async fn dispatch_event(
 		ActorEvent::WorkflowHistoryRequested { reply } => {
 			let Some(callback) = bindings.get_workflow_history.clone() else {
 				// Dropped means unsupported; `Ok(None)` means supported without history.
-					drop(reply);
+				drop(reply);
 				return;
 			};
 			let ctx = ctx.clone();

--- a/rivetkit-typescript/packages/rivetkit-napi/tests/napi_actor_events.rs
+++ b/rivetkit-typescript/packages/rivetkit-napi/tests/napi_actor_events.rs
@@ -276,7 +276,7 @@ mod moved_tests {
 	}
 
 	#[tokio::test]
-	async fn workflow_history_without_callback_drops_reply_and_replay_returns_none() {
+	async fn workflow_requests_without_callbacks_drop_replies() {
 		let bindings = Arc::new(empty_bindings());
 		let config = test_adapter_config();
 		let core_ctx = actor_context("actor-workflow", "actor", Vec::new(), "local");
@@ -325,13 +325,13 @@ mod moved_tests {
 		let history_error = RivetTransportError::extract(&history_error);
 		assert_eq!(history_error.group(), "actor");
 		assert_eq!(history_error.code(), "dropped_reply");
-		assert_eq!(
-			replay_rx
-				.await
-				.expect("workflow replay reply should resolve")
-				.expect("workflow replay should succeed"),
-			None
-		);
+		let replay_error = replay_rx
+			.await
+			.expect("workflow replay reply should resolve")
+			.expect_err("workflow replay without a callback should drop its reply");
+		let replay_error = RivetTransportError::extract(&replay_error);
+		assert_eq!(replay_error.group(), "actor");
+		assert_eq!(replay_error.code(), "dropped_reply");
 	}
 
 	#[tokio::test]

--- a/rivetkit-typescript/packages/rivetkit-napi/tests/napi_actor_events.rs
+++ b/rivetkit-typescript/packages/rivetkit-napi/tests/napi_actor_events.rs
@@ -276,7 +276,7 @@ mod moved_tests {
 	}
 
 	#[tokio::test]
-	async fn workflow_requests_without_callbacks_return_none() {
+	async fn workflow_history_without_callback_drops_reply_and_replay_returns_none() {
 		let bindings = Arc::new(empty_bindings());
 		let config = test_adapter_config();
 		let core_ctx = actor_context("actor-workflow", "actor", Vec::new(), "local");
@@ -318,13 +318,13 @@ mod moved_tests {
 
 		drain_tasks(&mut tasks, &mut registered_task_rx).await;
 
-		assert_eq!(
-			history_rx
-				.await
-				.expect("workflow history reply should resolve")
-				.expect("workflow history should succeed"),
-			None
-		);
+		let history_error = history_rx
+			.await
+			.expect("workflow history reply should resolve")
+			.expect_err("workflow history without a callback should drop its reply");
+		let history_error = RivetTransportError::extract(&history_error);
+		assert_eq!(history_error.group(), "actor");
+		assert_eq!(history_error.code(), "dropped_reply");
 		assert_eq!(
 			replay_rx
 				.await

--- a/rivetkit-typescript/packages/rivetkit-wasm/src/lib.rs
+++ b/rivetkit-typescript/packages/rivetkit-wasm/src/lib.rs
@@ -778,10 +778,11 @@ async fn dispatch_event(callbacks: &WasmCallbacks, ctx: &WasmActorContext, event
 			reply.send(result);
 		}
 		ActorEvent::WorkflowReplayRequested { entry_id, reply } => {
+			let Some(callback) = callbacks.replay_workflow.as_ref() else {
+				drop(reply);
+				return;
+			};
 			let result = async {
-				let Some(callback) = callbacks.replay_workflow.as_ref() else {
-					return Ok(None);
-				};
 				let payload = object();
 				set_anyhow(&payload, "ctx", JsValue::from(ctx.clone()))?;
 				if let Some(entry_id) = entry_id {

--- a/rivetkit-typescript/packages/rivetkit-wasm/src/lib.rs
+++ b/rivetkit-typescript/packages/rivetkit-wasm/src/lib.rs
@@ -756,11 +756,11 @@ async fn dispatch_event(callbacks: &WasmCallbacks, ctx: &WasmActorContext, event
 			}
 		}
 		ActorEvent::WorkflowHistoryRequested { reply } => {
-				let Some(callback) = callbacks.get_workflow_history.as_ref() else {
-					// Dropped means unsupported; `Ok(None)` means supported without history.
-					drop(reply);
-					return;
-				};
+			let Some(callback) = callbacks.get_workflow_history.as_ref() else {
+				// Dropped means unsupported; `Ok(None)` means supported without history.
+				drop(reply);
+				return;
+			};
 			let result = async {
 				let payload = object();
 				set_anyhow(&payload, "ctx", JsValue::from(ctx.clone()))?;

--- a/rivetkit-typescript/packages/rivetkit-wasm/src/lib.rs
+++ b/rivetkit-typescript/packages/rivetkit-wasm/src/lib.rs
@@ -756,10 +756,12 @@ async fn dispatch_event(callbacks: &WasmCallbacks, ctx: &WasmActorContext, event
 			}
 		}
 		ActorEvent::WorkflowHistoryRequested { reply } => {
-			let result = async {
 				let Some(callback) = callbacks.get_workflow_history.as_ref() else {
-					return Ok(None);
+					// Dropped means unsupported; `Ok(None)` means supported without history.
+					drop(reply);
+					return;
 				};
+			let result = async {
 				let payload = object();
 				set_anyhow(&payload, "ctx", JsValue::from(ctx.clone()))?;
 				let value = call_callback(callback, &payload.into()).await?;

--- a/rivetkit-typescript/packages/rivetkit/tests/driver/actor-inspector.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/driver/actor-inspector.test.ts
@@ -313,6 +313,25 @@ describeDriverMatrix("Actor Inspector", (driverTestConfig) => {
 				await waitForInspectorOpen(ws);
 				const init = await waitForInspectorMessageWithTag(ws, "Init");
 				expect(init.body.val.isWorkflowEnabled).toBe(false);
+
+				const replayResponse = waitForInspectorMessageWithTag(
+					ws,
+					"WorkflowReplayResponse",
+				);
+				ws.send(
+					TO_SERVER_VERSIONED.serialize(
+						{
+							body: {
+								tag: "WorkflowReplayRequest",
+								val: { id: 1n, entryId: null },
+							},
+						},
+						INSPECTOR_PROTOCOL_VERSION,
+					),
+				);
+				expect((await replayResponse).body.val.isWorkflowEnabled).toBe(
+					false,
+				);
 			} finally {
 				ws.close();
 			}

--- a/rivetkit-typescript/packages/rivetkit/tests/driver/actor-inspector.test.ts
+++ b/rivetkit-typescript/packages/rivetkit/tests/driver/actor-inspector.test.ts
@@ -295,6 +295,29 @@ describeDriverMatrix("Actor Inspector", (driverTestConfig) => {
 			expect(count).toBe(42);
 		});
 
+		test("inspector websocket Init disables workflows for non-workflow actors", async (c) => {
+			const { client } = await setupDriverTest(c, driverTestConfig);
+			const handle = client.counter.getOrCreate([
+				"inspector-init-workflow-disabled",
+			]);
+
+			await handle.increment(0);
+			const gatewayUrl = await handle.getGatewayUrl();
+			const ws = new WebSocket(buildInspectorWebSocketUrl(gatewayUrl), [
+				"rivet",
+				"rivet_inspector_token.token",
+			]);
+			ws.binaryType = "arraybuffer";
+
+			try {
+				await waitForInspectorOpen(ws);
+				const init = await waitForInspectorMessageWithTag(ws, "Init");
+				expect(init.body.val.isWorkflowEnabled).toBe(false);
+			} finally {
+				ws.close();
+			}
+		});
+
 		test("PATCH /inspector/state pushes StateUpdated over inspector websocket", async (c) => {
 			const { client } = await setupDriverTest(c, driverTestConfig);
 			const handle = client.counter.getOrCreate([


### PR DESCRIPTION
## Summary
- report inspector workflows as unsupported when no history callback is registered
- keep supported workflows with empty history distinct from unsupported workflows
- align native and WASM behavior
- add unit and cross-runtime WebSocket regression coverage

## Verification
- `git diff --check`
- `npx --yes @biomejs/biome@2.3.0 check rivetkit-typescript/packages/rivetkit/tests/driver/actor-inspector.test.ts` (passes with one pre-existing non-null assertion warning)

Rust and driver tests were not run because the orb does not have Rust or workspace dependencies installed.