### PR TITLE
chore: configure frontend orb environment

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:$PATH"
+
+amp orb services ensure

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+node_version=22.17.1
+
+if ! command -v node >/dev/null || ! node -e 'process.exit(Number(process.versions.node.split(".")[0]) >= 22 ? 0 : 1)'; then
+	echo "Installing Node.js v${node_version}..."
+	archive="node-v${node_version}-linux-x64.tar.xz"
+	install_dir="$HOME/.local/node-v${node_version}"
+	mkdir -p "$install_dir" "$HOME/.local/bin"
+	curl --fail --location --silent --show-error \
+		"https://nodejs.org/dist/v${node_version}/${archive}" \
+		--output "/tmp/${archive}"
+	tar -xJf "/tmp/${archive}" --strip-components=1 --directory "$install_dir"
+	ln -sf "$install_dir/bin/node" "$HOME/.local/bin/node"
+	ln -sf "$install_dir/bin/corepack" "$HOME/.local/bin/corepack"
+	ln -sf "$install_dir/bin/npm" "$HOME/.local/bin/npm"
+	ln -sf "$install_dir/bin/npx" "$HOME/.local/bin/npx"
+	rm -f "/tmp/${archive}"
+fi
+
+export PATH="$HOME/.local/bin:$PATH"
+
+echo "Enabling the repository's pinned pnpm version..."
+corepack enable --install-directory "$HOME/.local/bin"
+corepack install --global pnpm@10.13.1
+
+echo "Installing workspace dependencies..."
+pnpm install --frozen-lockfile
+
+echo "Building frontend workspace dependencies..."
+SKIP_NAPI_BUILD=1 SKIP_WASM_BUILD=1 pnpm exec turbo run build --filter='@rivetkit/engine-frontend^...'
+
+echo "Preparing agent directories and Git hooks..."
+scripts/setup/agents-dir.sh
+pnpm exec lefthook install
+
+echo "Starting declared orb services..."
+amp orb services ensure

--- a/.amp/services.yaml
+++ b/.amp/services.yaml
@@ -1,0 +1,12 @@
+services:
+  frontend:
+    command: >-
+      PATH="$HOME/.local/bin:$PATH"
+      VITE_APP_API_URL=https://api.staging.rivet.dev/
+      VITE_APP_CLOUD_API_URL=https://cloud-api.staging.rivet.dev/
+      VITE_DEPLOYMENT_TYPE=staging
+      pnpm --dir frontend dev --host 0.0.0.0 --port "$PORT" --strictPort
+    port: 43708
+    portal:
+      title: Frontend
+      description: Rivet dashboard Vite development server.

--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,8 @@ scripts/ralph/codex-streams/
 # Agent working files now live user-scoped in ~/.agents (or $AGENTS_DIR).
 # This entry is a safety net so a stray in-repo .agent/ never gets committed.
 .agent/
-.amp/
+.amp/*
+!.amp/services.yaml
 
 # Container runner examples: e2e local state
 container-runner/examples/e2e-test/.bin/


### PR DESCRIPTION
- Add reusable orb setup and resume hooks for frontend development
- Build frontend workspace dependencies before starting the Vite service
- Run the frontend against staging APIs through a supervised orb portal