### PR TITLE
fix(rivetkit): correct actor connection keepalive interval

### DIFF
--- a/rivetkit-typescript/packages/rivetkit/src/client/actor-conn.ts
+++ b/rivetkit-typescript/packages/rivetkit/src/client/actor-conn.ts
@@ -238,7 +238,7 @@ export class ActorConnRaw {
 			},
 		});
 
-		this.#keepNodeAliveInterval = setInterval(() => 60_000);
+		this.#keepNodeAliveInterval = setInterval(() => {}, 60_000);
 	}
 
 	#clearResolvedActorIdentity() {


### PR DESCRIPTION
- Pass the 60-second delay to `setInterval` instead of returning it from the callback.
- Prevent Actor connections from scheduling a zero-delay timer for their entire lifetime.
- Verified with the RivetKit TypeScript typecheck, Biome, and `git diff --check`.