### PR TITLE
fix(integrations): validate Vercel Eve quickstart

### DIFF
--- a/website/src/content/docs/integrations/vercel-eve.mdx
+++ b/website/src/content/docs/integrations/vercel-eve.mdx
@@ -39,7 +39,7 @@ cd my-agent
 npm add @rivet-dev/agentos @rivet-dev/agentos-eve @rivet-dev/vercel-world
 ```
 
-- `@rivet-dev/agentos`: Provides the durable VM actor.
+- `@rivet-dev/agentos`: Provides the agentOS VM.
 - `@rivet-dev/agentos-eve`: Connects Eve's sandbox API to agentOS.
 - `@rivet-dev/vercel-world`: Runs Eve workflows on [Rivet World](https://workflow-sdk.dev/worlds).
 
@@ -53,6 +53,7 @@ Update `agent/agent.ts`:
 import { defineAgent } from "eve";
 
 export default defineAgent({
+	model: "anthropic/claude-sonnet-5",
 	build: {
 		externalDependencies: [
 			"@rivet-dev/agentos",
@@ -65,14 +66,42 @@ export default defineAgent({
 		],
 	},
 	experimental: {
-		workflow: { world: "./world.ts" },
+		workflow: { world: "#world" },
 	},
 });
 ```
 
 </Step>
 
-<Step title="Register agentOS and Vercel World">
+<Step title="Configure Rivet World">
+
+Rivet World lets you run Eve on top of Rivet.
+
+Add the World module import to `package.json`:
+
+```json title="package.json"
+{
+	"imports": {
+		"#world": "./world.ts"
+	}
+}
+```
+
+Create `world.ts`:
+
+```ts title="world.ts"
+import { createWorld as createRivetWorld } from "@rivet-dev/vercel-world";
+import { registry } from "./registry";
+
+export const createWorld = () => createRivetWorld({ registry });
+```
+
+The first World operation starts this registry and waits for the Rivet envoy to
+be ready.
+
+</Step>
+
+<Step title="Configure agentOS">
 
 Create `registry.ts`:
 
@@ -92,26 +121,6 @@ export const registry = setup({
 });
 ```
 
-</Step>
-
-<Step title="Connect Eve to the combined registry">
-
-Create `world.ts`:
-
-```ts title="world.ts"
-import { createWorld as createRivetWorld } from "@rivet-dev/vercel-world";
-import { registry } from "./registry";
-
-export const createWorld = () => createRivetWorld({ registry });
-```
-
-The first World operation starts this registry and waits for the Rivet envoy to
-be ready.
-
-</Step>
-
-<Step title="Use agentOS as the sandbox">
-
 Create `agent/sandbox.ts`:
 
 ```ts title="agent/sandbox.ts"
@@ -128,10 +137,16 @@ export default defineSandbox({
 
 <Step title="Run Eve">
 
-Run the agent:
+Link Eve to Vercel once so it can call your configured model:
 
 ```sh
-eve dev
+npm exec -- eve link
+```
+
+Then run the agent:
+
+```sh
+npm exec -- eve dev
 ```
 
 </Step>
@@ -155,4 +170,3 @@ agentOS is a drop-in replacement for any Eve sandbox backend.
 Rivet World stores Eve's runs in Rivet Actors so agents resume instead of restarting.
 
 [Read the Rivet World + Vercel Eve documentation →](/integrations/vercel-workflows)
-


### PR DESCRIPTION
- Correct the Vercel Eve setup for the published Eve release.
- Consolidate the Rivet World and agentOS configuration steps.
- Add the required model linking and launch commands.