### PR TITLE
fix(cli): pass RIVET_ENDPOINT to supabase edge functions in dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6211,6 +6211,7 @@ name = "rivetkit-engine-process"
 version = "2.3.7"
 dependencies = [
  "anyhow",
+ "libc",
  "reqwest 0.12.22",
  "rivet-error",
  "serde",

--- a/engine/packages/cli/Cargo.toml
+++ b/engine/packages/cli/Cargo.toml
@@ -20,10 +20,8 @@ reqwest-eventsource.workspace = true
 rivetkit-engine-process.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tempfile.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
-
-[dev-dependencies]
-tempfile.workspace = true

--- a/engine/packages/cli/src/commands/dev.rs
+++ b/engine/packages/cli/src/commands/dev.rs
@@ -1,16 +1,18 @@
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
 use clap::{Parser, ValueEnum};
 use reqwest::Client;
-use rivetkit_engine_process::EngineProcessManager;
+use rivetkit_engine_process::{EngineProcessManager, EngineStartup};
 use serde_json::json;
+use tempfile::NamedTempFile;
 use tokio::process::{Child, Command};
 
 use crate::{
-	DEFAULT_ENGINE_ENDPOINT, LOCAL_NAMESPACE, POOL_NAME, SUPABASE_FN_DEFAULT,
-	engine_runner::engine_config, util::encode,
+	DEFAULT_ENGINE_ENDPOINT, LOCAL_NAMESPACE, POOL_NAME, SUPABASE_ENGINE_ENDPOINT,
+	SUPABASE_FN_DEFAULT, engine_runner::engine_config, util::encode,
 };
 
 const HANDLER_METADATA_TIMEOUT: Duration = Duration::from_secs(30);
@@ -72,11 +74,19 @@ impl Opts {
 			return Ok(());
 		}
 
-		let plan = HandlerPlan::resolve(&self)?;
+		let plan = HandlerPlan::resolve(&self, config.public_url.as_deref())?;
+
+		// Captured before `config` is moved into the engine manager below, so a
+		// reused engine's advertised endpoint can be compared against it.
+		let needed_public_url = config.public_url.clone();
 
 		// Start (or reuse) the engine. The engine is intentionally orphaned, so
 		// it survives this process and a later `rivet dev` reattaches to it.
-		let _engine = EngineProcessManager::start_or_reuse(config).await?;
+		let engine = EngineProcessManager::start_or_reuse(config).await?;
+
+		if self.provider == Some(Provider::Supabase) {
+			check_supabase_engine_reuse(engine.startup(), needed_public_url.as_deref())?;
+		}
 
 		let mut child = plan.spawn()?;
 
@@ -133,11 +143,15 @@ struct HandlerPlan {
 	program: String,
 	args: Vec<String>,
 	env: Vec<(String, String)>,
+	/// Kept alive so the generated Supabase env file outlives the spawned
+	/// dev server.
+	_env_file: Option<NamedTempFile>,
 }
 
 impl HandlerPlan {
-	fn resolve(opts: &Opts) -> Result<Self> {
+	fn resolve(opts: &Opts, engine_endpoint: Option<&str>) -> Result<Self> {
 		let provider = opts.provider;
+		let mut env_file = None;
 		let port = resolve_port(provider, opts.port, opts.url.is_some())?;
 		let handler_url = match &opts.url {
 			Some(url) => url.clone(),
@@ -169,6 +183,17 @@ impl HandlerPlan {
 					opts.fn_name.clone(),
 					"--no-verify-jwt".to_string(),
 				];
+				// `supabase functions serve` does not forward this process's
+				// environment to the edge runtime worker, so the endpoint has to
+				// reach the function through an env file. A user-supplied
+				// `--env-file` owns the value instead.
+				if supabase_env_file(&opts.command).is_none() {
+					let endpoint = engine_endpoint.unwrap_or(SUPABASE_ENGINE_ENDPOINT);
+					let file = write_supabase_env_file(endpoint)?;
+					args.push("--env-file".to_string());
+					args.push(file.path().display().to_string());
+					env_file = Some(file);
+				}
 				args.extend(opts.command.iter().cloned());
 				("npx".to_string(), args, Vec::new())
 			}
@@ -190,6 +215,7 @@ impl HandlerPlan {
 			program,
 			args,
 			env,
+			_env_file: env_file,
 		})
 	}
 
@@ -262,13 +288,30 @@ fn resolve_engine_public_url(opts: &Opts) -> Result<Option<String>> {
 		return Ok(Some(endpoint));
 	}
 
-	Ok(None)
+	Ok(Some(SUPABASE_ENGINE_ENDPOINT.to_string()))
+}
+
+fn write_supabase_env_file(endpoint: &str) -> Result<NamedTempFile> {
+	let mut file = NamedTempFile::new().context("create supabase env file")?;
+	writeln!(file, "RIVET_ENDPOINT={endpoint}").context("write supabase env file")?;
+	file.flush().context("flush supabase env file")?;
+	Ok(file)
 }
 
 fn supabase_env_file(command: &[String]) -> Option<PathBuf> {
-	command
-		.windows(2)
-		.find_map(|window| (window[0] == "--env-file").then(|| PathBuf::from(&window[1])))
+	// The Supabase CLI is pflag-based, so it accepts both `--env-file value` and
+	// `--env-file=value`. Detect both so a user override is never missed and
+	// silently overridden by the auto-injected temp file.
+	let mut iter = command.iter();
+	while let Some(arg) = iter.next() {
+		if let Some(value) = arg.strip_prefix("--env-file=") {
+			return Some(PathBuf::from(value));
+		}
+		if arg == "--env-file" {
+			return iter.next().map(PathBuf::from);
+		}
+	}
+	None
 }
 
 fn read_env_value(key: &str) -> Option<String> {
@@ -352,6 +395,74 @@ async fn register_runner_config(endpoint: &str, runner: &str, handler_url: &str)
 	Ok(())
 }
 
+/// Validates that an engine `rivet dev --provider supabase` is about to reuse is
+/// actually usable by the Supabase edge runtime.
+///
+/// The edge runtime runs in a container and reaches the engine through a
+/// non-loopback host address, so a loopback-only engine is unreachable no matter
+/// what `RIVET_ENDPOINT` says, and an engine advertising a different public URL
+/// gets rejected with an endpoint mismatch. A freshly spawned engine is
+/// configured correctly by construction, so only the reused case is uncertain,
+/// and it is decided from the engine's runtime stamp rather than a network probe.
+///
+/// A loopback binding is a hard failure (deterministic and unrecoverable). A
+/// public-URL difference only warns: matching mirrors the engine's own endpoint
+/// normalization, so we avoid blocking a setup the engine would actually accept.
+fn check_supabase_engine_reuse(
+	startup: &EngineStartup,
+	needed_public_url: Option<&str>,
+) -> Result<()> {
+	let stamp = match startup {
+		// Just spawned with the requested configuration; nothing to verify.
+		EngineStartup::Spawned => return Ok(()),
+		EngineStartup::Reused { stamp } => stamp,
+	};
+
+	let Some(stamp) = stamp else {
+		// No usable stamp: an engine from an older CLI or one started by hand. We
+		// cannot tell how it is configured, so warn rather than block a setup
+		// that may be fine.
+		tracing::warn!(
+			"reusing an already-running engine whose configuration is unknown; if the Supabase \
+			 edge runtime cannot reach it, stop the engine and re-run `rivet dev`"
+		);
+		return Ok(());
+	};
+
+	if stamp.binds_loopback_only() {
+		bail!(
+			"a Rivet engine is already running but is bound to loopback only ({}), so the Supabase \
+			 edge runtime cannot reach it from its container. This usually means an engine from a \
+			 previous `rivet dev` (a different provider or an older CLI) is still running. Stop it \
+			 and re-run `rivet dev` so the engine rebinds for Supabase.",
+			stamp.bind_host
+		);
+	}
+
+	if let Some(needed) = needed_public_url {
+		let advertised = stamp.public_url.as_deref();
+		if !advertised.is_some_and(|url| public_urls_match(url, needed)) {
+			tracing::warn!(
+				advertised = advertised.unwrap_or("none"),
+				needed,
+				"reusing an already-running engine that advertises a different endpoint than this \
+				 project needs; the Supabase edge runtime may be rejected with an endpoint \
+				 mismatch. If actors fail to start, stop the engine and re-run `rivet dev`"
+			);
+		}
+	}
+
+	Ok(())
+}
+
+/// Loose endpoint equality for the reuse warning: trailing-slash and
+/// case-insensitive. Deliberately lenient so an equivalent endpoint spelled
+/// differently does not warn; the engine performs the authoritative match.
+fn public_urls_match(a: &str, b: &str) -> bool {
+	a.trim_end_matches('/')
+		.eq_ignore_ascii_case(b.trim_end_matches('/'))
+}
+
 async fn wait_for_handler_metadata(handler_url: &str) -> Result<()> {
 	let metadata_url = format!("{}/metadata", handler_url.trim_end_matches('/'));
 	let client = Client::new();
@@ -391,6 +502,72 @@ async fn wait_for_handler_metadata(handler_url: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use rivetkit_engine_process::EngineRuntimeStamp;
+
+	fn stamp(bind_host: &str, public_url: Option<&str>) -> EngineRuntimeStamp {
+		EngineRuntimeStamp {
+			pid: std::process::id(),
+			endpoint: DEFAULT_ENGINE_ENDPOINT.to_string(),
+			bind_host: bind_host.to_string(),
+			public_url: public_url.map(str::to_string),
+		}
+	}
+
+	const SUPABASE_URL: &str = "http://host.docker.internal:6420";
+
+	#[test]
+	fn supabase_reuse_ok_when_freshly_spawned() {
+		assert!(check_supabase_engine_reuse(&EngineStartup::Spawned, Some(SUPABASE_URL)).is_ok());
+	}
+
+	#[test]
+	fn supabase_reuse_ok_when_engine_binds_all_interfaces_and_matches_url() {
+		let startup = EngineStartup::Reused {
+			stamp: Some(stamp("0.0.0.0", Some(SUPABASE_URL))),
+		};
+		assert!(check_supabase_engine_reuse(&startup, Some(SUPABASE_URL)).is_ok());
+	}
+
+	#[test]
+	fn supabase_reuse_fails_when_engine_is_loopback() {
+		let startup = EngineStartup::Reused {
+			stamp: Some(stamp("127.0.0.1", Some(SUPABASE_URL))),
+		};
+		let error = check_supabase_engine_reuse(&startup, Some(SUPABASE_URL))
+			.unwrap_err()
+			.to_string();
+		assert!(error.contains("loopback"));
+		assert!(error.contains("127.0.0.1"));
+	}
+
+	#[test]
+	fn supabase_reuse_ok_when_binding_unknown() {
+		let startup = EngineStartup::Reused { stamp: None };
+		assert!(check_supabase_engine_reuse(&startup, Some(SUPABASE_URL)).is_ok());
+	}
+
+	#[test]
+	fn supabase_reuse_ok_but_warns_on_public_url_mismatch() {
+		// A reachable engine advertising a different endpoint only warns, so the
+		// call still succeeds.
+		let startup = EngineStartup::Reused {
+			stamp: Some(stamp("0.0.0.0", Some("http://127.0.0.1:6420"))),
+		};
+		assert!(check_supabase_engine_reuse(&startup, Some(SUPABASE_URL)).is_ok());
+	}
+
+	#[test]
+	fn public_urls_match_is_lenient_on_trailing_slash_and_case() {
+		assert!(public_urls_match(
+			"http://host.docker.internal:6420",
+			"http://host.docker.internal:6420/"
+		));
+		assert!(public_urls_match("http://HOST:6420", "http://host:6420"));
+		assert!(!public_urls_match(
+			"http://127.0.0.1:6420",
+			"http://host.docker.internal:6420"
+		));
+	}
 
 	fn opts(provider: Option<Provider>) -> Opts {
 		Opts {
@@ -405,7 +582,7 @@ mod tests {
 
 	#[test]
 	fn cloudflare_provider_uses_default_port_and_wrangler_command() {
-		let plan = HandlerPlan::resolve(&opts(Some(Provider::Cloudflare))).unwrap();
+		let plan = HandlerPlan::resolve(&opts(Some(Provider::Cloudflare)), None).unwrap();
 
 		assert_eq!(plan.handler_url, "http://127.0.0.1:8787/api/rivet");
 		assert_eq!(plan.program, "npx");
@@ -429,7 +606,7 @@ mod tests {
 		opts.port = Some(8788);
 		opts.command = vec!["--local-protocol".into(), "http".into()];
 
-		let plan = HandlerPlan::resolve(&opts).unwrap();
+		let plan = HandlerPlan::resolve(&opts, None).unwrap();
 
 		assert_eq!(plan.handler_url, "http://127.0.0.1:8788/api/rivet");
 		assert_eq!(
@@ -449,7 +626,7 @@ mod tests {
 
 	#[test]
 	fn supabase_provider_uses_default_port_function_and_no_verify_jwt() {
-		let plan = HandlerPlan::resolve(&opts(Some(Provider::Supabase))).unwrap();
+		let plan = HandlerPlan::resolve(&opts(Some(Provider::Supabase)), None).unwrap();
 
 		assert_eq!(
 			plan.handler_url,
@@ -457,10 +634,36 @@ mod tests {
 		);
 		assert_eq!(plan.program, "npx");
 		assert_eq!(
-			plan.args,
+			plan.args[..5],
 			["supabase", "functions", "serve", "rivet", "--no-verify-jwt"]
 		);
+		assert_eq!(plan.args[5], "--env-file");
 		assert!(plan.env.is_empty());
+
+		let written = std::fs::read_to_string(&plan.args[6]).unwrap();
+		assert_eq!(
+			written.trim(),
+			format!("RIVET_ENDPOINT={SUPABASE_ENGINE_ENDPOINT}")
+		);
+	}
+
+	#[test]
+	fn supabase_env_file_uses_resolved_engine_endpoint() {
+		let plan = HandlerPlan::resolve(
+			&opts(Some(Provider::Supabase)),
+			Some("http://192.168.1.5:6420"),
+		)
+		.unwrap();
+
+		let written = std::fs::read_to_string(&plan.args[6]).unwrap();
+		assert_eq!(written.trim(), "RIVET_ENDPOINT=http://192.168.1.5:6420");
+	}
+
+	#[test]
+	fn supabase_public_engine_url_defaults_to_docker_host() {
+		let public_url = resolve_engine_public_url(&opts(Some(Provider::Supabase))).unwrap();
+
+		assert_eq!(public_url, Some(SUPABASE_ENGINE_ENDPOINT.to_string()));
 	}
 
 	#[test]
@@ -470,7 +673,7 @@ mod tests {
 		opts.fn_name = "actors".into();
 		opts.command = vec!["--env-file".into(), ".env.local".into()];
 
-		let plan = HandlerPlan::resolve(&opts).unwrap();
+		let plan = HandlerPlan::resolve(&opts, None).unwrap();
 
 		assert_eq!(
 			plan.handler_url,
@@ -496,7 +699,7 @@ mod tests {
 		opts.port = Some(3001);
 		opts.command = vec!["node".into(), "handler.js".into()];
 
-		let plan = HandlerPlan::resolve(&opts).unwrap();
+		let plan = HandlerPlan::resolve(&opts, None).unwrap();
 
 		assert_eq!(plan.handler_url, "http://127.0.0.1:3001/api/rivet");
 		assert_eq!(plan.program, "node");
@@ -509,7 +712,7 @@ mod tests {
 		let mut opts = opts(None);
 		opts.command = vec!["npm".into(), "run".into(), "dev".into()];
 
-		let error = HandlerPlan::resolve(&opts).unwrap_err().to_string();
+		let error = HandlerPlan::resolve(&opts, None).unwrap_err().to_string();
 
 		assert!(error.contains("provide --port"));
 	}
@@ -520,7 +723,7 @@ mod tests {
 		opts.url = Some("http://127.0.0.1:9000/custom".into());
 		opts.command = vec!["npm".into(), "run".into(), "dev".into()];
 
-		let plan = HandlerPlan::resolve(&opts).unwrap();
+		let plan = HandlerPlan::resolve(&opts, None).unwrap();
 
 		assert_eq!(plan.handler_url, "http://127.0.0.1:9000/custom");
 		assert_eq!(plan.program, "npm");
@@ -538,6 +741,48 @@ mod tests {
 		.unwrap();
 		let mut opts = opts(Some(Provider::Supabase));
 		opts.command = vec!["--env-file".into(), env_path.to_string_lossy().into_owned()];
+
+		let public_url = resolve_engine_public_url(&opts).unwrap();
+
+		assert_eq!(
+			public_url,
+			Some("http://host.docker.internal:6420".to_string())
+		);
+	}
+
+	#[test]
+	fn supabase_env_file_detects_equals_form() {
+		let mut opts = opts(Some(Provider::Supabase));
+		opts.command = vec!["--env-file=custom.env".into()];
+
+		let plan = HandlerPlan::resolve(&opts, None).unwrap();
+
+		// A user-supplied `--env-file=value` must suppress the auto-injected temp
+		// file rather than being appended after and overriding it.
+		assert_eq!(
+			plan.args,
+			[
+				"supabase",
+				"functions",
+				"serve",
+				"rivet",
+				"--no-verify-jwt",
+				"--env-file=custom.env"
+			]
+		);
+	}
+
+	#[test]
+	fn supabase_public_engine_url_reads_equals_form_env_file() {
+		let temp = tempfile::tempdir().unwrap();
+		let env_path = temp.path().join(".env.local");
+		std::fs::write(
+			&env_path,
+			"RIVET_ENDPOINT=\"http://host.docker.internal:6420\"\n",
+		)
+		.unwrap();
+		let mut opts = opts(Some(Provider::Supabase));
+		opts.command = vec![format!("--env-file={}", env_path.to_string_lossy())];
 
 		let public_url = resolve_engine_public_url(&opts).unwrap();
 

--- a/engine/packages/cli/src/main.rs
+++ b/engine/packages/cli/src/main.rs
@@ -14,6 +14,11 @@ pub(crate) const DEFAULT_NAMESPACE: &str = "production";
 pub(crate) const LOCAL_NAMESPACE: &str = "default";
 pub(crate) const POOL_NAME: &str = "default";
 pub(crate) const SUPABASE_FN_DEFAULT: &str = "rivet";
+/// Supabase runs the edge runtime in a container, so the handler reaches the
+/// engine on the host through Docker's host alias instead of loopback.
+/// `supabase functions serve` supplies the `host-gateway` mapping on Linux;
+/// Docker Desktop provides the alias on macOS and Windows.
+pub(crate) const SUPABASE_ENGINE_ENDPOINT: &str = "http://host.docker.internal:6420";
 
 #[derive(Parser)]
 #[command(name = "rivet", version, about = "Rivet CLI")]

--- a/examples/hello-world-supabase-functions/README.md
+++ b/examples/hello-world-supabase-functions/README.md
@@ -8,10 +8,17 @@ A minimal Rivet Actor counter running on Supabase Edge Functions with the WebAss
 git clone https://github.com/rivet-dev/rivet.git
 cd rivet/examples/hello-world-supabase-functions
 npm install
+npx supabase start
 npm run dev
 ```
 
-`rivet dev` runs a local Rivet engine and spawns `supabase functions serve` for you.
+`supabase functions serve` requires the local Supabase stack, so `npx supabase start` must run first. `rivet dev` then runs a local Rivet engine and spawns `supabase functions serve` for you.
+
+Call the actor from another terminal:
+
+```sh
+npm run client
+```
 
 ## Prerequisites
 
@@ -20,7 +27,11 @@ npm run dev
 
 ## Implementation
 
-The function calls `serve` from `@rivetkit/supabase`, which loads the WebAssembly runtime and serves the Rivet handler. `RIVET_ENDPOINT` is the only required variable.
+The function calls `serve` from `@rivetkit/supabase`, which loads the WebAssembly runtime and serves the Rivet handler. `RIVET_ENDPOINT` is the only required variable, and `rivet dev` passes it to the function automatically.
+
+The edge runtime runs in a container, so it reaches the engine on the host at `http://host.docker.internal:6420` rather than loopback. `supabase functions serve` supplies the required `host-gateway` mapping on Linux, and Docker Desktop provides the alias on macOS and Windows, so this works across platforms. Set `RIVET_ENDPOINT` yourself only to override that.
+
+[`supabase/functions/rivet/deno.json`](https://github.com/rivet-dev/rivet/tree/main/examples/hello-world-supabase-functions/supabase/functions/rivet/deno.json) maps `rivetkit` onto the pre-bundled `@rivetkit/supabase` so Deno can resolve the import and the deploy stays small.
 
 See [`supabase/functions/rivet/index.ts`](https://github.com/rivet-dev/rivet/tree/main/examples/hello-world-supabase-functions/supabase/functions/rivet/index.ts).
 

--- a/examples/hello-world-supabase-functions/supabase/functions/rivet/deno.json
+++ b/examples/hello-world-supabase-functions/supabase/functions/rivet/deno.json
@@ -1,0 +1,6 @@
+{
+	"imports": {
+		"rivetkit": "npm:@rivetkit/supabase",
+		"@rivetkit/supabase": "npm:@rivetkit/supabase"
+	}
+}

--- a/rivetkit-rust/packages/engine-process/Cargo.toml
+++ b/rivetkit-rust/packages/engine-process/Cargo.toml
@@ -20,6 +20,9 @@ tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
 
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
 [dev-dependencies]
 tempfile.workspace = true
 tokio = { workspace = true, features = ["test-util"] }

--- a/rivetkit-rust/packages/engine-process/src/lib.rs
+++ b/rivetkit-rust/packages/engine-process/src/lib.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
 use reqwest::{Client, Url};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio::process::{Child, Command};
 use tokio::task::JoinHandle;
@@ -68,6 +68,42 @@ pub enum ResolvedEngine {
 	Binary(PathBuf),
 }
 
+/// Effective runtime parameters of a spawned engine, stamped to disk so a later
+/// process that reattaches can tell how the running engine is configured without
+/// probing it over the network.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EngineRuntimeStamp {
+	pub pid: u32,
+	pub endpoint: String,
+	pub bind_host: String,
+	pub public_url: Option<String>,
+}
+
+impl EngineRuntimeStamp {
+	/// True if the engine bound a loopback address only, so peers on other hosts
+	/// (for example a container reaching the host) cannot connect to it.
+	pub fn binds_loopback_only(&self) -> bool {
+		if self.bind_host == "localhost" {
+			return true;
+		}
+		self.bind_host
+			.parse::<std::net::IpAddr>()
+			.map(|ip| ip.is_loopback())
+			.unwrap_or(false)
+	}
+}
+
+/// How `start_or_reuse` satisfied the request.
+#[derive(Debug)]
+pub enum EngineStartup {
+	/// A new engine was spawned with the requested configuration.
+	Spawned,
+	/// An already-running engine was reused. `stamp` is its recorded runtime
+	/// parameters, or `None` when no live stamp was found (an engine from an
+	/// older CLI, started by hand, or a stale stamp whose process is gone).
+	Reused { stamp: Option<EngineRuntimeStamp> },
+}
+
 /// Manages the rivet-engine subprocess.
 ///
 /// The engine is intentionally orphaned: dropping the manager (or having the
@@ -92,12 +128,18 @@ pub enum ResolvedEngine {
 #[derive(Debug)]
 pub struct EngineProcessManager {
 	watcher: Option<JoinHandle<()>>,
+	startup: EngineStartup,
 }
 
 impl EngineProcessManager {
 	pub async fn start_or_reuse(config: EngineResolverConfig) -> Result<Self> {
 		let resolved = resolve_engine_binary(&config).await?;
 		Self::start_resolved(resolved, &config).await
+	}
+
+	/// How the engine was obtained: freshly spawned or reused.
+	pub fn startup(&self) -> &EngineStartup {
+		&self.startup
 	}
 
 	async fn start_resolved(
@@ -110,7 +152,12 @@ impl EngineProcessManager {
 				endpoint = %endpoint,
 				"reusing already-running engine process"
 			);
-			return Ok(Self { watcher: None });
+			return Ok(Self {
+				watcher: None,
+				startup: EngineStartup::Reused {
+					stamp: read_engine_stamp(),
+				},
+			});
 		}
 
 		let ResolvedEngine::Binary(binary_path) = resolved else {
@@ -124,7 +171,12 @@ impl EngineProcessManager {
 				version = ?health.version,
 				"reusing already-running engine process"
 			);
-			return Ok(Self { watcher: None });
+			return Ok(Self {
+				watcher: None,
+				startup: EngineStartup::Reused {
+					stamp: read_engine_stamp(),
+				},
+			});
 		}
 
 		if !binary_path.exists() {
@@ -224,8 +276,22 @@ impl EngineProcessManager {
 			"engine process is healthy"
 		);
 
+		// Record the effective runtime parameters so a later reattaching process
+		// can tell how this engine is bound. Best-effort: a failed write only
+		// costs that later process its reuse diagnostics.
+		let stamp = EngineRuntimeStamp {
+			pid,
+			endpoint: endpoint.clone(),
+			bind_host: resolve_bind_host(config)?,
+			public_url: config.public_url.clone(),
+		};
+		if let Err(error) = write_engine_stamp(&stamp) {
+			tracing::warn!(?error, "failed to write engine runtime stamp");
+		}
+
 		Ok(Self {
 			watcher: Some(spawn_engine_watcher(child, pid)),
+			startup: EngineStartup::Spawned,
 		})
 	}
 }
@@ -233,6 +299,67 @@ impl EngineProcessManager {
 /// Path to the rivet-engine database directory under the shared storage root.
 pub fn engine_db_path() -> Result<PathBuf> {
 	Ok(storage_root()?.join("var").join("engine").join("db"))
+}
+
+fn engine_stamp_path() -> Result<PathBuf> {
+	Ok(storage_root()?
+		.join("var")
+		.join("engine")
+		.join("runtime.json"))
+}
+
+/// The address the engine actually binds: the explicit `bind_host` override, or
+/// the endpoint host when unset. Must match `engine_env`'s guard host.
+fn resolve_bind_host(config: &EngineResolverConfig) -> Result<String> {
+	if let Some(bind_host) = &config.bind_host {
+		return Ok(bind_host.clone());
+	}
+	let endpoint = &config.endpoint;
+	let endpoint_url =
+		Url::parse(endpoint).with_context(|| format!("parse engine endpoint `{endpoint}`"))?;
+	Ok(endpoint_url
+		.host_str()
+		.ok_or_else(|| invalid_endpoint(endpoint, "missing host"))?
+		.to_owned())
+}
+
+fn write_engine_stamp(stamp: &EngineRuntimeStamp) -> Result<()> {
+	let path = engine_stamp_path()?;
+	if let Some(dir) = path.parent() {
+		ensure_dir(dir)?;
+	}
+	let contents = serde_json::to_vec_pretty(stamp).context("serialize engine stamp")?;
+	std::fs::write(&path, contents)
+		.with_context(|| format!("write engine stamp `{}`", path.display()))?;
+	Ok(())
+}
+
+/// Reads the runtime stamp of the currently running engine, if its recorded
+/// process is still alive. A stale stamp (process gone) reads as `None` so
+/// callers treat the binding as unknown rather than trusting old data. On
+/// platforms without a liveness check (see `pid_is_alive`) the stamp is always
+/// treated as unknown for the same reason.
+fn read_engine_stamp() -> Option<EngineRuntimeStamp> {
+	let path = engine_stamp_path().ok()?;
+	let contents = std::fs::read(&path).ok()?;
+	let stamp: EngineRuntimeStamp = serde_json::from_slice(&contents).ok()?;
+	pid_is_alive(stamp.pid).then_some(stamp)
+}
+
+#[cfg(unix)]
+fn pid_is_alive(pid: u32) -> bool {
+	// `kill(pid, 0)` sends no signal but performs the existence and permission
+	// checks: success or EPERM means the process exists, ESRCH means it is gone.
+	let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+	result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(not(unix))]
+fn pid_is_alive(_pid: u32) -> bool {
+	// No portable liveness check here, so fail safe: report the process as gone
+	// so a stale stamp is never trusted. The binding check then falls back to
+	// its "unknown, warn" branch instead of silently trusting old data.
+	false
 }
 
 /// Computes the environment variables that configure a rivet-engine process
@@ -245,11 +372,7 @@ pub fn engine_env(config: &EngineResolverConfig) -> Result<Vec<(String, String)>
 	let endpoint = &config.endpoint;
 	let endpoint_url =
 		Url::parse(endpoint).with_context(|| format!("parse engine endpoint `{endpoint}`"))?;
-	let guard_host = endpoint_url
-		.host_str()
-		.ok_or_else(|| invalid_endpoint(endpoint, "missing host"))?
-		.to_owned();
-	let guard_host = config.bind_host.clone().unwrap_or(guard_host);
+	let guard_host = resolve_bind_host(config)?;
 	let guard_port = endpoint_url
 		.port_or_known_default()
 		.ok_or_else(|| invalid_endpoint(endpoint, "missing port"))?;
@@ -834,6 +957,46 @@ mod tests {
 			version: "test-version".to_owned(),
 			releases_endpoint,
 		}
+	}
+
+	fn stamp_with_bind(bind_host: &str) -> EngineRuntimeStamp {
+		EngineRuntimeStamp {
+			pid: 1,
+			endpoint: "http://127.0.0.1:6420".to_owned(),
+			bind_host: bind_host.to_owned(),
+			public_url: None,
+		}
+	}
+
+	#[test]
+	fn binds_loopback_only_detects_loopback_addresses() {
+		assert!(stamp_with_bind("127.0.0.1").binds_loopback_only());
+		assert!(stamp_with_bind("localhost").binds_loopback_only());
+		assert!(stamp_with_bind("::1").binds_loopback_only());
+	}
+
+	#[test]
+	fn binds_loopback_only_false_for_reachable_addresses() {
+		assert!(!stamp_with_bind("0.0.0.0").binds_loopback_only());
+		assert!(!stamp_with_bind("::").binds_loopback_only());
+		assert!(!stamp_with_bind("192.168.1.5").binds_loopback_only());
+	}
+
+	#[test]
+	fn resolve_bind_host_prefers_override_then_endpoint() {
+		let mut config = test_config(String::new(), false);
+		config.endpoint = "http://127.0.0.1:6420".to_owned();
+		assert_eq!(resolve_bind_host(&config).unwrap(), "127.0.0.1");
+		config.bind_host = Some("0.0.0.0".to_owned());
+		assert_eq!(resolve_bind_host(&config).unwrap(), "0.0.0.0");
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn pid_is_alive_true_for_self_false_for_missing() {
+		assert!(pid_is_alive(std::process::id()));
+		// PID 0 targets the process group on unix, so use a very high, unused PID.
+		assert!(!pid_is_alive(0x7FFF_FFFF));
 	}
 
 	#[tokio::test]

--- a/website/src/content/docs/actors/quickstart/supabase.mdx
+++ b/website/src/content/docs/actors/quickstart/supabase.mdx
@@ -76,11 +76,27 @@ Your function code keeps importing from `rivetkit` as usual. The import map only
 </Step>
 <Step title="Run Locally">
 
+Start the local Supabase stack. `supabase functions serve` fails without it:
+
+```sh
+npx supabase start
+```
+
 Start Rivet. The CLI runs the local engine, spawns `supabase functions serve` for you, and populates the connection values:
 
 ```sh
 npx @rivetkit/cli dev --provider supabase
 ```
+
+The edge runtime runs in a container, so the CLI points the function at the engine on the host with `RIVET_ENDPOINT=http://host.docker.internal:6420`. Override it by passing your own `--env-file` to `supabase functions serve`:
+
+```sh
+npx @rivetkit/cli dev --provider supabase -- --env-file ./supabase/functions/.env.local
+```
+
+<Note>
+The engine keeps running after the CLI exits so a later `rivet dev` can reattach. Changing `RIVET_ENDPOINT` therefore has no effect until the engine restarts. Use `rivet engine` to manage it.
+</Note>
 
 Visit [http://localhost:6420](http://localhost:6420) in your browser (or point your AI agent at it) to open the Rivet developer tools and inspect your actors live.
 


### PR DESCRIPTION
- Pass `RIVET_ENDPOINT` to the Supabase edge function during `rivet dev` by generating an env file and passing `--env-file` to `supabase functions serve`. The Supabase CLI does not forward the parent process environment to the edge runtime worker, so the function previously fell back to loopback and never connected back to the engine.
- Default the engine's advertised URL to `http://host.docker.internal:6420` for the Supabase provider, since the edge runtime runs in a container and cannot reach the host on loopback. A user-supplied `--env-file` still takes precedence.
- Record the engine's effective bind host and public URL to a runtime stamp file when it is spawned, and read it back when a later `rivet dev` reattaches. This is deterministic and needs no network probing.
- Fail fast when `rivet dev --provider supabase` would reuse an engine that the stamp shows is bound to loopback only (left over from another provider or an older CLI), since the edge runtime cannot reach it from its container. A freshly spawned engine is known-good and never blocked; an engine with no usable stamp is warned about rather than blocked.
- Warn (without blocking) when reusing an otherwise reachable engine that advertises a different public URL than the current project needs, which the engine would reject with an endpoint mismatch.
- Add the missing `deno.json` import map to the `hello-world-supabase-functions` example. Without it Deno cannot resolve the bare `rivetkit` specifier and every worker fails to boot.
- Document that `supabase start` must run before `rivet dev`, and note that the reused engine keeps its endpoint and binding until restarted.
- Move `tempfile` from dev-dependencies to dependencies.
