### PR TITLE
feat(frontend): add impersonation banner with stop-impersonating action

### DIFF
--- a/frontend/src/app/impersonation-banner.tsx
+++ b/frontend/src/app/impersonation-banner.tsx
@@ -1,0 +1,45 @@
+import { faRightFromBracket, faUserSecret, Icon } from "@rivet-gg/icons";
+import { useMutation } from "@tanstack/react-query";
+import { Button } from "@/components";
+import { authClient } from "@/lib/auth";
+import { queryClient } from "@/queries/global";
+
+export function ImpersonationBanner() {
+	const { data: session } = authClient.useSession();
+
+	const stopImpersonating = useMutation({
+		mutationFn: async () => {
+			const result = await authClient.admin.stopImpersonating();
+			if (result.error) {
+				throw new Error(
+					result.error.message ?? "Failed to stop impersonating",
+				);
+			}
+		},
+		onSuccess: () => {
+			queryClient.clear();
+			window.location.href = "/";
+		},
+	});
+
+	if (!session?.session?.impersonatedBy) return null;
+
+	return (
+		<div className="fixed inset-x-0 bottom-0 z-50 flex items-center justify-center gap-3 border-t border-destructive/40 bg-destructive px-4 py-2 text-sm text-destructive-foreground">
+			<Icon icon={faUserSecret} className="size-4" />
+			<span>
+				You are impersonating{" "}
+				<strong>{session.user?.email ?? "another user"}</strong>.
+			</span>
+			<Button
+				variant="secondary"
+				size="sm"
+				isLoading={stopImpersonating.isPending}
+				startIcon={<Icon icon={faRightFromBracket} />}
+				onClick={() => stopImpersonating.mutate()}
+			>
+				Stop impersonating
+			</Button>
+		</div>
+	);
+}

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,5 +1,5 @@
 import { notFound, redirect } from "@tanstack/react-router";
-import { organizationClient } from "better-auth/client/plugins";
+import { adminClient, organizationClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 import { cloudEnv } from "./env";
 import { features } from "./features";
@@ -8,7 +8,7 @@ const createClient = () =>
 	createAuthClient({
 		baseURL: cloudEnv().VITE_APP_CLOUD_API_URL,
 		fetchOptions: { credentials: "include" },
-		plugins: [organizationClient()],
+		plugins: [organizationClient(), adminClient()],
 	});
 
 type AuthClient = ReturnType<typeof createClient>;

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import type {
 	ProjectContext,
 } from "@/app/data-providers/cache";
 import { DevToolbar } from "@/app/dev-toolbar";
+import { ImpersonationBanner } from "@/app/impersonation-banner";
 import { FullscreenLoading } from "@/components";
 import { features } from "@/lib/features";
 
@@ -29,6 +30,7 @@ function CloudRoute() {
 	return (
 		<>
 			<Outlet />
+			<ImpersonationBanner />
 			<DevToolbar />
 			{import.meta.env.DEV ? (
 				<TanStackRouterDevtools position="bottom-right" />


### PR DESCRIPTION
- Add a fixed bottom banner shown while an admin is impersonating another user, with a "Stop impersonating" action.
- Enable the Better Auth admin client so the session's impersonation state is available on the frontend.
- Stopping impersonation restores the original admin session, clears cached queries, and reloads the app.
- Banner is scoped to the cloud/platform flavor.